### PR TITLE
Add API for occupations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,10 @@ gem "aws-sdk-s3", require: false
 gem "after_party"
 gem "sidekiq", "~> 7"
 
+# For API documentation
+gem "rswag-api"
+gem "rswag-ui"
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 
@@ -64,6 +68,7 @@ end
 group :development do
   gem "erb_lint", require: false
   gem "erblint-github"
+  gem "rswag-specs"
   gem "standardrb"
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "jsonapi-resources"
 # For API documentation
 gem "rswag-api"
 gem "rswag-ui"
+gem "rack-cors"
 
 # Use Sass to process CSS
 # gem "sassc-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem "roo", "~> 2.9.0"
 gem "aws-sdk-s3", require: false
 gem "after_party"
 gem "sidekiq", "~> 7"
+gem "jsonapi-resources"
 
 # For API documentation
 gem "rswag-api"
@@ -63,12 +64,12 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "rspec-rails"
+  gem "rswag-specs"
 end
 
 group :development do
   gem "erb_lint", require: false
   gem "erblint-github"
-  gem "rswag-specs"
   gem "standardrb"
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,8 @@ GEM
       reline (>= 0.3.0)
     jmespath (1.6.2)
     json (2.6.2)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -258,6 +260,16 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
+    rswag-api (2.8.0)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.8.0)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (>= 2.2, < 4.0)
+      railties (>= 3.1, < 7.1)
+      rspec-core (>= 2.14)
+    rswag-ui (2.8.0)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.38.0)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -360,6 +372,9 @@ DEPENDENCIES
   rollbar
   roo (~> 2.9.0)
   rspec-rails
+  rswag-api
+  rswag-specs
+  rswag-ui
   selenium-webdriver
   sidekiq (~> 7)
   sprockets-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,10 @@ GEM
     json (2.6.2)
     json-schema (3.0.0)
       addressable (>= 2.8)
+    jsonapi-resources (0.10.7)
+      activerecord (>= 4.1)
+      concurrent-ruby
+      railties (>= 4.1)
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -366,6 +370,7 @@ DEPENDENCIES
   erblint-github
   factory_bot_rails
   importmap-rails
+  jsonapi-resources
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4)
@@ -373,6 +375,7 @@ DEPENDENCIES
   jsonapi-resources
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.4)
   rollbar
   roo (~> 2.9.0)

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,11 @@
 
 require_relative "config/application"
 
+# https://github.com/rswag/rswag/issues/359#issuecomment-728836401
+if defined? RSpec
+  RSpec.configure do |config|
+    config.swagger_dry_run = false
+  end
+end
+
 Rails.application.load_tasks

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,5 @@
+class API::V1::APIController < ApplicationController
+  include JSONAPI::ActsAsResourceController
+
+  protect_from_forgery with: :null_session
+end

--- a/app/controllers/api/v1/occupations_controller.rb
+++ b/app/controllers/api/v1/occupations_controller.rb
@@ -1,0 +1,2 @@
+class API::V1::OccupationsController < API::V1::APIController
+end

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -1,6 +1,11 @@
 class Occupation < ApplicationRecord
-  validates :name, presence: true
   has_many :competency_options, as: :resource
 
   belongs_to :onet_code, optional: true
+
+  validates :name, presence: true
+
+  def onet_soc_code
+    onet_code&.code
+  end
 end

--- a/app/resources/api/v1/occupation_resource.rb
+++ b/app/resources/api/v1/occupation_resource.rb
@@ -1,0 +1,20 @@
+class API::V1::OccupationResource < JSONAPI::Resource
+  immutable
+  model_name "Occupation"
+
+  attributes :name, :description, :onet_code, :rapids_code, :time_based_hours, :competency_based_hours
+
+  def onet_code
+    @model.onet_soc_code
+  end
+
+  class << self
+    def default_sort
+      [{field: "name", direction: :asc}]
+    end
+
+    def records_for_populate(options = {})
+      super(options).includes(:onet_code)
+    end
+  end
+end

--- a/app/resources/api/v1/occupation_resource.rb
+++ b/app/resources/api/v1/occupation_resource.rb
@@ -2,7 +2,7 @@ class API::V1::OccupationResource < JSONAPI::Resource
   immutable
   model_name "Occupation"
 
-  attributes :name, :description, :onet_code, :rapids_code, :time_based_hours, :competency_based_hours
+  attributes :name, :onet_code, :rapids_code, :time_based_hours, :competency_based_hours
 
   def onet_code
     @model.onet_soc_code

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,13 @@
+# Be sure to restart your server when you modify this file.
+
+# Avoid CORS issues when API is called from the frontend app.
+# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
+
+# Read more: https://github.com/cyu/rack-cors
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "localhost:3000", "127.0.0.1:3000", "admin.example.localhost:3000"
+    resource "*", headers: :any, methods: [:get, :options]
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "localhost:3000", "127.0.0.1:3000", "admin.example.localhost:3000"
+    origins "localhost:3000", "127.0.0.1:3000", "admin.example.localhost:3000", "https://admin.apprenticeshipstandards.org"
     resource "*", headers: :any, methods: [:get, :options]
   end
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "API"
+end

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -1,0 +1,7 @@
+JSONAPI.configure do |config|
+  # :underscored_key, :camelized_key, :dasherized_key, or custom
+  config.json_key_format = :underscored_key
+
+  # Allowed values are :integer(default), :uuid, :string, or a proc
+  config.resource_key_type = :uuid
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,14 +1,13 @@
 Rswag::Api.configure do |c|
-
   # Specify a root folder where Swagger JSON files are located
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = Rails.root.to_s + '/swagger'
+  c.swagger_root = Rails.root.to_s + "/swagger"
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request
   # For example, you could leverage this to dynamically assign the "host" property
   #
-  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
 end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,5 +1,4 @@
 Rswag::Ui.configure do |c|
-
   # List the Swagger endpoints that you want to be documented through the
   # swagger-ui. The first parameter is the path (absolute or relative to the UI
   # host) to the corresponding endpoint and the second is a title that will be
@@ -8,7 +7,7 @@ Rswag::Ui.configure do |c|
   # (under swagger_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => "/api-docs"
+  mount Rswag::Api::Engine => "/api-docs"
+
   constraints(Subdomain) do
     require "sidekiq/web"
 
@@ -32,4 +35,10 @@ Rails.application.routes.draw do
   root to: "standards_imports#new", as: :guest_root
 
   resources :standards_imports, only: [:new, :create, :show]
+
+  namespace :api do
+    namespace :v1 do
+      jsonapi_resources :occupations
+    end
+  end
 end

--- a/spec/requests/api/v1/occupations_spec.rb
+++ b/spec/requests/api/v1/occupations_spec.rb
@@ -3,9 +3,9 @@ require "swagger_helper"
 RSpec.describe "api/v1/occupations", type: :request do
   path "/api/v1/occupations" do
     get "List occupations" do
-      response(200, "successful") do
-        produces "application/vnd.api+json"
+      produces "application/vnd.api+json"
 
+      response(200, "successful") do
         let(:onet_code1) { create(:onet_code, code: "51-7011.00") }
         let!(:occ1) { create(:occupation, name: "Information Technology Specialist", onet_code: onet_code1, rapids_code: "1132", time_based_hours: 2782, competency_based_hours: 2000) }
         let!(:occ2) { create(:occupation, name: "Accordion Maker", rapids_code: "0860", time_based_hours: 8000, competency_based_hours: 8500) }
@@ -25,6 +25,13 @@ RSpec.describe "api/v1/occupations", type: :request do
                 properties: {
                   id: {type: :string},
                   type: {type: :string},
+                  links: {
+                    type: :object,
+                    properties: {
+                      self: {type: :string}
+                    },
+                    required: %w[self]
+                  },
                   attributes: {
                     type: :object,
                     properties: {
@@ -37,7 +44,7 @@ RSpec.describe "api/v1/occupations", type: :request do
                     required: %w[name]
                   }
                 },
-                required: %w[id type attributes]
+                required: %w[id type attributes links]
               }
             }
           },
@@ -75,6 +82,77 @@ RSpec.describe "api/v1/occupations", type: :request do
                 }
               }
             ]
+          }
+
+          expect(json_response).to eq expected_resp
+        end
+      end
+    end
+  end
+
+  path "/api/v1/occupations/{id}" do
+    get "Retrieve occupation" do
+      parameter name: :id, in: :path, type: :string
+      produces "application/vnd.api+json"
+
+      response(200, "successful") do
+        let(:onet_code1) { create(:onet_code, code: "51-7011.00") }
+        let!(:occ) { create(:occupation, name: "Information Technology Specialist", onet_code: onet_code1, rapids_code: "1132", time_based_hours: 2782, competency_based_hours: 2000) }
+        let(:id) { occ.id }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            "application/vnd.api+json" => {example: response_json}
+          }
+        end
+
+        schema type: :object,
+          properties: {
+            data: {
+              type: :object,
+              properties: {
+                id: {type: :string},
+                type: {type: :string},
+                links: {
+                  type: :object,
+                  properties: {
+                    self: {type: :string}
+                  },
+                  required: %w[self]
+                },
+                attributes: {
+                  type: :object,
+                  properties: {
+                    name: {type: :string},
+                    onet_code: {type: :string, nullable: true},
+                    rapids_code: {type: :string, nullable: true},
+                    time_based_hours: {type: :integer, nullable: true},
+                    competency_based_hours: {type: :integer, nullable: true}
+                  },
+                  required: %w[name]
+                },
+                required: %w[id type attributes links]
+              }
+            }
+          },
+          required: %w[data]
+
+        run_test! do |response|
+          expected_resp = {
+            data: {
+              id: occ.id.to_s,
+              type: "occupations",
+              links: {
+                self: api_v1_occupation_url(occ)
+              },
+              attributes: {
+                name: occ.name,
+                onet_code: "51-7011.00",
+                rapids_code: "1132",
+                time_based_hours: 2782,
+                competency_based_hours: 2000
+              }
+            }
           }
 
           expect(json_response).to eq expected_resp

--- a/spec/requests/api/v1/occupations_spec.rb
+++ b/spec/requests/api/v1/occupations_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "api/v1/occupations", type: :request do
             ]
           }
 
-          expect(json_response).to eq expected_resp
+          expect(response_json).to eq expected_resp
         end
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe "api/v1/occupations", type: :request do
             }
           }
 
-          expect(json_response).to eq expected_resp
+          expect(response_json).to eq expected_resp
         end
       end
     end

--- a/spec/requests/api/v1/occupations_spec.rb
+++ b/spec/requests/api/v1/occupations_spec.rb
@@ -1,0 +1,88 @@
+require "swagger_helper"
+
+RSpec.describe "api/v1/occupations", type: :request do
+  path "/api/v1/occupations" do
+    get "List occupations" do
+      response(200, "successful") do
+        produces "application/vnd.api+json"
+
+        let(:onet_code1) { create(:onet_code, code: "123.4") }
+        let!(:occ1) { create(:occupation, name: "Foo", description: "Occ1 Desc", onet_code: onet_code1, time_based_hours: 400) }
+        let!(:occ2) { create(:occupation, name: "Bar", description: "Occ2 Desc", rapids_code: "4567", competency_based_hours: 250) }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            "application/vnd.api+json" => {example: response_json}
+          }
+        end
+
+        schema type: :object,
+          properties: {
+            data: {
+              type: :array,
+              items: {
+                type: :object,
+                properties: {
+                  id: {type: :string},
+                  type: {type: :string},
+                  attributes: {
+                    type: :object,
+                    properties: {
+                      name: {type: :string},
+                      description: {type: :string, nullable: true},
+                      onet_code: {type: :string, nullable: true},
+                      rapids_code: {type: :string, nullable: true},
+                      time_based_hours: {type: :integer, nullable: true},
+                      competency_based_hours: {type: :integer, nullable: true}
+                    },
+                    required: %w[name]
+                  }
+                },
+                required: %w[id type attributes]
+              }
+            }
+          },
+          required: %w[data]
+
+        run_test! do |response|
+          expected_resp = {
+            data: [
+              {
+                id: occ2.id.to_s,
+                type: "occupations",
+                links: {
+                  self: api_v1_occupation_url(occ2)
+                },
+                attributes: {
+                  name: occ2.name,
+                  description: occ2.description,
+                  onet_code: nil,
+                  rapids_code: "4567",
+                  time_based_hours: nil,
+                  competency_based_hours: 250
+                }
+              },
+              {
+                id: occ1.id.to_s,
+                type: "occupations",
+                links: {
+                  self: api_v1_occupation_url(occ1)
+                },
+                attributes: {
+                  name: occ1.name,
+                  description: occ1.description,
+                  onet_code: "123.4",
+                  rapids_code: nil,
+                  time_based_hours: 400,
+                  competency_based_hours: nil
+                }
+              }
+            ]
+          }
+
+          expect(json_response).to eq expected_resp
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/occupations_spec.rb
+++ b/spec/requests/api/v1/occupations_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "api/v1/occupations", type: :request do
       response(200, "successful") do
         produces "application/vnd.api+json"
 
-        let(:onet_code1) { create(:onet_code, code: "123.4") }
-        let!(:occ1) { create(:occupation, name: "Foo", description: "Occ1 Desc", onet_code: onet_code1, time_based_hours: 400) }
-        let!(:occ2) { create(:occupation, name: "Bar", description: "Occ2 Desc", rapids_code: "4567", competency_based_hours: 250) }
+        let(:onet_code1) { create(:onet_code, code: "51-7011.00") }
+        let!(:occ1) { create(:occupation, name: "Information Technology Specialist", onet_code: onet_code1, rapids_code: "1132", time_based_hours: 2782, competency_based_hours: 2000) }
+        let!(:occ2) { create(:occupation, name: "Accordion Maker", rapids_code: "0860", time_based_hours: 8000, competency_based_hours: 8500) }
 
         after do |example|
           example.metadata[:response][:content] = {
@@ -29,7 +29,6 @@ RSpec.describe "api/v1/occupations", type: :request do
                     type: :object,
                     properties: {
                       name: {type: :string},
-                      description: {type: :string, nullable: true},
                       onet_code: {type: :string, nullable: true},
                       rapids_code: {type: :string, nullable: true},
                       time_based_hours: {type: :integer, nullable: true},
@@ -55,11 +54,10 @@ RSpec.describe "api/v1/occupations", type: :request do
                 },
                 attributes: {
                   name: occ2.name,
-                  description: occ2.description,
                   onet_code: nil,
-                  rapids_code: "4567",
-                  time_based_hours: nil,
-                  competency_based_hours: 250
+                  rapids_code: "0860",
+                  time_based_hours: 8000,
+                  competency_based_hours: 8500
                 }
               },
               {
@@ -70,11 +68,10 @@ RSpec.describe "api/v1/occupations", type: :request do
                 },
                 attributes: {
                   name: occ1.name,
-                  description: occ1.description,
-                  onet_code: "123.4",
-                  rapids_code: nil,
-                  time_based_hours: 400,
-                  competency_based_hours: nil
+                  onet_code: "51-7011.00",
+                  rapids_code: "1132",
+                  time_based_hours: 2782,
+                  competency_based_hours: 2000
                 }
               }
             ]

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,19 @@
+module RequestHelpers
+  def response_json
+    @_response_json ||= if response
+      JSON.parse(response.body)
+    else
+      fail "expected to find response, found nil"
+    end
+  end
+
+  def json_response
+    @_json_response ||= if response
+      JSON.parse(response.body, symbolize_names: true)
+    else
+      fail "expected to find response, found nil"
+    end
+  end
+end
+
+RSpec.configure { |config| config.include RequestHelpers }

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,14 +1,6 @@
 module RequestHelpers
   def response_json
     @_response_json ||= if response
-      JSON.parse(response.body)
-    else
-      fail "expected to find response, found nil"
-    end
-  end
-
-  def json_response
-    @_json_response ||= if response
       JSON.parse(response.body, symbolize_names: true)
     else
       fail "expected to find response, found nil"

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join("swagger").to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    "v1/swagger.yaml" => {
+      openapi: "3.0.1",
+      info: {
+        title: "API V1",
+        version: "v1"
+      },
+      paths: {},
+      servers: [
+        {
+          url: "http://{defaultHost}",
+          variables: {
+            defaultHost: {
+              default: "localhost:3000"
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -24,6 +24,10 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
+          url: "https://admin.apprenticeshipstandards.org",
+          description: "Production server"
+        },
+        {
           url: "http://localhost:3000",
           description: "Local development server (uses test data)"
         },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -26,6 +26,10 @@ RSpec.configure do |config|
         {
           url: "http://localhost:3000",
           description: "Local development server (uses test data)"
+        },
+        {
+          url: "http://admin.example.localhost:3000",
+          description: "Local development server (uses test data)"
         }
       ]
     }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -24,12 +24,8 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
-          url: "http://{defaultHost}",
-          variables: {
-            defaultHost: {
-              default: "localhost:3000"
-            }
-          }
+          url: "http://localhost:3000",
+          description: "Local development server (uses test data)"
         }
       ]
     }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -14,28 +14,26 @@ paths:
             application/vnd.api+json:
               example:
                 data:
-                - id: d9186843-dcb4-4868-84aa-4bde55971603
+                - id: 183ddc14-69e3-49fc-a305-b06fe0b380de
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/d9186843-dcb4-4868-84aa-4bde55971603
+                    self: http://www.example.com/api/v1/occupations/183ddc14-69e3-49fc-a305-b06fe0b380de
                   attributes:
-                    name: Bar
-                    description: Occ2 Desc
+                    name: Accordion Maker
                     onet_code:
-                    rapids_code: '4567'
-                    time_based_hours:
-                    competency_based_hours: 250
-                - id: 4839d4d9-9737-43b1-9242-b20f2962c0b8
+                    rapids_code: '0860'
+                    time_based_hours: 8000
+                    competency_based_hours: 8500
+                - id: 8bdb4666-aaf9-437b-9379-e74c432cbd82
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/4839d4d9-9737-43b1-9242-b20f2962c0b8
+                    self: http://www.example.com/api/v1/occupations/8bdb4666-aaf9-437b-9379-e74c432cbd82
                   attributes:
-                    name: Foo
-                    description: Occ1 Desc
-                    onet_code: '123.4'
-                    rapids_code:
-                    time_based_hours: 400
-                    competency_based_hours:
+                    name: Information Technology Specialist
+                    onet_code: 51-7011.00
+                    rapids_code: '1132'
+                    time_based_hours: 2782
+                    competency_based_hours: 2000
               schema:
                 type: object
                 properties:
@@ -53,9 +51,6 @@ paths:
                           properties:
                             name:
                               type: string
-                            description:
-                              type: string
-                              nullable: true
                             onet_code:
                               type: string
                               nullable: true
@@ -77,7 +72,5 @@ paths:
                 required:
                 - data
 servers:
-- url: http://{defaultHost}
-  variables:
-    defaultHost:
-      default: localhost:3000
+- url: http://localhost:3000
+  description: Local development server (uses test data)

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -14,20 +14,20 @@ paths:
             application/vnd.api+json:
               example:
                 data:
-                - id: 89e62581-322e-4164-be19-c3f492781327
+                - id: 8df86347-d95d-4dad-829d-a5b9d171d9ba
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/89e62581-322e-4164-be19-c3f492781327
+                    self: http://www.example.com/api/v1/occupations/8df86347-d95d-4dad-829d-a5b9d171d9ba
                   attributes:
                     name: Accordion Maker
                     onet_code:
                     rapids_code: '0860'
                     time_based_hours: 8000
                     competency_based_hours: 8500
-                - id: 490079a7-f465-40d1-a6b5-6afc3d8980ef
+                - id: fa55b8c6-a97d-43df-8a2c-1715af5f69b7
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/490079a7-f465-40d1-a6b5-6afc3d8980ef
+                    self: http://www.example.com/api/v1/occupations/fa55b8c6-a97d-43df-8a2c-1715af5f69b7
                   attributes:
                     name: Information Technology Specialist
                     onet_code: 51-7011.00
@@ -46,6 +46,13 @@ paths:
                           type: string
                         type:
                           type: string
+                        links:
+                          type: object
+                          properties:
+                            self:
+                              type: string
+                          required:
+                          - self
                         attributes:
                           type: object
                           properties:
@@ -69,6 +76,76 @@ paths:
                       - id
                       - type
                       - attributes
+                      - links
+                required:
+                - data
+  "/api/v1/occupations/{id}":
+    get:
+      summary: Retrieve occupation
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+          content:
+            application/vnd.api+json:
+              example:
+                data:
+                  id: 3f5b1a44-6149-48da-8363-94b60a3244e5
+                  type: occupations
+                  links:
+                    self: http://www.example.com/api/v1/occupations/3f5b1a44-6149-48da-8363-94b60a3244e5
+                  attributes:
+                    name: Information Technology Specialist
+                    onet_code: 51-7011.00
+                    rapids_code: '1132'
+                    time_based_hours: 2782
+                    competency_based_hours: 2000
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                      links:
+                        type: object
+                        properties:
+                          self:
+                            type: string
+                        required:
+                        - self
+                      attributes:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          onet_code:
+                            type: string
+                            nullable: true
+                          rapids_code:
+                            type: string
+                            nullable: true
+                          time_based_hours:
+                            type: integer
+                            nullable: true
+                          competency_based_hours:
+                            type: integer
+                            nullable: true
+                        required:
+                        - name
+                      required:
+                      - id
+                      - type
+                      - attributes
+                      - links
                 required:
                 - data
 servers:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -14,20 +14,20 @@ paths:
             application/vnd.api+json:
               example:
                 data:
-                - id: 183ddc14-69e3-49fc-a305-b06fe0b380de
+                - id: 89e62581-322e-4164-be19-c3f492781327
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/183ddc14-69e3-49fc-a305-b06fe0b380de
+                    self: http://www.example.com/api/v1/occupations/89e62581-322e-4164-be19-c3f492781327
                   attributes:
                     name: Accordion Maker
                     onet_code:
                     rapids_code: '0860'
                     time_based_hours: 8000
                     competency_based_hours: 8500
-                - id: 8bdb4666-aaf9-437b-9379-e74c432cbd82
+                - id: 490079a7-f465-40d1-a6b5-6afc3d8980ef
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/8bdb4666-aaf9-437b-9379-e74c432cbd82
+                    self: http://www.example.com/api/v1/occupations/490079a7-f465-40d1-a6b5-6afc3d8980ef
                   attributes:
                     name: Information Technology Specialist
                     onet_code: 51-7011.00
@@ -73,4 +73,6 @@ paths:
                 - data
 servers:
 - url: http://localhost:3000
+  description: Local development server (uses test data)
+- url: http://admin.example.localhost:3000
   description: Local development server (uses test data)

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,83 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/v1/occupations":
+    get:
+      summary: List occupations
+      responses:
+        '200':
+          description: successful
+          content:
+            application/vnd.api+json:
+              example:
+                data:
+                - id: d9186843-dcb4-4868-84aa-4bde55971603
+                  type: occupations
+                  links:
+                    self: http://www.example.com/api/v1/occupations/d9186843-dcb4-4868-84aa-4bde55971603
+                  attributes:
+                    name: Bar
+                    description: Occ2 Desc
+                    onet_code:
+                    rapids_code: '4567'
+                    time_based_hours:
+                    competency_based_hours: 250
+                - id: 4839d4d9-9737-43b1-9242-b20f2962c0b8
+                  type: occupations
+                  links:
+                    self: http://www.example.com/api/v1/occupations/4839d4d9-9737-43b1-9242-b20f2962c0b8
+                  attributes:
+                    name: Foo
+                    description: Occ1 Desc
+                    onet_code: '123.4'
+                    rapids_code:
+                    time_based_hours: 400
+                    competency_based_hours:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        type:
+                          type: string
+                        attributes:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            description:
+                              type: string
+                              nullable: true
+                            onet_code:
+                              type: string
+                              nullable: true
+                            rapids_code:
+                              type: string
+                              nullable: true
+                            time_based_hours:
+                              type: integer
+                              nullable: true
+                            competency_based_hours:
+                              type: integer
+                              nullable: true
+                          required:
+                          - name
+                      required:
+                      - id
+                      - type
+                      - attributes
+                required:
+                - data
+servers:
+- url: http://{defaultHost}
+  variables:
+    defaultHost:
+      default: localhost:3000

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -14,20 +14,20 @@ paths:
             application/vnd.api+json:
               example:
                 data:
-                - id: 8df86347-d95d-4dad-829d-a5b9d171d9ba
+                - id: 9f8c2e51-9269-472f-83a0-1e55bc0dae23
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/8df86347-d95d-4dad-829d-a5b9d171d9ba
+                    self: http://www.example.com/api/v1/occupations/9f8c2e51-9269-472f-83a0-1e55bc0dae23
                   attributes:
                     name: Accordion Maker
                     onet_code:
                     rapids_code: '0860'
                     time_based_hours: 8000
                     competency_based_hours: 8500
-                - id: fa55b8c6-a97d-43df-8a2c-1715af5f69b7
+                - id: 8c11d60d-5b71-4896-89e4-d585a8013767
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/fa55b8c6-a97d-43df-8a2c-1715af5f69b7
+                    self: http://www.example.com/api/v1/occupations/8c11d60d-5b71-4896-89e4-d585a8013767
                   attributes:
                     name: Information Technology Specialist
                     onet_code: 51-7011.00
@@ -95,10 +95,10 @@ paths:
             application/vnd.api+json:
               example:
                 data:
-                  id: 3f5b1a44-6149-48da-8363-94b60a3244e5
+                  id: 20fc41e6-1b85-4464-a8fe-aec95f66a912
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/3f5b1a44-6149-48da-8363-94b60a3244e5
+                    self: http://www.example.com/api/v1/occupations/20fc41e6-1b85-4464-a8fe-aec95f66a912
                   attributes:
                     name: Information Technology Specialist
                     onet_code: 51-7011.00

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -14,20 +14,20 @@ paths:
             application/vnd.api+json:
               example:
                 data:
-                - id: 9f8c2e51-9269-472f-83a0-1e55bc0dae23
+                - id: fe5ee882-442b-4dd6-8199-47e2546061c0
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/9f8c2e51-9269-472f-83a0-1e55bc0dae23
+                    self: http://www.example.com/api/v1/occupations/fe5ee882-442b-4dd6-8199-47e2546061c0
                   attributes:
                     name: Accordion Maker
                     onet_code:
                     rapids_code: '0860'
                     time_based_hours: 8000
                     competency_based_hours: 8500
-                - id: 8c11d60d-5b71-4896-89e4-d585a8013767
+                - id: 37bf165c-101d-4388-b118-ea96bf2d7551
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/8c11d60d-5b71-4896-89e4-d585a8013767
+                    self: http://www.example.com/api/v1/occupations/37bf165c-101d-4388-b118-ea96bf2d7551
                   attributes:
                     name: Information Technology Specialist
                     onet_code: 51-7011.00
@@ -95,10 +95,10 @@ paths:
             application/vnd.api+json:
               example:
                 data:
-                  id: 20fc41e6-1b85-4464-a8fe-aec95f66a912
+                  id: 62a0afeb-cc61-4932-bcca-f5a97e9af002
                   type: occupations
                   links:
-                    self: http://www.example.com/api/v1/occupations/20fc41e6-1b85-4464-a8fe-aec95f66a912
+                    self: http://www.example.com/api/v1/occupations/62a0afeb-cc61-4932-bcca-f5a97e9af002
                   attributes:
                     name: Information Technology Specialist
                     onet_code: 51-7011.00
@@ -149,6 +149,8 @@ paths:
                 required:
                 - data
 servers:
+- url: https://admin.apprenticeshipstandards.org
+  description: Production server
 - url: http://localhost:3000
   description: Local development server (uses test data)
 - url: http://admin.example.localhost:3000


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203289004376685/f

This sets up the [rswag](https://github.com/rswag/rswag) and [jsonapi-resources](https://github.com/cerebris/jsonapi-resources) gems to start building the API in [{json:api}](https://jsonapi.org/format/) format.

The API docs are viewable from `/api-docs`:

<img width="1528" alt="Screen Shot 2023-01-31 at 10 59 51 AM" src="https://user-images.githubusercontent.com/1938665/215856775-793c423e-b0ec-47ab-82b5-ee3b9f9bcdbb.png">

<img width="1320" alt="Screen Shot 2023-01-31 at 11 05 40 AM" src="https://user-images.githubusercontent.com/1938665/215857838-902daf75-b046-4617-8dac-52f6d160a506.png">

and can be run from localhost, the admin.localhost, or the production domains:

<img width="828" alt="Screen Shot 2023-02-01 at 8 41 14 AM" src="https://user-images.githubusercontent.com/1938665/216106283-803b9934-0bf3-424b-b009-017bf1abeab1.png">

