### PR TITLE
Add route constraints depending on site subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ Rails 7, and PostgreSQL 14.
 ## Development setup
 1. Run `bin/setup`
 2. Install [libvips][libvips] for use with ActiveStorage
+4. To access the admin pages, you must modify your `/etc/hosts` file:
+   ```
+   # Added for ApprenticeshipStandards.org
+   127.0.0.1 admin.example.localhost
+   # End ApprenticeshipStandards.org additions
+   ```
 3. Start rails app: `bin/dev`. The application will be available
-   at http://localhost:3000.
+   at http://localhost:3000. The admin pages will be available at:
+   http://admin.example.localhost:3000.
 
 [libvips]: https://www.libvips.org/install.html
 

--- a/app/lib/subdomain.rb
+++ b/app/lib/subdomain.rb
@@ -1,0 +1,7 @@
+class Subdomain
+  class << self
+    def matches?(request)
+      request.subdomain == "admin"
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,6 +70,8 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
+  config.hosts << "admin.example.localhost"
+
   config.after_initialize do
     Bullet.enable = true
     Bullet.alert = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,15 @@
 Rails.application.routes.draw do
-  devise_for :users,
-    skip: :registrations,
-    controllers: {
-      sessions: "users/sessions"
-    }
-  as :user do
-    get "users/edit", to: "devise/registrations#edit", as: "edit_user_registration"
-    patch "users", to: "devise/registrations#update", as: "user_registration"
-    put "users", to: "devise/registrations#update", as: nil
+  constraints(Subdomain) do
+    devise_for :users,
+      skip: :registrations,
+      controllers: {
+        sessions: "users/sessions"
+      }
+    as :user do
+      get "users/edit", to: "devise/registrations#edit", as: "edit_user_registration"
+      patch "users", to: "devise/registrations#update", as: "user_registration"
+      put "users", to: "devise/registrations#update", as: nil
+    end
   end
 
   root to: "standards_imports#new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,10 +20,11 @@ Rails.application.routes.draw do
         root to: "file_imports#index"
       end
     end
+
+    resources :file_imports, only: [:index]
   end
 
   root to: "standards_imports#new", as: :guest_root
 
   resources :standards_imports, only: [:new, :create, :show]
-  resources :file_imports, only: [:index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,20 @@ Rails.application.routes.draw do
       patch "users", to: "devise/registrations#update", as: "user_registration"
       put "users", to: "devise/registrations#update", as: nil
     end
+
+    devise_scope :user do
+      unauthenticated do
+        root to: "users/sessions#new", as: :unauthenticated_root
+      end
+
+      authenticated :user do
+        root to: "file_imports#index"
+      end
+    end
   end
 
-  root to: "standards_imports#new"
+  root to: "standards_imports#new", as: :guest_root
+
   resources :standards_imports, only: [:new, :create, :show]
   resources :file_imports, only: [:index]
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,4 +77,8 @@ RSpec.configure do |config|
   config.before(:each, type: :system, debug: true) do
     driven_by :selenium_chrome
   end
+
+  config.before(:each, type: :request, admin: true) do
+    host! "admin.example.com"
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,4 +81,8 @@ RSpec.configure do |config|
   config.before(:each, type: :request, admin: true) do
     host! "admin.example.com"
   end
+
+  config.before(:each, type: :system, admin: true) do
+    Capybara.app_host = "http://admin.example.localhost"
+  end
 end

--- a/spec/requests/file_imports_spec.rb
+++ b/spec/requests/file_imports_spec.rb
@@ -2,23 +2,33 @@ require "rails_helper"
 
 RSpec.describe "FileImports", type: :request do
   describe "GET /index" do
-    context "when admin user" do
-      it "returns http success" do
-        admin = create(:admin)
-        create_pair(:standards_import, :with_files)
+    context "on admin subdomain", :admin do
+      context "when admin user" do
+        it "returns http success" do
+          admin = create(:admin)
+          create_pair(:standards_import, :with_files)
 
-        sign_in admin
-        get file_imports_path
+          sign_in admin
+          get file_imports_path
 
-        expect(response).to be_successful
+          expect(response).to be_successful
+        end
+      end
+
+      context "when guest" do
+        it "redirects to root path" do
+          get file_imports_path
+
+          expect(response).to redirect_to new_user_session_path
+        end
       end
     end
 
-    context "when guest" do
-      it "redirects to root path" do
-        get file_imports_path
-
-        expect(response).to redirect_to new_user_session_path
+    context "on non-admin subdomain" do
+      it "has 404 response" do
+        expect{
+          get file_imports_path
+        }.to raise_error(ActionController::RoutingError)
       end
     end
   end

--- a/spec/requests/file_imports_spec.rb
+++ b/spec/requests/file_imports_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "FileImports", type: :request do
 
     context "on non-admin subdomain" do
       it "has 404 response" do
-        expect{
+        expect {
           get file_imports_path
         }.to raise_error(ActionController::RoutingError)
       end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,8 +1,26 @@
 require "rails_helper"
 
 RSpec.describe "Users::Sessions", type: :request do
+  describe "GET /new" do
+    context "on admin subdomain" do
+      it "is successful", :admin do
+        get new_user_session_path
+
+        expect(response).to be_successful
+      end
+    end
+
+    context "on non-admin subdomain" do
+      it "has 404 response" do
+        expect{
+          get new_user_session_path
+        }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+
   describe "GET /create" do
-    it "redirects to file imports path" do
+    it "redirects to file imports path", :admin do
       user = create(:admin)
 
       post user_session_path, params: {

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Users::Sessions", type: :request do
 
     context "on non-admin subdomain" do
       it "has 404 response" do
-        expect{
+        expect {
           get new_user_session_path
         }.to raise_error(ActionController::RoutingError)
       end

--- a/spec/system/file_imports/index_spec.rb
+++ b/spec/system/file_imports/index_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "file_imports/index" do
-  it "displays status and link to file" do
+  it "displays status and link to file", :admin do
     create :standards_import, :with_files
     admin = create :admin
 


### PR DESCRIPTION
This will allow the sign in routes and the file_imports routes only to be accessed when on an admin subdomain. The routes will return a 404 if accessed on a non-admin subdomain.

These changes also add different root paths depending on whether the user is signed in or not, or whether on a non-admin subdomain.