### PR TITLE
Change hybrid hours to separate min/max fields

### DIFF
--- a/db/migrate/20230131201834_remove_hybrid_hours_from_occupations.rb
+++ b/db/migrate/20230131201834_remove_hybrid_hours_from_occupations.rb
@@ -1,0 +1,5 @@
+class RemoveHybridHoursFromOccupations < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :occupations, :hybrid_hours, :int4range
+  end
+end

--- a/db/migrate/20230131201910_add_hybrid_hours_min_max_to_occupations.rb
+++ b/db/migrate/20230131201910_add_hybrid_hours_min_max_to_occupations.rb
@@ -1,0 +1,6 @@
+class AddHybridHoursMinMaxToOccupations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :occupations, :hybrid_hours_min, :integer
+    add_column :occupations, :hybrid_hours_max, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -124,9 +124,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_31_214712) do
     t.datetime "updated_at", null: false
     t.string "rapids_code"
     t.integer "time_based_hours"
-    t.int4range "hybrid_hours"
     t.integer "competency_based_hours"
     t.uuid "onet_code_id"
+    t.integer "hybrid_hours_min"
+    t.integer "hybrid_hours_max"
     t.index ["onet_code_id"], name: "index_occupations_on_onet_code_id"
   end
 

--- a/lib/tasks/occupation.rake
+++ b/lib/tasks/occupation.rake
@@ -10,19 +10,19 @@ namespace :occupation do
         next if index.zero?
         occupation = Occupation.find_or_initialize_by(name: row["RAPIDS TITLE"])
         onet_code = OnetCode.find_by(code: row["ONET SOC CODE"].strip)
-        hybrid_start_hours = nil
-        hybrid_end_hours = nil
-        hybrid_hours = nil
+        hybrid_hours_min = nil
+        hybrid_hours_max = nil
 
         if row["HYBRID"]
           hours = row["HYBRID"]
-          hybrid_start_hours = hours.match(/(\d{1,})\s*-/)
-          hybrid_end_hours = hours.match(/-\s*(\d{1,})/)
+          hybrid_hours = hours.match(/(\d{1,})\s*-\s*(\d{1,})/)
 
-          hybrid_hours = if hybrid_start_hours && hybrid_end_hours
-            (hybrid_start_hours[1]..hybrid_end_hours[1])
+          if hybrid_hours
+            hybrid_hours_min = hybrid_hours[1]
+            hybrid_hours_max = hybrid_hours[2]
           else
-            (hours..hours)
+            hybrid_hours_min = hours
+            hybrid_hours_max = hours
           end
         end
 
@@ -30,7 +30,8 @@ namespace :occupation do
           rapids_code: row["RAPIDS CODE"],
           onet_code: onet_code,
           time_based_hours: row["TIME-BASED"],
-          hybrid_hours: hybrid_hours,
+          hybrid_hours_min: hybrid_hours_min,
+          hybrid_hours_max: hybrid_hours_max,
           competency_based_hours: row["COMPETENCY-BASED"]
         )
       end

--- a/lib/tasks/occupation.rake
+++ b/lib/tasks/occupation.rake
@@ -15,11 +15,11 @@ namespace :occupation do
 
         if row["HYBRID"]
           hours = row["HYBRID"]
-          hybrid_hours = hours.match(/(\d{1,})\s*-\s*(\d{1,})/)
+          hybrid_hours = hours.match(/(?<hybrid_hours_min>\d{1,})\s*-\s*(?<hybrid_hours_max>\d{1,})/)
 
           if hybrid_hours
-            hybrid_hours_min = hybrid_hours[1]
-            hybrid_hours_max = hybrid_hours[2]
+            hybrid_hours_min = hybrid_hours[:hybrid_hours_min]
+            hybrid_hours_max = hybrid_hours[:hybrid_hours_max]
           else
             hybrid_hours_min = hours
             hybrid_hours_max = hours


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203831316199916/f

This removes the Postgres range field type for hybrid_hours and replaces it with min/max fields instead. It also updates the occupation scraper rake task to use the new fields.
