### PR TITLE
Add ErrorSubscriber for test and dev environments

### DIFF
--- a/app/models/concerns/active_storage_attachment_extension.rb
+++ b/app/models/concerns/active_storage_attachment_extension.rb
@@ -11,7 +11,9 @@ module ActiveStorageAttachmentExtension
 
   def create_file_import
     if record_type == "StandardsImport"
-      FileImport.create!(active_storage_attachment: self)
+      Rails.error.handle do
+        FileImport.create!(active_storage_attachment: self)
+      end
     end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,6 +73,10 @@ Rails.application.configure do
   config.hosts << "admin.example.localhost"
 
   config.after_initialize do
+    Rails.error.subscribe(ErrorSubscriber.new)
+  end
+
+  config.after_initialize do
     Bullet.enable = true
     Bullet.alert = true
     Bullet.bullet_logger = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,6 +59,10 @@ Rails.application.configure do
   # config.action_view.annotate_rendered_view_with_filenames = true
 
   config.after_initialize do
+    Rails.error.subscribe(ErrorSubscriber.new)
+  end
+
+  config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.unused_eager_loading_enable = false

--- a/config/initializers/error_subscriber.rb
+++ b/config/initializers/error_subscriber.rb
@@ -1,0 +1,7 @@
+class ErrorSubscriber
+  def report(error, handled:, severity:, context:, source: nil)
+    if Rails.env.development?
+      raise error
+    end
+  end
+end

--- a/spec/models/active_storage_attachment_spec.rb
+++ b/spec/models/active_storage_attachment_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe ActiveStorage::Attachment, type: :model do
     expect(file_import.active_storage_attachment).to eq attachment
   end
 
+  it "publishes error message if creating import record fails" do
+    import = create(:standards_import)
+    attachment = build(:active_storage_attachment, record: import)
+    error = StandardError.new("some error")
+    allow(FileImport).to receive(:create!).and_raise(error)
+
+    expect_any_instance_of(ErrorSubscriber).to receive(:report).and_call_original
+    expect { attachment.save! }.to_not change(FileImport, :count)
+  end
+
   it "does not create a file import record when type is not standards import" do
     user = create(:user)
     attachment = build(:active_storage_attachment, record: user)


### PR DESCRIPTION
This uses the Rails internal error_reporting
for handling exceptions.

https://edgeguides.rubyonrails.org/error_reporting.html

Errors in development are raised, while the test
environment will silently catch them.

We can add error reporting for production in
the future to this class or a separate new
error subscriber class.