### PR TITLE
Set mailer recipient to actual person

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -7,7 +7,7 @@ class AdminMailer < ApplicationMailer
   def new_standards_import(standards_import)
     @standards_import = standards_import
 
-    mail to: "admin@example.org",
+    mail to: "jeanine@thoughtbot.com",
       subject: "New standards import uploaded"
   end
 end

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AdminMailer, type: :mailer do
       mail = AdminMailer.new_standards_import(si)
 
       expect(mail.subject).to eq("New standards import uploaded")
-      expect(mail.to).to eq(["admin@example.org"])
+      expect(mail.to).to eq(["jeanine@thoughtbot.com"])
       expect(mail.from).to eq(["admin@example.com"])
 
       mail.body.parts.each do |part|


### PR DESCRIPTION
Set mailer recipient to an actual verified email in Mailgun so we can test the mail delivery of the new standards import message until we get Mailgun for production set up.