### PR TITLE
Link occupations to onet codes

### DIFF
--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -1,3 +1,5 @@
 class Occupation < ApplicationRecord
   validates :name, presence: true
+
+  belongs_to :onet_code, optional: true
 end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -2,5 +2,9 @@ class OccupationStandard < ApplicationRecord
   belongs_to :occupation, optional: true
   belongs_to :registration_agency
 
-  delegate :rapids_code, :onet_code, to: :occupation, allow_nil: true
+  delegate :rapids_code, to: :occupation, allow_nil: true
+
+  def onet_code
+    occupation&.onet_code&.code
+  end
 end

--- a/db/migrate/20230117181100_remove_onet_code_from_occupations.rb
+++ b/db/migrate/20230117181100_remove_onet_code_from_occupations.rb
@@ -1,0 +1,5 @@
+class RemoveOnetCodeFromOccupations < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :occupations, :onet_code, :string
+  end
+end

--- a/db/migrate/20230117181123_add_onet_code_to_occupations.rb
+++ b/db/migrate/20230117181123_add_onet_code_to_occupations.rb
@@ -1,0 +1,5 @@
+class AddOnetCodeToOccupations < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :occupations, :onet_code, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_12_190008) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_17_181123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -74,11 +74,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_12_190008) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "onet_code"
     t.string "rapids_code"
     t.integer "time_based_hours"
     t.int4range "hybrid_hours"
     t.integer "competency_based_hours"
+    t.uuid "onet_code_id"
+    t.index ["onet_code_id"], name: "index_occupations_on_onet_code_id"
   end
 
   create_table "onet_codes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -143,5 +144,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_12_190008) do
   add_foreign_key "file_imports", "active_storage_attachments"
   add_foreign_key "occupation_standards", "occupations"
   add_foreign_key "occupation_standards", "registration_agencies"
+  add_foreign_key "occupations", "onet_codes"
   add_foreign_key "registration_agencies", "states"
 end

--- a/lib/tasks/deployment/20230117180717_reimport_occupations.rake
+++ b/lib/tasks/deployment/20230117180717_reimport_occupations.rake
@@ -1,5 +1,5 @@
 namespace :after_party do
-  desc 'Deployment task: reimport_occupations'
+  desc "Deployment task: reimport_occupations"
   task reimport_occupations: :environment do
     puts "Running deploy task 'reimport_occupations'"
 

--- a/lib/tasks/deployment/20230117180717_reimport_occupations.rake
+++ b/lib/tasks/deployment/20230117180717_reimport_occupations.rake
@@ -1,0 +1,16 @@
+namespace :after_party do
+  desc 'Deployment task: reimport_occupations'
+  task reimport_occupations: :environment do
+    puts "Running deploy task 'reimport_occupations'"
+
+    Occupation.destroy_all
+    ENV["FORCE"] = "true"
+    Rake::Task["occupation:onet_code_scraper"].invoke
+    Rake::Task["occupation:rapids_codes_scraper"].invoke
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/occupation.rake
+++ b/lib/tasks/occupation.rake
@@ -9,6 +9,7 @@ namespace :occupation do
       xlsx.sheet(0).parse(headers: true).each_with_index do |row, index|
         next if index.zero?
         occupation = Occupation.find_or_initialize_by(name: row["RAPIDS TITLE"])
+        onet_code = OnetCode.find_by(code: row["ONET SOC CODE"].strip)
         hybrid_start_hours = nil
         hybrid_end_hours = nil
         hybrid_hours = nil
@@ -27,6 +28,7 @@ namespace :occupation do
 
         occupation.update!(
           rapids_code: row["RAPIDS CODE"],
+          onet_code: onet_code,
           time_based_hours: row["TIME-BASED"],
           hybrid_hours: hybrid_hours,
           competency_based_hours: row["COMPETENCY-BASED"]

--- a/spec/factories/onet_codes.rb
+++ b/spec/factories/onet_codes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :onet_code do
+    name { "Actors" }
+    code { "27-2011.00" }
+  end
+end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -23,11 +23,19 @@ RSpec.describe OccupationStandard, type: :model do
   end
 
   describe "#onet_code" do
-    it "returns occupation onet_code when occupation exists" do
-      occupation = build_stubbed(:occupation, onet_code: "abc")
+    it "returns occupation onet_code string when occupation and onet_code exists" do
+      onet_code = build_stubbed(:onet_code, code: "abc")
+      occupation = build_stubbed(:occupation, onet_code: onet_code)
       occupation_standard = build(:occupation_standard, occupation: occupation)
 
       expect(occupation_standard.onet_code).to eq "abc"
+    end
+
+    it "returns nil when occupation exists but onet_code does not" do
+      occupation = build_stubbed(:occupation, onet_code: nil)
+      occupation_standard = build(:occupation_standard, occupation: occupation)
+
+      expect(occupation_standard.onet_code).to be_nil
     end
 
     it "returns nil when no occupation" do

--- a/spec/models/onet_code_spec.rb
+++ b/spec/models/onet_code_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe OnetCode, type: :model do
+  it "has a valid factory" do
+    onet_code = build(:onet_code)
+
+    expect(onet_code).to be_valid
+  end
+end
+

--- a/spec/models/onet_code_spec.rb
+++ b/spec/models/onet_code_spec.rb
@@ -7,4 +7,3 @@ RSpec.describe OnetCode, type: :model do
     expect(onet_code).to be_valid
   end
 end
-


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203289004376695/f

This removes the string `onet_code` on the occupations table and replaces it with an association instead. It also updates the rake task that imports occupations to link the onet code.
