### PR TITLE
Destroy file_import when standards_import or attachment is destroyed

### DIFF
--- a/app/models/concerns/active_storage_attachment_extension.rb
+++ b/app/models/concerns/active_storage_attachment_extension.rb
@@ -2,7 +2,7 @@ module ActiveStorageAttachmentExtension
   extend ActiveSupport::Concern
 
   included do
-    has_one :file_import
+    has_one :file_import, foreign_key: :active_storage_attachment_id, dependent: :destroy
 
     after_commit :create_file_import, on: :create
   end

--- a/spec/models/active_storage_attachment_spec.rb
+++ b/spec/models/active_storage_attachment_spec.rb
@@ -33,4 +33,17 @@ RSpec.describe ActiveStorage::Attachment, type: :model do
 
     expect { attachment.save! }.to_not change(FileImport, :count)
   end
+
+  it "deletes file import record when deleted" do
+    file_import = create(:file_import)
+    attachment = file_import.active_storage_attachment
+
+    expect {
+      attachment.destroy!
+    }.to change(ActiveStorage::Attachment, :count).by(-1)
+      .and change(FileImport, :count).by(-1)
+
+    expect { attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { file_import.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
 end

--- a/spec/models/standards_import_spec.rb
+++ b/spec/models/standards_import_spec.rb
@@ -7,6 +7,23 @@ RSpec.describe StandardsImport, type: :model do
     expect(si).to be_valid
   end
 
+  it "deletes file import record when deleted" do
+    standards_import = create(:standards_import, :with_files)
+    attachment = standards_import.files.first
+    file_import = attachment.file_import
+
+    expect(attachment).to be
+    expect(file_import).to be
+
+    expect {
+      standards_import.destroy!
+    }.to change(ActiveStorage::Attachment, :count).by(-1)
+      .and change(FileImport, :count).by(-1)
+
+    expect { attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { file_import.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
   describe "#file_count" do
     it "returns file count" do
       si = create(:standards_import, :with_files)


### PR DESCRIPTION
This makes sure to destroy the file_import record that is associated to the ActiveStorage::Attachment record when either the attachment is removed directly, or when the StandardsImport record itself is removed.
