### PR TITLE
Set up JavaScript system specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,4 +64,6 @@ end
 
 group :test do
   gem "capybara"
+  gem "selenium-webdriver"
+  gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (4.1.0)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     debug (1.6.3)
@@ -209,6 +210,12 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.6.1)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -241,6 +248,11 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -263,6 +275,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4)
   rspec-rails
+  selenium-webdriver
   sprockets-rails
   standardrb
   stimulus-rails
@@ -270,6 +283,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/README.md
+++ b/README.md
@@ -9,3 +9,84 @@ Rails 7, and PostgreSQL 14.
    at http://localhost:3000.
 
 [libvips]: https://www.libvips.org/install.html
+
+## Linting
+
+We are using [standard][standard] for Ruby
+linting. To check the style of all Ruby files, run:
+
+```
+bundle exec standardrb
+```
+
+To automatically apply linting fixes, run:
+
+```
+bundle exec standardrb --fix
+```
+
+[standard]: https://github.com/testdouble/standard
+
+## Testing Suite
+
+We are using [RSpec](http://rspec.info/) for tests. Before beginning a new
+feature, please run the specs and make sure the entire test suite is passing.
+All tests should be passing when submitting a PR. Please write specs as
+appropriate.
+
+To run all specs:
+
+```
+bundle exec rspec spec -fd
+```
+
+To run an individual file:
+
+```
+bundle exec rspec spec/models/user_spec.rb -fd
+```
+
+To run an individual spec, pass the spec name or partial match:
+```
+bundle exec rspec spec/models/user_spec.rb -fd -e "valid factory"
+```
+
+Individual specs can also be run by specifying the line number:
+
+```
+bundle exec rspec spec/models/user_spec.rb:4 -fd
+```
+
+The `-fd` flag is for "format: documentation", and will list out each spec name
+as it is run. These flags can be left off for more concise output.
+
+### JavaScript system specs
+
+For system specs that require JavaScript, append `js: true` to the relevant
+scenario, context, or describe statement. This has the added benefit of
+generating a screenshot upon failure. To force any non-JS-requiring system test
+to generate a screenshot, you can also temporarily add `js: true` to the spec to
+help diagnose the failure. For example:
+
+```
+# spec/system/standards_import/new_spec.html.erb
+
+it "shows success message", js: true do
+ ...
+end
+```
+
+By default we are using the headless version of Chrome to run system specs with
+JavaScript, but you can run the non-headless version to watch the spec get run
+in the browser. To use the non-headless version, add `debug: true` to the spec:
+
+```
+# spec/system/standards_import/new_spec.html.erb
+
+it "shows success message", debug: true do
+ ...
+end
+```
+
+Any errors when running in debug mode will also create a screenshot in the `tmp`
+directory to help with debugging.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require "capybara/rails"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -66,5 +66,13 @@ RSpec.configure do |config|
 
   config.before(:each, type: :system) do
     driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :selenium_chrome_headless
+  end
+
+  config.before(:each, type: :system, debug: true) do
+    driven_by :selenium_chrome
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,3 @@
+Capybara.server_host = "0.0.0.0"
+Capybara.server_port = 4000
+Capybara.app_host = "http://localhost:4000"

--- a/spec/system/standards_imports/new_spec.rb
+++ b/spec/system/standards_imports/new_spec.rb
@@ -9,17 +9,7 @@ RSpec.describe "standards_imports/new" do
     fill_in "Notes", with: "a" * 500
     attach_file "Files", ["spec/fixtures/files/pixel1x1.jpg", "spec/fixtures/files/pixel1x1.pdf", "spec/fixtures/files/pixel1x1-2.jpg"]
 
-    expect {
-      click_on "Upload"
-    }.to change(StandardsImport, :count).by(1)
-      .and change(ActiveStorage::Attachment, :count).by(3)
-
-    si = StandardsImport.last
-    expect(si.name).to eq "Mickey Mouse"
-    expect(si.email).to eq "mickey@example.com"
-    expect(si.organization).to eq "Disney"
-    expect(si.notes).to eq "a" * 500
-    expect(si.files.count).to eq 3
+    click_on "Upload"
 
     expect(page).to have_text "Mickey Mouse"
     expect(page).to have_text "mickey@example.com"
@@ -28,5 +18,12 @@ RSpec.describe "standards_imports/new" do
     expect(page).to have_text "pixel1x1.jpg"
     expect(page).to have_text "pixel1x1.pdf"
     expect(page).to have_text "pixel1x1-2.jpg"
+
+    si = StandardsImport.last
+    expect(si.name).to eq "Mickey Mouse"
+    expect(si.email).to eq "mickey@example.com"
+    expect(si.organization).to eq "Disney"
+    expect(si.notes).to eq "a" * 500
+    expect(si.files.count).to eq 3
   end
 end


### PR DESCRIPTION
This sets up RSpec to run JavaScript system specs with selenium. The configuration allows for a headless mode and a non-headless mode.