### PR TITLE
Add bullet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem "bullet"
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails"
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,9 @@ GEM
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.38.0)
       addressable
       matrix
@@ -259,6 +262,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -282,6 +286,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet
   capybara
   debug
   dotenv-rails

--- a/app/controllers/standards_imports_controller.rb
+++ b/app/controllers/standards_imports_controller.rb
@@ -14,7 +14,7 @@ class StandardsImportsController < ApplicationController
   end
 
   def show
-    @standards_import = StandardsImport.find(params[:id])
+    @standards_import = StandardsImport.includes(files_attachments: :blob).find(params[:id])
   end
 
   private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,14 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+    Bullet.add_footer = true
+    Bullet.unused_eager_loading_enable = false
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,11 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.unused_eager_loading_enable = false
+    Bullet.raise = true # raise an error if n+1 query occurs
+  end
 end


### PR DESCRIPTION
This sets up the Bullet gem to catch N+1 queries.

The test environment is configured to raise
errors on N+1 queries. The dev environment
configuration will show an alert and UI notice.

The unused eager loading configuration
is turned off as past experience with
that flag sometimes results in catch-22
issues with N+1 fixes.

Fix N+1 issue with active storage
attachments in standards_import#show
method.