### PR TITLE
scrape California's public posting of new programs or updated standards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,4 +84,5 @@ group :test do
   gem "capybara_accessible_selectors", git: "https://github.com/citizensadvice/capybara_accessible_selectors", tag: "v0.10.0"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     debug (1.6.3)
       irb (>= 1.3.6)
@@ -152,6 +154,7 @@ GEM
       railties (>= 5.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.1.5)
@@ -345,6 +348,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -393,6 +400,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  webmock
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/jobs/scraper/california_job.rb
+++ b/app/jobs/scraper/california_job.rb
@@ -2,28 +2,33 @@ class Scraper::CaliforniaJob < ApplicationJob
   queue_as :default
 
   def perform
-    url_base = "https://www.dir.ca.gov/das/"
-    fetch_url = url_base + "ProgramStandards.htm"
+    protocol = "https://"
+    url_base = "www.dir.ca.gov/das/"
+    fetch_url = protocol + url_base + "ProgramStandards.htm"
+
     uri = URI.parse(fetch_url)
     response = Net::HTTP.get_response(uri)
     html = response.body
-    doc = Nokogiri::HTML(html)
 
+    doc = Nokogiri::HTML(html)
     nodeset = doc.css(".main-primary a[href]")
     file_paths = nodeset.map { |element| element["href"] }.select { |href| href.ends_with?(".pdf") }
 
     file_paths.each do |path|
-      full_path = url_base + path
-      full_path.gsub!(/\s/, "%20")
+      query = url_base + path
+      query.gsub!(/\s/, "%20")
 
       standards_import = StandardsImport.where(
-        name: full_path,
+        name: protocol + query,
         organization: fetch_url
       ).first_or_create!(
         notes: "From Scraper::CaliforniaJob"
       )
 
-      standards_import.files.attach(io: URI.open(full_path), filename: File.basename(path))
+      # protocol needs to be hardcoded to avoid Rubocop error:
+      # Security/Open: The use of `URI.open` is a serious security risk
+      # https://github.com/rubocop/rubocop/issues/6216#issuecomment-1252449855
+      standards_import.files.attach(io: URI.open("https://#{query}"), filename: File.basename(path))
     end
   end
 end

--- a/app/jobs/scraper/california_job.rb
+++ b/app/jobs/scraper/california_job.rb
@@ -7,8 +7,10 @@ class Scraper::CaliforniaJob < ApplicationJob
     uri = URI.parse(fetch_url)
     response = Net::HTTP.get_response(uri)
     html = response.body
+    doc = Nokogiri::HTML(html)
 
-    file_paths = html.scan(/="(.*\/.*.pdf)/).flatten
+    nodeset = doc.css(".main-primary a[href]")
+    file_paths = nodeset.map{|element| element["href"]}.select{|href| href.ends_with?(".pdf")}
 
     file_paths.each do |path|
       full_path = url_base + path

--- a/app/jobs/scraper/california_job.rb
+++ b/app/jobs/scraper/california_job.rb
@@ -1,4 +1,3 @@
-require 'open-uri'
 class Scraper::CaliforniaJob < ApplicationJob
   queue_as :default
 
@@ -11,18 +10,18 @@ class Scraper::CaliforniaJob < ApplicationJob
 
     file_paths = html.scan(/="(.*\/.*.pdf)/).flatten
 
-    if file_paths.any?
-      standards_import = StandardsImport.create!(
-        name: fetch_url,
-        organization: "California",
-        notes: "From scraper"
+    file_paths.each do |path|
+      full_path = url_base + path
+      full_path.gsub!(/\s/, "%20")
+
+      standards_import = StandardsImport.where(
+        name: full_path,
+        organization: fetch_url,
+      ).first_or_create!(
+        notes: "From Scraper::CaliforniaJob"
       )
 
-      file_paths.each do |path|
-        full_path = url_base + path
-        full_path.gsub!(/\s/, "%20")
-        standards_import.files.attach(io: URI.open(full_path), filename: File.basename(path))
-      end
+      standards_import.files.attach(io: URI.open(full_path), filename: File.basename(path))
     end
   end
 end

--- a/app/jobs/scraper/california_job.rb
+++ b/app/jobs/scraper/california_job.rb
@@ -3,14 +3,14 @@ class Scraper::CaliforniaJob < ApplicationJob
 
   def perform
     url_base = "https://www.dir.ca.gov/das/"
-    fetch_url =  url_base + "ProgramStandards.htm"
+    fetch_url = url_base + "ProgramStandards.htm"
     uri = URI.parse(fetch_url)
     response = Net::HTTP.get_response(uri)
     html = response.body
     doc = Nokogiri::HTML(html)
 
     nodeset = doc.css(".main-primary a[href]")
-    file_paths = nodeset.map{|element| element["href"]}.select{|href| href.ends_with?(".pdf")}
+    file_paths = nodeset.map { |element| element["href"] }.select { |href| href.ends_with?(".pdf") }
 
     file_paths.each do |path|
       full_path = url_base + path
@@ -18,7 +18,7 @@ class Scraper::CaliforniaJob < ApplicationJob
 
       standards_import = StandardsImport.where(
         name: full_path,
-        organization: fetch_url,
+        organization: fetch_url
       ).first_or_create!(
         notes: "From Scraper::CaliforniaJob"
       )

--- a/app/jobs/scraper/california_job.rb
+++ b/app/jobs/scraper/california_job.rb
@@ -1,0 +1,28 @@
+require 'open-uri'
+class Scraper::CaliforniaJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    url_base = "https://www.dir.ca.gov/das/"
+    fetch_url =  url_base + "ProgramStandards.htm"
+    uri = URI.parse(fetch_url)
+    response = Net::HTTP.get_response(uri)
+    html = response.body
+
+    file_paths = html.scan(/="(.*\/.*.pdf)/).flatten
+
+    if file_paths.any?
+      standards_import = StandardsImport.create!(
+        name: fetch_url,
+        organization: "California",
+        notes: "From scraper"
+      )
+
+      file_paths.each do |path|
+        full_path = url_base + path
+        full_path.gsub!(/\s/, "%20")
+        standards_import.files.attach(io: URI.open(full_path), filename: File.basename(path))
+      end
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,6 +73,8 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
+  config.active_job.queue_adapter = :inline
+
   config.hosts << "admin.example.localhost"
 
   config.after_initialize do

--- a/lib/tasks/scraper.rake
+++ b/lib/tasks/scraper.rake
@@ -1,0 +1,7 @@
+namespace :scraper do
+  task states: :environment do
+    if Date.current.wday.eql?(0) || ENV["FORCE"] == "true"
+      Scraper::CaliforniaJob.perform_later
+    end
+  end
+end

--- a/spec/fixtures/files/scraper/california.htm
+++ b/spec/fixtures/files/scraper/california.htm
@@ -1,0 +1,1085 @@
+<!doctype html>
+
+<!--BEGIN include /ssi/inc_1.html-->
+
+<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
+<!--[if IE 9]>    <html class="no-js ie9 oldie" lang="en"> <![endif]-->
+<!--[if (gt IE 9)]><!-->
+<html class="no-js" lang="en">
+<!-- InstanceBegin template="/Templates/2-column.dwt" codeOutsideHTMLIsLocked="false" -->
+<!--<![endif]-->
+
+
+<!--END include /ssi/inc_1.html-->
+
+<head>
+	<meta charset="utf-8">
+
+
+	<!-- **************************************************************** -->
+	<!-- Begin Document Title - Customize to fit your needs -->
+
+	<title>The Division of Apprenticeship Standards (DAS) Resources for Program Sponsors</title>
+
+	<!-- End Document Title -->
+
+
+
+
+	<!-- Begin Meta Information - Customize to fit your needs -->
+
+	<meta name="Author" content="Division of Apprenticeship Standards" />
+	<meta name="Description" content="DAS administers California apprenticeship law and enforces apprenticeship standards for wages, hours,
+working conditions and the specific skills required for state certification as a journeyperson in an apprenticeable occupation.
+DAS promotes apprenticeship training, consults with program sponsors, and monitors programs to ensure high standards for
+on-the-job training and supplemental classroom instruction." />
+	<meta name="Keywords" content="Apprentice, apprenticeship, Apprenticeship Standards, DAS, Status of AB931 - Proposed Regulations,
+Electrician's Certification Program, Subject Matter Experts (SME's),
+Proposed Regulations for Electrician Certification, Labor Code sections 3099-3099.5 (AB 931)" />
+	<!-- End Meta Information -->
+
+
+	<!--BEGIN include /ssi/inc_2_css_js.html-->
+
+	<!-- head content, for all pages -->
+	<!-- Use highest compatibility mode -->
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+	<!-- http://t.co/dKP3o1e -->
+	<meta name="HandheldFriendly" content="True">
+	<!-- for Blackberry, AvantGo -->
+	<meta name="MobileOptimized" content="320">
+
+
+	<!-- for Windows mobile -->
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+
+	<!-- Not in 5.6.2 -->
+	<!-- Google Fonts -->
+	<!-- <link href="https://fonts.googleapis.com/css?family=Asap+Condensed:400,600|Source+Sans+Pro:400,700" rel="stylesheet"> -->
+	<link href="https://fonts.googleapis.com/css?family=Asap+Condensed:400,600|Source+Sans+Pro:400,600,700"
+		rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
+
+	<!-- For all browsers -->
+	<link rel="stylesheet" href="/css/cagov.core.css">
+
+	<!-- Not in 5.6.2 -->
+	<script src="/js/search.js"></script>
+	<!--
+Step 3
+Select a color scheme:
+
+<link rel="stylesheet" href="/css/colorscheme-eureka.css">
+<link rel="stylesheet" href="/css/colorscheme-mono.css">
+<link rel="stylesheet" href="/css/colorscheme-oceanside.css">
+<link rel="stylesheet" href="/css/colorscheme-orangecounty.css">
+<link rel="stylesheet" href="/css/colorscheme-pasorobles.css">
+<link rel="stylesheet" href="/css/colorscheme-santabarbara.css">
+<link rel="stylesheet" href="/css/colorscheme-sacramento.css">
+<link rel="stylesheet" href="/css/colorscheme-sierra.css">
+<link rel="stylesheet" href="/css/colorscheme-trinity.css">
+-->
+
+	<link rel="stylesheet" href="/css/colorscheme-oceanside.css">
+	<!-- Custom CSS -->
+	<link rel="stylesheet" type="text/css" href="/css/custom.css">
+	<link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
+
+
+	<!-- BEGIN Load jQuery from CDN with fallback to local copy -->
+	<script src="https://code.jquery.com/jquery-3.6.1.min.js"
+		integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+	<script>
+		//Fall back to local copy if no jquery found
+    if (typeof jQuery == 'undefined') {
+        document.write(unescape("%3Cscript src='/js/libs/jquery.js' type='text/javascript'%3E%3C/script%3E"));
+    }
+	</script>
+	<!-- END Load jQuery migrate from CDN with fallback to local copy -->
+
+	<!-- CHATBOT Script -->
+	<script type="text/javascript" src="https://lwda-prod.ochat.osaas.app/embed/DIR-1655436669699"></script>
+
+	<!-- DIR Customs Scripts -->
+	<script type="text/javascript" src="/javascript/custom_scripts.js"></script>
+
+
+	<!-- apple touch icons -->
+	<link rel="apple-touch-icon-precomposed" sizes="100x100" href="/images/apple-touch-icon-precomposed.png">
+	<link rel="icon" sizes="192x192" href="/images/apple-touch-icon-192x192.png">
+	<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/images/apple-touch-icon-180x180.png">
+	<link rel="apple-touch-icon-precomposed" sizes="152x152" href="/images/apple-touch-icon-152x152.png">
+	<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/images/apple-touch-icon-144x144.png">
+	<link rel="apple-touch-icon-precomposed" sizes="120x120" href="/images/apple-touch-icon-120x120.png">
+	<link rel="apple-touch-icon-precomposed" sizes="114x114" href="/images/apple-touch-icon-114x114.png">
+	<link rel="apple-touch-icon-precomposed" sizes="72x72" href="/images/apple-touch-icon-72x72.png">
+	<link rel="apple-touch-icon-precomposed" href="/images/apple-touch-icon-57x57.png">
+	<link rel="shortcut icon" href="/images/apple-touch-icon-57x57.png">
+	<link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
+	<!-- For everything else -->
+	<link rel="shortcut icon" href="/favicon.ico">
+
+
+	<!-- Include Google Analytics -->
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<!-- Universal Analytics -->
+
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-3419582-30"></script>
+
+	<script>
+		window.dataLayer = window.dataLayer || [];
+ function gtag() { dataLayer.push(arguments); }
+ gtag('js', new Date());
+
+    gtag('config', 'UA-3419582-2');  //statewide GA property
+    gtag('config', 'UA-3419582-30');  //please update state department UA code in line below before deployment
+    gtag('config', 'UA-5092920-1');  //un-comment line and update UA code to add a third GA property
+
+
+ var getOutboundLink = function (url) {
+  gtag('event', 'click', {
+   'event_category': 'navigation',
+   'event_label': 'outbound link: ' + url,
+   'transport_type': 'beacon',
+   'event_callback': function () { document.location = url; }
+  });
+ }
+
+ var trackDownload = function (filename) {
+  gtag('event', 'click', {
+   'event_category': 'download',
+   'event_label': 'file: ' + filename,
+   'transport_type': 'beacon',
+   'event_callback': function () { document.location = url; }
+  });
+ }
+	</script>
+
+
+
+	<!-- Google Analytics 4 -->
+
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-75V2BNQ3DR"></script>
+
+	<script>
+		window.dataLayer = window.dataLayer || [];
+ function gtag() { dataLayer.push(arguments); }
+ gtag('js', new Date());
+ gtag('config', 'G-69TD0KNT0F'); // statewide GA4 Property ID
+ gtag('config', 'G-9C30LB4KFJ'); // update individual agency GA4 Property ID code before deployment
+	</script>
+
+
+	<!--END include /ssi/inc_2_css_js.html-->
+</head>
+
+<body class="two-column">
+	<!--BEGIN include /ssi/inc_3_header.html-->
+
+	<header role="banner" id="header" class="global-header">
+		<div id="skip-to-content"><a href="#main-content">Skip to Main Content</a></div>
+
+		<div class="utility-header">
+			<div class="container">
+				<div class="group flex-row">
+					<div class="social-media-links">
+						<div class="header-cagov-logo"><a
+								href="https://ca.gov"><span class="sr-only">CA.gov</span><img src="/images/Ca-Gov-Logo-Gold.svg" class="pos-rel" alt="ca.gov website logo" aria-hidden="true" /></a>
+						</div>
+						<a href="/" class="ca-gov-icon-home"><span class="sr-only">Home</span></a>
+					</div>
+
+					<div class="settings-links">
+						<a href="/mediaroom.html" style="padding-top:3px;">Press room</a></li>
+						<span class="careers"><a href="/dirjobs/dirjobs.htm">Careers at DIR</a></span>
+						<span class="hide-phone-portrait-down"><a href="/Multilingual/Spanish/index.html">&Iacute;ndice en espa&ntilde;ol</a></span>
+						<button class="btn btn-xs btn-primary" data-bs-toggle="collapse" data-bs-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings">
+                    <span class="ca-gov-icon-gear" aria-hidden="true"></span> Settings
+                </button>
+					</div>
+
+					<!--
+            <div class="settings-links">
+                <a href="/mediaroom.html">Press room</a></li>
+                <span class="careers"><a href="/dirjobs/dirjobs.htm">Careers at DIR</a></span>
+                <span class="hide-phone-portrait-down"><a href="/Multilingual/Spanish/index.html">Índice en español</a></span>
+                <button class="btn btn-xs btn-primary" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings"><span class="ca-gov-icon-gear" aria-hidden="true"></span> Settings</button>
+            </div>
+-->
+				</div>
+			</div>
+		</div>
+
+
+		<div class="site-settings section section-standout collapse collapsed" id="siteSettings">
+			<div class="container p-y">
+
+
+				<div class="btn-group btn-group-justified-sm" aria-label="contrastMode">
+					<div class="btn-group"><button type="button"
+                    class="btn btn-standout disableHighContrastMode">Default</button></div>
+					<div class="btn-group"><button type="button" class="btn btn-standout enableHighContrastMode">High
+                    Contrast</button></div>
+				</div>
+
+				<div class="btn-group" aria-label="textSizeMode">
+					<div class="btn-group"><button type="button" class="btn btn-standout resetTextSize">Reset</button>
+					</div>
+					<div class="btn-group"><button type="button" class="btn btn-standout increaseTextSize"><span
+                        class="hidden-xs">Increase Font Size</span><span class="visible-xs">Font <span
+                            class="sr-only">Increase</span><span class="ca-gov-icon-plus-line small"
+                            aria-hidden="true"></span></span></button></div>
+					<div class="btn-group"><button type="button" class="btn btn-standout decreaseTextSize"><span
+                        class="hidden-xs">Decrease Font Size</span><span class="visible-xs">Font <span
+                            class="sr-only">Decrease</span><span class="ca-gov-icon-minus-line small"
+                            aria-hidden="true"></span></span></button></div>
+					<div class="btn-group">
+						<button type="button" class="btn btn-standout dyslexicFont">Dyslexic Font</button>
+					</div>
+				</div>
+				<button type="button" class="close" data-bs-toggle="collapse" data-bs-target="#siteSettings"
+            aria-label="Close"><span aria-hidden="true" class=" ca-gov-icon-close-mark"></span></button>
+			</div>
+		</div>
+		<!-- header branding -->
+		<div class="branding">
+			<div class="header-organization-banner">
+				<a href="/">
+					<div class="logo-assets">
+						<img src="/images/template-logo.png" class="logo-img" alt="State of California Department of Industrial Relations" />
+						<div class="logo-text">
+						</div>
+					</div>
+				</a>
+			</div>
+		</div>
+		<!-- mobile navigation controls -->
+		<div class="mobile-controls">
+			<span class="mobile-control-group mobile-header-icons">
+        <!-- Add more mobile controls here. These will be on the right side of the mobile page header section -->
+    </span>
+			<div class="mobile-control-group main-nav-icons">
+				<button class="mobile-control toggle-search">
+            <span class="ca-gov-icon-search hidden-print" aria-hidden="true"></span><span class="sr-only">Search</span>
+        </button>
+				<button id="nav-icon3" class="mobile-control toggle-menu" aria-expanded="false" aria-controls="navigation"
+            data-bs-toggle="collapse" data-bs-target="#navigation">
+            <span></span>
+            <span></span>
+            <span></span>
+            <span></span>
+            <span class="sr-only">Menu</span>
+        </button>
+
+			</div>
+		</div>
+
+		<div class="navigation-search">
+
+			<!-- Step 2 Select Navigation Type: Options are: megadropdown dropdown singlelevel -->
+
+			<nav id="navigation" class="main-navigation dropdown auto-highlight nav-full-width-icons">
+				<ul id="nav_list" class="top-level-nav">
+
+
+					<li class="nav-item">
+						<a href="/dlse/" class="first-level-link"><span class="ca-gov-icon-gears"></span><br class="show-large-up" />Labor
+							<br class="hide-1280-up hide-small-and-medium" />Law</a>
+							<div class="sub-nav">
+
+								<ul class="second-level-nav">
+									<li class="unit1">
+										<a href="/dlse/"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Labor
+											Commissioner's Office</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/Judgment-Enforcement-Unit.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Judgment
+											Enforcement Unit</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/dlseWagesAndHours.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Wages</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/DistrictOffices.htm" class="second-level-link"
+											aria-label="District Offices for DLSE"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Offices</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/dlse-bofe.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>BOFE</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/DLSE-CL.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Minors</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/outreach.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Outreach</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/Manual-Instructions.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Policy</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/DLSE-Databases.htm" class="second-level-link"
+											aria-label="Labor Law Databases"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Databases</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/DLSE_OpinionLetters.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Opinions</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/dlseRetaliation.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Retaliation</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/Training.htm" class="second-level-link"
+											aria-label="DLSE Training"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Training</a>
+									</li>
+									<li class="unit1">
+										<a href="/wpnodb.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Postings</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/Registration_Services.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Registration
+											Services</a>
+									</li>
+									<li class="unit1">
+										<a href="/Public-Works/PublicWorks.html" class="second-level-link"
+											aria-label="Public Works home page"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Public
+											Works</a>
+									</li>
+									<li class="unit1">
+										<a href="/dlse/ECU/ElectricalTrade.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Electrician
+											Certification</a>
+									</li>
+								</ul>
+							</div>
+					</li>
+					<li class="nav-item">
+						<a href="/dosh/" class="first-level-link"><span class="ca-gov-icon-gears"></span>Cal/OSHA -
+							<br class="hide-small-and-medium" />Safety &amp; Health</a>
+							<div class="sub-nav">
+
+								<ul class="second-level-nav">
+									<li class="unit1">
+										<a href="/dosh/"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Cal/OSHA
+											Home</a>
+									</li>
+									<li class="unit1">
+										<a href="/dosh/consultation.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Consultation</a>
+									</li>
+									<li class="unit1">
+										<a href="/dosh/Enforcementpage.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Enforcement</a>
+									</li>
+									<li class="unit1">
+										<a href="/dosh/HeatIllnessInfo.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Heat
+											Illness Prevention</a>
+									</li>
+									<li class="unit1">
+										<a href="/dosh/puborder.asp#IIPP"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Injury
+											&amp; Illness Prevention Program</a>
+									</li>
+									<li class="unit1">
+										<a href="/dosh/cal_vpp/vpp_index.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Partnership
+											Programs</a>
+									</li>
+									<li class="unit1">
+										<a href="/dosh/Payment_options.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Payment
+											Options</a>
+									</li>
+									<li class="unit1">
+										<a href="/permits-licenses-certifications.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Permits,
+											Registrations, Certifications, &amp; Licenses</a>
+									</li>
+									<li class="unit1">
+										<a href="/dosh/PublicSafety.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Public
+											Safety</a>
+									</li>
+									<li class="unit1">
+										<a href="/dosh/Required-Notifications.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Required
+											Notifications</a>
+									</li>
+									<li class="unit1">
+										<a href="/dosh/Worker-Health-and-Safety-in-Wildfire-Regions.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Worker
+											Safety &amp; Health in Wildfire Regions</a>
+									</li>
+									<li class="unit1">
+										<a href="/wpnodb.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Workplace
+											Postings</a>
+									</li>
+								</ul>
+							</div>
+					</li>
+					<li class="nav-item">
+						<a href="/dwc/" class="first-level-link"><span class="ca-gov-icon-gears"></span><br class="show-large-up" />Workers'
+							<br class="hide-1280-up hide-small-and-medium" />Comp</a>
+							<div class="sub-nav">
+
+								<ul class="second-level-nav">
+									<li class="unit1">
+										<a href="/dwc/"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Workers'
+											Comp Home</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/a_z_index.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>A
+											- Z Index</a>
+									</li>
+									<li class="unit1">
+										<a href="https://www.dir.ca.gov/DWC/CourtCalendar/CourtCal.asp"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Court
+											calendar</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/DEU.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Disability
+											Evaluation Unit</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/dir2.htm" class="second-level-link"
+											aria-label="District Offices for Division of Workers' Compensation"><span class="ca-gov-icon-gears" aria-hidden="true"></span>District
+											Offices</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/eams/eams.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Electronic
+											Adjudication Management System</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/employer.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Employer
+											Information</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/IMR.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Independent
+											Medical Review</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/IandA.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Information
+											and Assistance Unit</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/injuredworker.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Injured
+											Worker</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/MedicalUnit/imchp.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Medical
+											Unit</a>
+									</li>
+									<li class="unit1">
+										<a href="/RTWSP/RTWSP.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>The
+											Return-to-Work Supplement Program</a>
+									</li>
+									<li class="unit1">
+										<a href="/dwc/claims.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>UEBTF
+											&amp; SIBTF</a>
+									</li>
+								</ul>
+							</div>
+					</li>
+
+					<li class="nav-item">
+						<a href="/osip/" class="first-level-link"><span class="ca-gov-icon-gears"></span><br class="show-large-up" />Self
+							<br class="hide-1280-up hide-small-and-medium" />Insurance</a>
+							<div class="sub-nav">
+
+								<ul class="second-level-nav">
+									<li class="unit1">
+										<a href="/osip/" class="second-level-link"
+											aria-label="About Self Insurance"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Self
+											Insurance Home</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/AppRequirements.htm" class="second-level-link"
+											aria-label="About Self Insurance"><span class="ca-gov-icon-gears" aria-hidden="true"></span>About</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/SelfInsuredEmployers.htm" class="second-level-link"
+											aria-label="Self-insurance information for Employers."><span class="ca-gov-icon-gears" aria-hidden="true"></span>Employers</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/SI-groups/index.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Groups</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/examination.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Third
+											Party Administrators</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/PublicEntitiesAndJPA.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Joint
+											Power Authorities</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/pubandforms.htm" class="second-level-link"
+											aria-label="Forms related to Self-Insurance"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Forms</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/lawsandregs.htm" class="second-level-link"
+											aria-label="Regulations related to OSIP"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Regulations</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/OSIP-AuditUnit.html" class="second-level-link"
+											aria-label="Self Insurance Audit Unit"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Audits</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/generalinfo.htm" class="second-level-link"
+											aria-label="Contact Office of Self Insurance"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Contact</a>
+									</li>
+								</ul>
+							</div>
+					</li>
+
+
+					<li class="nav-item">
+						<a href="/das/"
+							class="first-level-link"><span class="ca-gov-icon-gears"></span><br class="hide-small-and-medium" />Apprenticeship</a>
+							<div class="sub-nav">
+
+								<ul class="second-level-nav">
+									<li class="unit1">
+										<a href="/das/"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Apprenticeship
+											Home</a>
+									</li>
+									<li class="unit1">
+										<a href="/databases/das/aigstart.asp"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Apprenticeship
+											Search</a>
+									</li>
+									<li class="unit1">
+										<a href="/das/publicworks.html" class="second-level-link"
+											aria-label="Public Works apprenticeship requirements"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Public
+											Works</a>
+									</li>
+									<li class="unit1">
+										<a href="/das/ProgramSponsor.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Sponsors</a>
+									</li>
+									<li class="unit1">
+										<a href="/databases/das/descOfAppr.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Overview</a>
+									</li>
+									<li class="unit1">
+										<a href="/das/educators.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Educators</a>
+									</li>
+									<li class="unit1">
+										<a href="/das/employers.htm" class="second-level-link"
+											aria-label="Apprenticeship information for employers"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Employers</a>
+									</li>
+									<li class="unit1">
+										<a href="/das/veterans.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Veterans</a>
+									</li>
+								</ul>
+							</div>
+					</li>
+					<li class="nav-item">
+						<a href="/directors_office.html"
+							class="first-level-link"><span class="ca-gov-icon-gears"></span><br class="show-large-up" />Director's
+							<br class="hide-1280-up hide-small-and-medium" />Office</a>
+							<div class="sub-nav">
+
+								<ul class="second-level-nav">
+									<li class="unit1">
+										<a href="/directors_office.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Director's
+											Office Home</a>
+									</li>
+									<li class="unit1">
+										<a href="/OLA/default.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Office
+											of Legislative and Regulatory Affairs</a>
+									</li>
+									<li class="unit1">
+										<a href="/OPRL/Statistics_Research.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Office
+											of the Director - Research</a>
+									</li>
+									<li class="unit1">
+										<a href="/Division/Decisions-and-Determinations.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Office
+											of the Director - Decisions and Determinations</a>
+									</li>
+									<li class="unit1">
+										<a href="/mediaroom.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Press
+											Room</a>
+									</li>
+									<li class="unit1">
+										<a href="/Public-Works/PublicWorks.html" class="second-level-link"
+											aria-label="Public Works home page"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Public
+											Works</a>
+									</li>
+									<li class="unit1">
+										<a href="/osip/sip.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Self
+											Insurance Plans</a>
+									</li>
+									<li class="unit1">
+										<a href="/LETF/LETF.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Labor
+											Enforcement</a>
+									</li>
+									<li class="unit1">
+										<a href="/aboutdir.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>About
+											DIR</a>
+									</li>
+								</ul>
+							</div>
+					</li>
+					<li class="nav-item">
+						<a href="/BoardsAndCommissions.html"
+							class="first-level-link"><span class="ca-gov-icon-gears"></span><br class="hide-small-and-medium" />Boards</a>
+							<div class="sub-nav">
+
+								<ul class="second-level-nav">
+									<li class="unit1">
+										<a href="/BoardsAndCommissions.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Boards
+											and Commissions Home</a>
+									</li>
+									<li class="unit1">
+										<a href="/chswc/chswc.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Commission
+											on Health and Safety and Workers' Compensation (CHSWC)</a>
+									</li>
+									<li class="unit1">
+										<a href="/oshsb/oshsb.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Occupational
+											Safety &amp; Health
+											<span style="font-weight:bold;opacity:.7;">Standards Board</span>
+											(OSHSB)</a>
+									</li>
+									<li class="unit1">
+										<a href="/oshab/oshab.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Occupational
+											Safety &amp; Health
+											<span style="font-weight:bold;opacity:.7;">Appeals Board</span> (OSHAB)</a>
+									</li>
+									<li class="unit1">
+										<a href="/wcab/wcab.htm"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Workers'
+											Compensation
+											<span style="font-weight:bold;opacity:.7;">Appeals&nbsp;Board</span>
+											(WCAB)</a>
+									</li>
+									<li class="unit1">
+										<a href="/iwc/iwc.html"
+											class="second-level-link"><span class="ca-gov-icon-gears" aria-hidden="true"></span>Industrial
+											Welfare Commission (IWC)</a>
+									</li>
+								</ul>
+							</div>
+					</li>
+					<li class="nav-item" id="nav-item-search">
+						<button class="first-level-link"><span class="ca-gov-icon-search" aria-hidden="true"></span>Search</button>
+					</li>
+
+				</ul>
+			</nav>
+
+			<div id="head-search" class="search-container">
+
+				<!-- Google Custom Search - /ssi/search.html-->
+				<!--Uncomment if you prefer to use original google search box.
+    (be advided that original custom search box is not meeting WCAG accessibility standards)-->
+				<!--<script type="text/javascript">
+    var cx = '001779225245372747843:9s-idxui5pk';// Step 7: Update this value with your search engine unique ID. Submit a request to the CDT Service Desk if you don't already know your unique search engine ID.
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script');
+    s[s.length - 1].parentNode.insertBefore(gcse, s[s.length - 1]);
+</script>
+<gcse:searchbox-only resultsUrl="/serp.html" enableAutoComplete="true"></gcse:searchbox-only>-->
+				<!--Custom Google Search ID Script can be found inside of serp.html file -->
+				<div class="container">
+					<form id="Search" class="pos-rel" action="/serp.html">
+						<span class="sr-only" id="SearchInput">Custom Google Search</span>
+						<input type="text" id="q" name="q" aria-labelledby="SearchInput" placeholder="Search this website" class="height-50 border-0 p-x-sm w-100 search-textfield" />
+						<button type="submit" class="pos-abs gsc-search-button top-0 width-50 height-50 border-0 bg-transparent"><span class="ca-gov-icon-search font-size-30 color-gray" aria-hidden="true"></span><span class="sr-only">Submit</span></button>
+						<div class="width-50 height-50 close-search-btn">
+							<button class="close-search gsc-clear-button width-50 height-50 border-0 bg-transparent pos-rel" type="reset"><span class="sr-only">Close Search</span><span class="ca-gov-icon-close-mark" aria-hidden="true"></span></button>
+						</div>
+					</form>
+				</div>
+
+			</div>
+
+		</div><!-- .navigation-search -->
+
+		<div class="header-decoration"></div>
+	</header>
+
+	<!--END include /ssi/inc_3_header.html-->
+
+	<!--BEGIN include /ssi/inc_4_begin_main_content.html-->
+
+	<div id="main-content" class="main-content" role="main">
+		<div class="section">
+			<main class="main-primary">
+
+				<!--END include /ssi/inc_4_begin_main_content.html-->
+
+				<!-- BEGIN include /ssi/das/inc_5_das_breadcrumbs.html -->
+
+				<ol class="breadcrumb">
+					<li><a href="/das/das.html">Apprenticeship Standards</a></li>
+				</ol>
+
+				<!-- END include /ssi/das/inc_5_das_breadcrumbs.html -->
+
+
+
+
+
+				<input id="altBreadcrumbTitle" type="hidden" value="DAS Program Sponsors and Contractors" />
+
+
+				<h2><a href="email/DAS.asp">Subscribe to email notification</a></h2>
+
+				<!-- body of document follows and is required. -->
+				<p>As required by Labor Code section 3075, the Division posts on this web-page copies of proposed new
+					apprenticeship standards (including proposed amendments to apprenticeship standards to include new
+					work processes or occupations). Interested parties may subscribe to email notification of new
+					postings on this page by using the button at the top of the page. </p>
+
+				<h1>Proposed New and Revised Program Standards </h1>
+				<p><em>Comments can be sent to:</em> <a
+						href="mailto:DASStandardList@dir.ca.gov">DASStandardList@dir.ca.gov</a>.</p>
+
+
+				<h2><a href="standards/Hartnell_College.pdf">Hartnell College Early Childhood Education Apprenticeship
+						Training Program </a></h2>
+				<p>Posted February 2, 2023</p>
+				<blockquote>
+					<p>Preschool Teacher<br />
+       Infant/Toddler Teacher
+</p>
+				</blockquote>
+
+				<h2><a href="standards/100054_HTA_Standards.pdf">Hospitality Training Academy JATC</a></h2>
+				<p>Posted January 19, 2023</p>
+				<blockquote>
+					<p>Bartender/Mixologist<br />
+Barista/Latte Artist/Cook
+</p>
+				</blockquote>
+
+
+				<h2><a href="standards/101034_Onramp_Standards.pdf">Onramp</a></h2>
+				<p>Posted January 19, 2023</p>
+				<blockquote>
+					<p>Software Engineer</p>
+				</blockquote>
+
+				<h2><a href="standards/101017_ClearDigitalLabs_Standards.pdf">Clear Digital Labs</a></h2>
+				<p>Posted January 18, 2023</p>
+				<blockquote>
+					<p>Marketing Coordinator <br />
+Digital Marketer
+
+</p>
+				</blockquote>
+
+				<h2><a href="standards/100859_SETA ECE_Standards.pdf">Sacramento Employment and Training Agency (SETA)
+						Early Childhood Education Apprenticeship Program</a></h2>
+				<p>Posted January 11, 2023</p>
+				<blockquote>
+					<p>Associate Teacher
+
+					</p>
+				</blockquote>
+
+				<h2><a href="standards/101015_SB ECE_Standards.pdf">Santa Barbara County Education Office (SBCEO) Early
+						Childhood Educator Apprenticeship Program</a></h2>
+				<p>Posted January 11, 2023</p>
+				<blockquote>
+					<p>Associate Teacher<br />
+Teacher<br />
+Master Teacher<br />
+Site Supervisor
+
+</p>
+				</blockquote>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<p class="page_datestamp">February 2023</p>
+
+			</main>
+			<!-- BEGIN include /ssi/das/inc_6_das_second_column_content.html" -->
+
+			<div class="main-secondary" role="navigation" aria-label="Common links for Apprenticeship">
+				<!--#DONTinclude virtual="/sample/modules/profile-banners.html" -->
+				<!--#DONTinclude virtual="/sample/modules/panels-sidebar.html" -->
+
+				<!-- BEGIN include /ssi/das/inc_das_sidebar_links.html" -->
+
+
+				<div class="panel-heading sidebar-title">
+					<h2>Division of Apprenticeship Standards</h2>
+				</div>
+
+				<div class="panel panel-default das-sidebar">
+					<div class="panel-heading emphasize">
+						<h3>Funding</h3>
+					</div>
+					<div class="panel-body emphasize">
+						<ul class="spaced">
+							<li><a href="/DAS/Grants/ERICA.html">Equal Representation in Construction Apprenticeship
+									Grant</a></li>
+							<li><a href="/DAS/Grants/Apprenticeship-Innovation-Funding.html">Apprenticeship Innovation
+									Funding</a></li>
+							<li><a href="/DAS/Grants/Grants.html">State Apprenticeship Expansion, Equity and Innovation
+									Grant</a></li>
+
+						</ul>
+					</div>
+
+					<div class="panel-heading">
+						<h3>Quick Links</h3>
+					</div>
+					<div class="panel-body">
+						<ul>
+
+							<li><a href="/databases/das/descOfAppr.html">How to become an apprentice</a></li>
+							<li><a href="/DAS/Employers.htm">How to set up an apprenticeship program</a></li>
+							<li><a href="/das/Events.html">Events</a></li>
+							<li><a href="/das/Laws_Regulations.htm">DAS Laws and Regulations</a></li>
+							<li><a href="/CAC/Laws_Regulations.htm">CAC Laws and Regulations</a></li>
+							<li><a href="/DAS/ProgramSponsor.htm">Program Sponsors</a></li>
+							<li><a href="/das/ProgramStandards.htm">Program Standards</a></li>
+							<li><a href="/das/DAS-e-News.html">Apprenticeship e-Newsletter</a></li>
+							<li><a href="/das/forms.html">Publications, reports, and forms</a></li>
+							<li><a href="/das/preapprenticeship.htm">Preapprenticeship</a></li>
+							<li><a href="/das/das_data.html">Apprenticeship Data</a></li>
+						</ul>
+					</div>
+					<div class="panel-heading">
+						<h3>Public Works and Apprenticeship</h3>
+					</div>
+					<div class="panel-body">
+						<ul>
+							<li><a href="/databases/das/aigstart.asp">Find an apprenticeship program</a></li>
+							<li><a href="/das/appcertpw/AppCertSearch.asp">Find a registered apprentice</a></li>
+							<li><a href="/oprl/pwappwage/PWAppWageStart.asp">Find apprenticeship wages</a></li>
+							<li><a href="/das/publicworks.html">Public Works Apprenticeship Requirements</a></li>
+						</ul>
+					</div>
+					<div class="panel-heading">
+						<h3>About DAS</h3>
+					</div>
+					<div class="panel-body">
+						<ul>
+							<li><a href="/das/DAS_overview.html">About Us (Overview of DAS)</a></li>
+							<li><a href="/das/das_contactUS.html">Contact DAS</a></li>
+							<li>Join us for our next meeting </li>
+							<li><a aria-label="CAC Meetings" href="/das/DAS_CACMeetings.html">California Apprenticeship
+									Council</a></li>
+							<li><a href="/das/DAS_IACAMeetings.html" aria-label="DAS IACA Meetings">Interagency Advisory
+									Committee on Apprenticeship</a></li>
+							<li><a href="/das/DAS_CYACMeetings.html"
+									aria-label="California Youth Apprenticeship Committee">California Youth
+									Apprenticeship Committee</a></li>
+						</ul>
+						<div class="cleaner"></div>
+					</div>
+				</div> <!-- .panel.panel-default -->
+
+				<div class="lower_right_side center">
+
+					<p style="text-align:center">Subscribe to our e-Newsletter<br />
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="/das/das-e-news_subscribe.html" class="button b-5"
+							aria-label="Apprenticeship e-Newsletter mail">Apprenticeship e-Newsletter</a>
+
+				</div>
+
+
+
+
+
+				<!-- END include /ssi/das/inc_das_sidebar_links.html" -->
+
+
+
+			</div>
+
+			<!-- BEGIN include /ssi/das/inc_6_das_second_column_content.html" -->
+
+
+		</div><!-- .section -->
+	</div><!-- .main-content -->
+
+	<!--BEGIN include /ssi/global-footer.html-->
+
+	<footer id="footer" class="global-footer">
+
+		<div class="section" style="background-color:#444;">
+			<div class="container">
+				<div class="upper_footer">
+					<div class="row">
+						<div class="col-md-4 footer_links">
+							<h2>About DIR</h2>
+							<ul>
+								<li><a href="/aboutdir.html">Who we are</a></li>
+								<li><a href="/divisions_and_programs.html">DIR Divisions, Boards &amp; Commissions</a>
+								</li>
+								<li><a href="/Tribal-Consultation.html">Tribal Consultation</a>
+								<li><a href="/Contactus.html">Contact DIR</a></li>
+							</ul>
+						</div><!-- .footer_links -->
+
+						<div class="col-md-4 footer_links">
+							<h2>Work with Us</h2>
+							<ul>
+								<li><a href="/dirjobs/dirjobs.htm">Career Opportunities</a></li>
+								<li><a href="/permits-licenses-certifications.html">Licensing, registrations,
+										certifications &amp; permits</a></li>
+								<li><a href="/dosh/Required-Notifications.html">Required Notifications</a></li>
+								<li><a href="/pra_request.html">Public Records Requests</a></li>
+							</ul>
+						</div><!-- .footer_links -->
+
+						<div class="col-md-4 footer_links">
+							<h2>Learn More</h2>
+							<ul>
+								<li><a href="/Bilingual-Services-Act/default.html">Acceso al idioma</a></li>
+								<li><a href="/faqslist.html"
+										aria-label="Index of frequently asked questions at DIR">Frequently Asked
+										Questions</a></li>
+								<li><a href="/federal-funding-disclosure.html">Federal Funding Disclosure</a></li>
+								<li><a href="/sitemap/sitemap.html" aria-label="Site map for the DIR website">Site
+										Map</a></li>
+							</ul>
+
+						</div><!-- .footer_links -->
+
+						<div class="clear_left"></div>
+
+					</div><!-- upper_footer -->
+
+				</div><!-- .container -->
+			</div><!-- .section -->
+
+			<div class="container lower_footer"
+				style="max-width:100%;font-size:93%;padding-top:15px;padding-bottom:15px;background:#292929;">
+
+				<a href="/RaI/ReportAnIssue.aspx" class="btn btn-app footer-issue-button">Report a website issue</a>
+
+				<div class="row">
+					<div class="three-quarters center" style="padding-top:4px;width:80%;margin-left:10%;">
+						<ul class="footer-links">
+							<li><a href="#skip-to-content">Back to Top</a></li>
+							<li><a href="/od_pub/conditions.html">Conditions of Use</a></li>
+							<li><a href="/od_pub/disclaimer.html"
+									aria-label="Disclaimer for DIR website.">Disclaimer</a></li>
+							<li><a href="/od_pub/privacy.html">Privacy Policy</a></li>
+							<li><a href="/Nondiscrimination-Notice.html">Nondiscrimination Notice</a></li>
+							<li><a href="/accessibility.html">Accessibility</a></li>
+							<li><a href="/od_pub/help.html">Site Help</a></li>
+							<li><a href="/ContactUs.html">Contact DIR</a></li>
+						</ul>
+					</div>
+					<div class="quarter text-right" style="width:10%;">
+						<ul class="socialsharer-container" style="padding-top:6px;">
+							<li><a
+									href="https://www.facebook.com/CaliforniaDIR"><span class="ca-gov-icon-share-facebook" aria-hidden="true"></span><span class="sr-only">Flickr</span></a>
+							</li>
+							<li><a
+									href="https://twitter.com/#!/CA_DIR"><span class="ca-gov-icon-twitter" aria-hidden="true"></span><span class="sr-only">Twitter</span></a>
+							</li>
+							<li><a
+									href="http://www.youtube.com/CaliforniaDIR"><span class="ca-gov-icon-youtube" aria-hidden="true"></span><span class="sr-only">YouTube</span></a>
+							</li>
+						</ul>
+					</div>
+				</div><!-- .row -->
+
+			</div><!-- .container -->
+
+			<!-- Copyright Statement -->
+			<div class="copyright">
+				<div class="container">
+					Copyright &copy; <script>
+						document.write(new Date().getFullYear())
+					</script> State of California
+				</div><!-- .container -->
+			</div><!-- .copyright -->
+	</footer>
+
+	<!-- Extra Decorative Content -->
+	<div class="decoration-last">&nbsp;</div>
+
+	<!--END include /ssi/global-footer.html-->
+
+	<script src="/js/cagov.core.js"></script>
+
+	<!-- **** BEGIN Monsido Script: Uncomment for Live Site Only ****
+
+<script type="text/javascript">
+    window._monsido = window._monsido || {
+        token: "ST8Y26wCUUJcKPXjqC1_rg",
+        statistics: {
+            enabled: true,
+            documentTracking: {
+                enabled: true,
+                documentCls: "monsido_download",
+                documentIgnoreCls: "monsido_ignore_download",
+                documentExt: ["pdf","doc","docx","xls","xlsx"],
+            },
+        },
+    };
+</script>
+<script type="text/javascript" async src="https://app-script.monsido.com/v2/monsido-script.js"></script>
+
+<!-- **** END Monsido Script: Uncomment for Live Site Only **** -->
+</body>
+
+</html>

--- a/spec/jobs/scraper/california_job_spec.rb
+++ b/spec/jobs/scraper/california_job_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Scraper::CaliforniaJob, type: :job do
   describe "#perform" do
     it "downloads pdf files to an standards import record" do
+      stub_responses
       expect {
         described_class.new.perform
       }.to change(StandardsImport, :count).by(1)
@@ -10,5 +11,15 @@ RSpec.describe Scraper::CaliforniaJob, type: :job do
       standard_import = StandardsImport.last
       expect(standard_import.files.count).to be > 0
     end
+  end
+
+  def stub_responses
+    html_file = file_fixture("scraper/california.htm")
+    stub_request(:get, /dir.ca.gov.*\.htm/).
+      to_return(status: 200, body: html_file.read, headers: {})
+
+    pdf_file = file_fixture("pixel1x1.pdf")
+    stub_request(:get, /dir.ca.gov.*\.pdf/).
+      to_return(status: 200, body: pdf_file.read, headers: {})
   end
 end

--- a/spec/jobs/scraper/california_job_spec.rb
+++ b/spec/jobs/scraper/california_job_spec.rb
@@ -2,14 +2,29 @@ require "rails_helper"
 
 RSpec.describe Scraper::CaliforniaJob, type: :job do
   describe "#perform" do
-    it "downloads pdf files to an standards import record" do
-      stub_responses
-      expect {
-        described_class.new.perform
-      }.to change(StandardsImport, :count).by(1)
+    context "when files have not been downloaded previously" do
+      it "downloads pdf files to a standards import record" do
+        stub_responses
+        expect {
+          described_class.new.perform
+        }.to change(StandardsImport, :count).by(6)
 
-      standard_import = StandardsImport.last
-      expect(standard_import.files.count).to be > 0
+        standard_import = StandardsImport.last
+        expect(standard_import.files.count).to eq 1
+      end
+    end
+
+    context "when some files have been downloaded previously" do
+      it "downloads new pdf files to a standards import record" do
+        create(:standards_import, name: "https://www.dir.ca.gov/das/standards/100859_SETA%20ECE_Standards.pdf", organization: "https://www.dir.ca.gov/das/ProgramStandards.htm")
+        stub_responses
+        expect {
+          described_class.new.perform
+        }.to change(StandardsImport, :count).by(5)
+
+        standard_import = StandardsImport.last
+        expect(standard_import.files.count).to eq 1
+      end
     end
   end
 

--- a/spec/jobs/scraper/california_job_spec.rb
+++ b/spec/jobs/scraper/california_job_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Scraper::CaliforniaJob, type: :job do
 
   def stub_responses
     html_file = file_fixture("scraper/california.htm")
-    stub_request(:get, /dir.ca.gov.*\.htm/).
-      to_return(status: 200, body: html_file.read, headers: {})
+    stub_request(:get, /dir.ca.gov.*\.htm/)
+      .to_return(status: 200, body: html_file.read, headers: {})
 
     pdf_file = file_fixture("pixel1x1.pdf")
-    stub_request(:get, /dir.ca.gov.*\.pdf/).
-      to_return(status: 200, body: pdf_file.read, headers: {})
+    stub_request(:get, /dir.ca.gov.*\.pdf/)
+      .to_return(status: 200, body: pdf_file.read, headers: {})
   end
 end

--- a/spec/jobs/scraper/california_job_spec.rb
+++ b/spec/jobs/scraper/california_job_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Scraper::CaliforniaJob, type: :job do
+  describe "#perform" do
+    it "downloads pdf files to an standards import record" do
+      expect {
+        described_class.new.perform
+      }.to change(StandardsImport, :count).by(1)
+
+      standard_import = StandardsImport.last
+      expect(standard_import.files.count).to be > 0
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 require "capybara/rails"
+require "webmock/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,4 @@
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: ["chromedriver.storage.googleapis.com"]
+)


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203778503386690/f

This adds a background job to scrape the standards from: https://www.dir.ca.gov/das/ProgramStandards.htm

One new StandardsImport record is created using the name of the file as the name of the record to ensure that we do not re-download the same files every time the job is run.

This also adds the webmock gem to make sure we do not make external HTTP requests in tests.
