### PR TITLE
Add After party task to import onet and rapids locally

### DIFF
--- a/lib/tasks/deployment/20230111195421_populate_onet_and_rapids_codes.rake
+++ b/lib/tasks/deployment/20230111195421_populate_onet_and_rapids_codes.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc "Deployment task: populate_onet_and_rapids_codes"
+  task populate_onet_and_rapids_codes: :environment do
+    puts "Running deploy task 'populate_onet_and_rapids_codes'"
+
+    if Rails.env.development?
+      ENV["FORCE"] = "true"
+      Rake::Task["occupation:onet_code_scraper"].invoke
+      Rake::Task["occupation:rapids_codes_scraper"].invoke
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/occupation.rake
+++ b/lib/tasks/occupation.rake
@@ -6,7 +6,8 @@ namespace :occupation do
     if Date.current.wday.eql?(0) || ENV["FORCE"] == "true"
       puts "Importing RAPIDS codes"
       xlsx = Roo::Spreadsheet.open("https://www.apprenticeship.gov/sites/default/files/wps/apprenticeship-occupations.xlsx")
-      xlsx.sheet(0).parse(headers: true).each do |row|
+      xlsx.sheet(0).parse(headers: true).each_with_index do |row, index|
+        next if index.zero?
         occupation = Occupation.find_or_initialize_by(name: row["RAPIDS TITLE"])
         hybrid_start_hours = nil
         hybrid_end_hours = nil


### PR DESCRIPTION
This adds an after party task to import the onet codes and the occupations locally on dev.

I noticed that the header row of the Excel spreadsheet was getting imported, despite the `headers: true`. [Found same issue on SO](https://stackoverflow.com/questions/52319170/exclude-headers-when-importing-google-spreadsheet-content-with-roo) without a great solution, so I just skipped the first row.