### PR TITLE
Ignore internal Sidekiq::JobRetry::Skip error

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -33,6 +33,7 @@ Rollbar.configure do |config|
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
   config.exception_level_filters["ActionController::RoutingError"] = "ignore"
+  config.exception_level_filters["Sidekiq::JobRetry::Skip"] = "ignore"
 
   # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
   # is not installed)


### PR DESCRIPTION
The actual error also gets reported to Rollbar, so we do not need this duplicate.

<img width="1129" alt="Screen Shot 2023-02-16 at 9 53 56 AM" src="https://user-images.githubusercontent.com/1938665/219448045-a0cacda3-a35e-4e47-8a9c-59ba433b784c.png">

-------

<img width="1200" alt="Screen Shot 2023-02-16 at 9 53 44 AM" src="https://user-images.githubusercontent.com/1938665/219448064-606793c2-98bb-4145-8f96-06ce00e96ba2.png">

