### PR TITLE
Set up ErrorSubscriber to send to Rollbar in production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,9 @@ module ApprenticeshipStandardsDotOrg
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.after_initialize do
+      Rails.error.subscribe(ErrorSubscriber.new)
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,10 +76,6 @@ Rails.application.configure do
   config.hosts << "admin.example.localhost"
 
   config.after_initialize do
-    Rails.error.subscribe(ErrorSubscriber.new)
-  end
-
-  config.after_initialize do
     Bullet.enable = true
     Bullet.alert = true
     Bullet.bullet_logger = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,10 +59,6 @@ Rails.application.configure do
   # config.action_view.annotate_rendered_view_with_filenames = true
 
   config.after_initialize do
-    Rails.error.subscribe(ErrorSubscriber.new)
-  end
-
-  config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.unused_eager_loading_enable = false

--- a/config/initializers/error_subscriber.rb
+++ b/config/initializers/error_subscriber.rb
@@ -2,6 +2,8 @@ class ErrorSubscriber
   def report(error, handled:, severity:, context:, source: nil)
     if Rails.env.development?
       raise error
+    elsif Rails.env.production?
+      Rollbar.send(severity, error, context)
     end
   end
 end


### PR DESCRIPTION
This sets up the ErrorSubscriber to report to Rollbar for production.

I tested this out in dev with the following code:

```
  def index
    Rails.error.handle(context: {state_id: "123"}) do
      1/0
    end
    @file_imports = FileImport.includes(active_storage_attachment: :blob)
  end
```
which resulted in:
https://rollbar.com/apprenticeship-standards-dot-o/apprenticeship-standards-dot-o/items/5/occurrences/308114213847/

Ref #12 