### PR TITLE
Display occupation standard on data import page plus other improvements

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,6 +6,10 @@
   .btn-primary {
     @apply bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded
   }
+
+  .btn-secondary {
+    @apply bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded
+  }
 }
 
 @layer base {

--- a/app/controllers/data_imports_controller.rb
+++ b/app/controllers/data_imports_controller.rb
@@ -15,6 +15,7 @@ class DataImportsController < ApplicationController
 
     if @data_import.save
       ProcessDataImportJob.perform_later(@data_import)
+      flash[:notice] = "Thank you for submitting your occupation standard!"
       redirect_to data_import_path(@data_import)
     else
       render :new, status: :unprocessable_entity

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -7,6 +7,8 @@ class DataImport < ApplicationRecord
 
   validate :file_presence
 
+  delegate :title, to: :occupation_standard, prefix: true, allow_nil: true
+
   private
 
   def file_presence

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -3,6 +3,8 @@ class DataImport < ApplicationRecord
 
   belongs_to :user
 
+  has_one :occupation_standard
+
   validate :file_presence
 
   private

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -9,6 +9,7 @@ class OccupationStandard < ApplicationRecord
   has_many :work_processes, dependent: :destroy
 
   delegate :rapids_code, to: :occupation, allow_nil: true
+  delegate :name, to: :occupation, prefix: true, allow_nil: true
 
   enum occupation_type: [:time, :competency, :hybrid], _suffix: :based
 

--- a/app/views/data_imports/edit.html.erb
+++ b/app/views/data_imports/edit.html.erb
@@ -7,5 +7,6 @@
   </div>
   <div>
     <%= f.submit "Update", class: "btn-primary" %>
+    <%= link_to "Cancel", :back, class: "btn-secondary" %>
   </div>
 <% end %>

--- a/app/views/data_imports/index.html.erb
+++ b/app/views/data_imports/index.html.erb
@@ -1,5 +1,6 @@
 <div id="data-imports" class="w-full flex flex-col mx-auto">
   <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standard Data Imports</h1>
+  <%= link_to "Upload data import", new_data_import_path, class: "btn-primary mb-3 w-fit" %>
   <% @data_imports.find_each do |data_import| %>
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= data_import.description %></p>

--- a/app/views/data_imports/index.html.erb
+++ b/app/views/data_imports/index.html.erb
@@ -3,7 +3,7 @@
   <%= link_to "Upload data import", new_data_import_path, class: "btn-primary mb-3 w-fit" %>
   <% @data_imports.find_each do |data_import| %>
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
-      <p class="font-medium"><%= data_import.description %></p>
+      <p class="font-medium"><%= link_to data_import.description, data_import_path(data_import) %></p>
       <%= link_to "Edit", edit_data_import_path(data_import) %>
     </div>
   <% end %>

--- a/app/views/data_imports/index.html.erb
+++ b/app/views/data_imports/index.html.erb
@@ -1,5 +1,5 @@
 <div id="data-imports" class="w-full flex flex-col mx-auto">
-  <h2 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standard Data Imports</h2>
+  <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standard Data Imports</h1>
   <% @data_imports.find_each do |data_import| %>
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= data_import.description %></p>

--- a/app/views/data_imports/new.html.erb
+++ b/app/views/data_imports/new.html.erb
@@ -19,6 +19,7 @@
       </div>
       <div>
         <%= f.submit "Upload", class: "btn-primary" %>
+        <%= link_to "Cancel", :back, class: "btn-secondary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/data_imports/show.html.erb
+++ b/app/views/data_imports/show.html.erb
@@ -7,14 +7,14 @@
     </div>
     <div class="mb-4">
       <div class="show-label">File</div>
-        <div class="w-full mb-1">
-          <%= link_to @data_import.file.filename.to_s, url_for(@data_import.file), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
-        </div>
+      <div class="w-full mb-1">
+        <%= link_to @data_import.file.filename.to_s, url_for(@data_import.file), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
+      </div>
     </div>
   </div>
   <div class=" max-w-prose mx-auto flex text-center space-x-2">
     <%= link_to "Upload more standards", new_data_import_path, class: "btn-primary" %>
-    <%= link_to "Edit occupation standard", edit_data_import_path(@data_import), class: "btn-primary" %>
-    <%= button_to "Delete occupation standard", data_import_path(@data_import), method: :delete, data: {turbo_method: :delete}, class: "btn-primary" %>
+    <%= link_to "Edit data import", edit_data_import_path(@data_import), class: "btn-primary" %>
+    <%= button_to "Delete data import", data_import_path(@data_import), method: :delete, data: {turbo_method: :delete}, class: "btn-primary" %>
   </div>
 </div>

--- a/app/views/data_imports/show.html.erb
+++ b/app/views/data_imports/show.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col w-full mx-auto">
-  <h1 class="w-full max-w-prose mx-auto text-center mb-3">Thank you for submitting your occupation standard!</h1>
+  <h1 class="w-full max-w-prose mx-auto text-center mb-3">Data Import</h1>
   <div class="w-full max-w-prose mx-auto mb-4">
     <div class="mb-4">
       <div class="show-label">Description</div>

--- a/app/views/data_imports/show.html.erb
+++ b/app/views/data_imports/show.html.erb
@@ -15,7 +15,7 @@
       <div class="mb-4">
         <div class="show-label">Occupation standard</div>
         <div class="w-full mb-1">
-          <%= link_to @data_import.occupation_standard.title, occupation_standard_path(@data_import.occupation_standard), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
+          <%= link_to @data_import.occupation_standard_title, occupation_standard_path(@data_import.occupation_standard), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
         </div>
       </div>
     <% end %>

--- a/app/views/data_imports/show.html.erb
+++ b/app/views/data_imports/show.html.erb
@@ -11,6 +11,14 @@
         <%= link_to @data_import.file.filename.to_s, url_for(@data_import.file), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
       </div>
     </div>
+    <% if @data_import.occupation_standard %>
+      <div class="mb-4">
+        <div class="show-label">Occupation standard</div>
+        <div class="w-full mb-1">
+          <%= link_to @data_import.occupation_standard.title, occupation_standard_path(@data_import.occupation_standard), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
+        </div>
+      </div>
+    <% end %>
   </div>
   <div class=" max-w-prose mx-auto flex text-center space-x-2">
     <%= link_to "Upload more standards", new_data_import_path, class: "btn-primary" %>

--- a/app/views/file_imports/index.html.erb
+++ b/app/views/file_imports/index.html.erb
@@ -1,5 +1,5 @@
 <div id="file-imports" class="w-full flex flex-col mx-auto">
-  <h2 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">File Imports</h2>
+  <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">File Imports</h1>
   <% @file_imports.find_each do |file_import| %>
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= link_to file_import.filename, file_import.active_storage_attachment.blob.url %></p>

--- a/app/views/occupation_standards/_occupation_standard.html.erb
+++ b/app/views/occupation_standards/_occupation_standard.html.erb
@@ -1,6 +1,6 @@
 <tr class="border-b">
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= link_to occupation_standard.id, occupation_standard, class: "underline" %>
+    <%= link_to occupation_standard.title, occupation_standard, class: "underline" %>
   </td>
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
     <%= occupation_standard.occupation.name %>

--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -7,7 +7,7 @@
           <thead class="border-b">
             <tr>
               <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-                ID
+                Title
               </th>
               <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
                 Occupation

--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col">
   <div class="overflow-x-auto sm:-mx-6 lg:-mx-8">
-    <h2 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standards</h2>
+    <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standards</h1>
     <div class="py-2 inline-block min-w-full sm:px-6 lg:px-8">
       <div class="overflow-hidden">
         <table class="min-w-full">

--- a/app/views/occupation_standards/show.html.erb
+++ b/app/views/occupation_standards/show.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col">
   <div class="overflow-x-auto sm:-mx-6 lg:-mx-8">
-    <h2 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standard for <%= @occupation_standard.occupation.name %></h2>
+    <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standard for <%= @occupation_standard.occupation.name %></h1>
     <div class="border-t border-gray-200">
       <dl>
         <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">

--- a/app/views/occupation_standards/show.html.erb
+++ b/app/views/occupation_standards/show.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col">
   <div class="overflow-x-auto sm:-mx-6 lg:-mx-8">
-    <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standard for <%= @occupation_standard.title %></h2>
+    <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standard for <%= @occupation_standard.title %></h1>
     <div class="border-t border-gray-200">
       <dl>
         <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">

--- a/app/views/occupation_standards/show.html.erb
+++ b/app/views/occupation_standards/show.html.erb
@@ -1,11 +1,11 @@
 <div class="flex flex-col">
   <div class="overflow-x-auto sm:-mx-6 lg:-mx-8">
-    <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standard for <%= @occupation_standard.occupation.name %></h1>
+    <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Occupation Standard for <%= @occupation_standard.title %></h2>
     <div class="border-t border-gray-200">
       <dl>
         <div class="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
           <dt "text-sm font-medium text-gray-500">Occupation:</dt>
-          <dd "mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @occupation_standard.occupation.name %></dd>
+          <dd "mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"><%= @occupation_standard.occupation_name %></dd>
         </div>
 
         <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">

--- a/app/views/related_instructions/index.html.erb
+++ b/app/views/related_instructions/index.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col">
   <div class="overflow-x-auto sm:-mx-6 lg:-mx-8">
-    <h2 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Related Instructions</h2>
+    <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Related Instructions</h1>
     <div class="py-2 inline-block min-w-full sm:px-6 lg:px-8">
       <div class="overflow-hidden">
         <%= render partial: "related_instructions/table", locals: {related_instructions: @related_instructions} %>

--- a/spec/system/file_imports/edit_spec.rb
+++ b/spec/system/file_imports/edit_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "file_imports/edit" do
     expect(page).to have_content("Edit #{file.filename}")
     select("Processing", from: "file_import[status]").click
     click_on "Update"
-    within("h2") do
+    within("h1") do
       expect(page).to have_content("File Imports")
     end
     expect(page).to have_content("Processing")

--- a/spec/views/data_imports/index_spec.rb
+++ b/spec/views/data_imports/index_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "data_imports/index.html.erb", type: :view do
     render
 
     expect(rendered).to have_selector("h1", text: "Occupation Standard Data Import")
-    expect(rendered).to have_text "DA Desc"
+    expect(rendered).to have_link("DA Desc", href: data_import_path(data_import))
     expect(rendered).to have_link("Edit", href: edit_data_import_path(data_import))
     expect(rendered).to have_link("Upload data import", href: new_data_import_path)
   end

--- a/spec/views/data_imports/index_spec.rb
+++ b/spec/views/data_imports/index_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe "data_imports/index.html.erb", type: :view do
 
     render
 
-    expect(rendered).to have_selector("h2", text: "Occupation Standard Data Import")
+    expect(rendered).to have_selector("h1", text: "Occupation Standard Data Import")
     expect(rendered).to have_text "DA Desc"
     expect(rendered).to have_link("Edit", href: edit_data_import_path(data_import))
   end
 end
-

--- a/spec/views/data_imports/index_spec.rb
+++ b/spec/views/data_imports/index_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "data_imports/index.html.erb", type: :view do
+  it "displays description and edit link", :admin do
+    data_import = create(:data_import, description: "DA Desc")
+    assign(:data_imports, DataImport.all)
+
+    render
+
+    expect(rendered).to have_selector("h2", text: "Occupation Standard Data Import")
+    expect(rendered).to have_text "DA Desc"
+    expect(rendered).to have_link("Edit", href: edit_data_import_path(data_import))
+  end
+end
+

--- a/spec/views/data_imports/index_spec.rb
+++ b/spec/views/data_imports/index_spec.rb
@@ -10,5 +10,6 @@ RSpec.describe "data_imports/index.html.erb", type: :view do
     expect(rendered).to have_selector("h1", text: "Occupation Standard Data Import")
     expect(rendered).to have_text "DA Desc"
     expect(rendered).to have_link("Edit", href: edit_data_import_path(data_import))
+    expect(rendered).to have_link("Upload data import", href: new_data_import_path)
   end
 end

--- a/spec/views/data_imports/show_spec.rb
+++ b/spec/views/data_imports/show_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "data_imports/show.html.erb", type: :view do
+  it "displays description and links", :admin do
+    data_import = create(:data_import, description: "DA Desc")
+    assign(:data_import, data_import)
+
+    render
+
+    expect(rendered).to have_selector("h1", text: "Data Import")
+    expect(rendered).to_not have_text("Occupation standard")
+    expect(rendered).to have_text("DA Desc")
+    expect(rendered).to have_link("Edit data import", href: edit_data_import_path(data_import))
+    expect(rendered).to have_button("Delete data import")
+  end
+
+  it "displays link to occupation standard if it exists" do
+    data_import = create(:data_import, description: "DA Desc")
+    occupation_standard = create(:occupation_standard, data_import: data_import, title: "Mechanic")
+    assign(:data_import, data_import)
+
+    render
+
+    expect(rendered).to have_link("Mechanic", href: occupation_standard_path(occupation_standard))
+  end
+end

--- a/spec/views/occupation_standards/index_spec.rb
+++ b/spec/views/occupation_standards/index_spec.rb
@@ -2,20 +2,20 @@ require "rails_helper"
 
 RSpec.describe "occupation_standards/index.html.erb", type: :view do
   it "displays name and description", :admin do
-    occupation_standards = create_list(:occupation_standard, 1)
+    occupation_standards = create_list(:occupation_standard, 1, title: "Mechanic")
     occupation_standard = occupation_standards.first
     assign(:occupation_standards, occupation_standards)
 
     render
 
     expect(rendered).to have_selector("h2", text: "Occupation Standards")
-    expect(rendered).to have_columnheader("ID")
+    expect(rendered).to have_columnheader("Title")
     expect(rendered).to have_columnheader("Occupation")
     expect(rendered).to have_columnheader("Registration Agency")
     expect(rendered).to have_columnheader("RAPIDS code")
     expect(rendered).to have_columnheader("ONET code")
 
-    expect(rendered).to have_link(occupation_standard.id, href: occupation_standard_path(occupation_standard))
+    expect(rendered).to have_link(occupation_standard.title, href: occupation_standard_path(occupation_standard))
     expect(rendered).to have_gridcell(occupation_standard.rapids_code)
     expect(rendered).to have_gridcell(occupation_standard.onet_code)
   end

--- a/spec/views/occupation_standards/index_spec.rb
+++ b/spec/views/occupation_standards/index_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "occupation_standards/index.html.erb", type: :view do
 
     render
 
-    expect(rendered).to have_selector("h2", text: "Occupation Standards")
+    expect(rendered).to have_selector("h1", text: "Occupation Standards")
     expect(rendered).to have_columnheader("Title")
     expect(rendered).to have_columnheader("Occupation")
     expect(rendered).to have_columnheader("Registration Agency")

--- a/spec/views/occupation_standards/show_spec.rb
+++ b/spec/views/occupation_standards/show_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 RSpec.describe "occupation_standards/show.html.erb", type: :view do
-  it "displays name and description" do
-    occupation_standard = build(:occupation_standard)
+  it "displays title and description" do
+    occupation_standard = build(:occupation_standard, title: "Mechanic")
     assign(:occupation_standard, occupation_standard)
 
     render
 
-    expect(rendered).to have_selector("h1", text: "Occupation Standard for #{occupation_standard.occupation.name}")
+    expect(rendered).to have_selector("h1", text: "Occupation Standard for Mechanic")
 
     expect(rendered).to have_selector("dt", text: "Occupation:")
     expect(rendered).to have_selector("dt", text: "URL:")
@@ -40,5 +40,15 @@ RSpec.describe "occupation_standards/show.html.erb", type: :view do
     expect(rendered).to have_columnheader("Default Hours")
     expect(rendered).to have_columnheader("Minimum Hours")
     expect(rendered).to have_columnheader("Maximum Hours")
+  end
+
+  it "allows for occupation standard not linked to an occupation" do
+    occupation_standard = build(:occupation_standard, occupation: nil)
+    assign(:occupation_standard, occupation_standard)
+
+    render
+
+    expect(rendered).to have_selector("h1", text: "Occupation Standard for #{occupation_standard.title}")
+    expect(rendered).to have_selector("dt", text: "Occupation:")
   end
 end

--- a/spec/views/occupation_standards/show_spec.rb
+++ b/spec/views/occupation_standards/show_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "occupation_standards/show.html.erb", type: :view do
-  it "displays name and description", :admin do
+  it "displays name and description" do
     occupation_standard = build(:occupation_standard)
     assign(:occupation_standard, occupation_standard)
 

--- a/spec/views/occupation_standards/show_spec.rb
+++ b/spec/views/occupation_standards/show_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "occupation_standards/show.html.erb", type: :view do
 
     render
 
-    expect(rendered).to have_selector("h2", text: "Occupation Standard for #{occupation_standard.occupation.name}")
+    expect(rendered).to have_selector("h1", text: "Occupation Standard for #{occupation_standard.occupation.name}")
 
     expect(rendered).to have_selector("dt", text: "Occupation:")
     expect(rendered).to have_selector("dt", text: "URL:")

--- a/spec/views/related_instructions/index_spec.rb
+++ b/spec/views/related_instructions/index_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "related_instructions/index.html.erb", type: :view do
 
     render
 
-    expect(rendered).to have_selector("h2", text: "Related Instructions")
+    expect(rendered).to have_selector("h1", text: "Related Instructions")
 
     expect(rendered).to have_columnheader("Title")
     expect(rendered).to have_columnheader("Sort Order")


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203289004376673/f

I will seek clarification on this ticket, but we do not really need to add a UI action to associate a data import with an occupation standard since that will happen when the data import is parsed. In a separate PR I will link up that parsing with the uploading of a data import. For now, this PR makes the following changes:

* Replace the h2 tags with h1 tags for better accessibility.
* Adds a "cancel" button to some of the form pages. It doesn't have exactly the same height as the Submit button, but not worrying about this for now.
* Adds an "Upload data import" button to the data_imports#index page, as there wasn't any way to get to the new upload page.
* Add a link to the data_imports#show page from the index page.
* Changed some of the verbiage on the Data Import CRUD pages to reference "data import" instead of "occupation standard" since we have separate CRUD pages for Occupation Standard.
* Added a link to the Occupation Standard from the Data Import show page. Right now this is conditional on the presence of the occupation standard, but ultimately we should always have an occupation standard linked to a data import.
* Display the Occupation Standard title instead of only the Occupation title on the occupation_standards#show page. It is possible for an occupation standard not to be linked to an occupation.

<img width="767" alt="Screen Shot 2023-02-07 at 11 56 46 AM" src="https://user-images.githubusercontent.com/1938665/217351587-c06b04c5-4bda-43f2-b9e1-577043ba3517.png">

<img width="1591" alt="Screen Shot 2023-02-07 at 11 55 14 AM" src="https://user-images.githubusercontent.com/1938665/217351343-d1e1bd7b-9bcc-40ad-8d9f-7ff1ab42543c.png">

<img width="1639" alt="Screen Shot 2023-02-07 at 11 55 21 AM" src="https://user-images.githubusercontent.com/1938665/217351333-263023e4-9fbe-40dc-901c-c9d021913f34.png">

<img width="1565" alt="Screen Shot 2023-02-07 at 11 54 35 AM" src="https://user-images.githubusercontent.com/1938665/217351353-66f07d3f-41e5-4315-8427-94ec89ed1d38.png">
<img width="881" alt="Screen Shot 2023-02-07 at 11 53 58 AM" src="https://user-images.githubusercontent.com/1938665/217351356-03c12e87-af15-499b-9118-48a0ca872b61.png">

