### PR TITLE
Capture sponsor name for CA scaper

### DIFF
--- a/app/jobs/scraper/california_job.rb
+++ b/app/jobs/scraper/california_job.rb
@@ -12,17 +12,17 @@ class Scraper::CaliforniaJob < ApplicationJob
 
     doc = Nokogiri::HTML(html)
     nodeset = doc.css(".main-primary a[href]")
-    file_paths = nodeset.map { |element| element["href"] }.select { |href| href.ends_with?(".pdf") }
+    file_paths = nodeset.map { |element| [element["href"], element.text.squish] }.select { |href, link_text| href.ends_with?(".pdf") }
 
-    file_paths.each do |path|
+    file_paths.each do |path, link_text|
       query = url_base + path
       query.gsub!(/\s/, "%20")
 
       standards_import = StandardsImport.where(
         name: protocol + query,
-        organization: fetch_url
+        organization: link_text
       ).first_or_create!(
-        notes: "From Scraper::CaliforniaJob"
+        notes: "From Scraper::CaliforniaJob: #{fetch_url}"
       )
 
       # protocol needs to be hardcoded to avoid Rubocop error:

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  self.implicit_order_column = :created_at
 end

--- a/spec/jobs/scraper/california_job_spec.rb
+++ b/spec/jobs/scraper/california_job_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Scraper::CaliforniaJob, type: :job do
         standard_import = StandardsImport.last
         expect(standard_import.files.count).to eq 1
         expect(standard_import.name).to eq "https://www.dir.ca.gov/das/standards/101015_SB%20ECE_Standards.pdf"
-        expect(standard_import.organization).to eq "https://www.dir.ca.gov/das/ProgramStandards.htm"
-        expect(standard_import.notes).to eq "From Scraper::CaliforniaJob"
+        expect(standard_import.organization).to eq "Santa Barbara County Education Office (SBCEO) Early Childhood Educator Apprenticeship Program"
+        expect(standard_import.notes).to eq "From Scraper::CaliforniaJob: https://www.dir.ca.gov/das/ProgramStandards.htm"
       end
     end
 
     context "when some files have been downloaded previously" do
       it "downloads new pdf files to a standards import record" do
-        create(:standards_import, name: "https://www.dir.ca.gov/das/standards/100859_SETA%20ECE_Standards.pdf", organization: "https://www.dir.ca.gov/das/ProgramStandards.htm")
+        create(:standards_import, name: "https://www.dir.ca.gov/das/standards/100859_SETA%20ECE_Standards.pdf", organization: "Sacramento Employment and Training Agency (SETA) Early Childhood Education Apprenticeship Program")
         stub_responses
         expect {
           described_class.new.perform

--- a/spec/jobs/scraper/california_job_spec.rb
+++ b/spec/jobs/scraper/california_job_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe Scraper::CaliforniaJob, type: :job do
 
         standard_import = StandardsImport.last
         expect(standard_import.files.count).to eq 1
+        expect(standard_import.name).to eq "https://www.dir.ca.gov/das/standards/101015_SB%20ECE_Standards.pdf"
+        expect(standard_import.organization).to eq "https://www.dir.ca.gov/das/ProgramStandards.htm"
+        expect(standard_import.notes).to eq "From Scraper::CaliforniaJob"
       end
     end
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/0/1203922546776347/f

This parses the link text and uses it for the sponsor name.
