### PR TITLE
Updates to occupation standards index view

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -10,6 +10,10 @@
   .btn-secondary {
     @apply bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded
   }
+
+  .pill {
+    @apply py-2 px-4 shadow-md no-underline rounded-full text-white font-sans font-semibold text-sm mr-2
+  }
 }
 
 @layer base {

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -8,4 +8,8 @@ class Occupation < ApplicationRecord
   def onet_soc_code
     onet_code&.code
   end
+
+  def to_s
+    "#{name} (#{rapids_code})"
+  end
 end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -11,6 +11,7 @@ class OccupationStandard < ApplicationRecord
   delegate :name, to: :occupation, prefix: true, allow_nil: true
 
   enum occupation_type: [:time, :competency, :hybrid], _suffix: :based
+  enum :status, [:importing, :in_review, :published]
 
   validates :title, presence: true
 

--- a/app/models/onet_code.rb
+++ b/app/models/onet_code.rb
@@ -1,4 +1,8 @@
 class OnetCode < ApplicationRecord
   validates :name, :code, presence: true
   validates :code, uniqueness: true
+
+  def to_s
+    "#{name} (#{code})"
+  end
 end

--- a/app/views/occupation_standards/_occupation_standard.html.erb
+++ b/app/views/occupation_standards/_occupation_standard.html.erb
@@ -12,6 +12,18 @@
     <%= occupation_standard.occupation.onet_code || occupation_standard.onet_code %>
   </td>
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= occupation_standard.status.titleize %>
+    <% if occupation_standard.importing? %>
+      <span class="pill bg-orange-500">
+        <%= occupation_standard.status.titleize %>
+      </span>
+    <% elsif occupation_standard.in_review? %>
+      <span class="pill bg-yellow-600">
+        <%= occupation_standard.status.titleize %>
+      </span>
+    <% elsif occupation_standard.published? %>
+      <span class="pill bg-green-700">
+        <%= occupation_standard.status.titleize %>
+      </span>
+    <% end %>
   </td>
 </tr>

--- a/app/views/occupation_standards/_occupation_standard.html.erb
+++ b/app/views/occupation_standards/_occupation_standard.html.erb
@@ -3,15 +3,15 @@
     <%= link_to occupation_standard.title, occupation_standard, class: "underline" %>
   </td>
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= occupation_standard.occupation.name %>
+    <%= occupation_standard.occupation %>
   </td>
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
     <%= occupation_standard.registration_agency %>
   </td>
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= occupation_standard.rapids_code %>
+    <%= occupation_standard.occupation.onet_code || occupation_standard.onet_code %>
   </td>
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= occupation_standard.onet_code %>
+    <%= occupation_standard.status.titleize %>
   </td>
 </tr>

--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -17,10 +17,10 @@
               </th>
 
               <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-                RAPIDS code
+                ONET code
               </th>
               <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-                ONET code
+                Status
               </th>
             </tr>
           </thead>

--- a/db/migrate/20230220215700_add_status_to_occupation_standards.rb
+++ b/db/migrate/20230220215700_add_status_to_occupation_standards.rb
@@ -1,0 +1,5 @@
+class AddStatusToOccupationStandards < ActiveRecord::Migration[7.0]
+  def change
+    add_column :occupation_standards, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_02_182410) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_20_215700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_182410) do
     t.integer "rsi_hours_max"
     t.uuid "data_import_id"
     t.uuid "organization_id"
+    t.integer "status", default: 0, null: false
     t.index ["data_import_id"], name: "index_occupation_standards_on_data_import_id"
     t.index ["occupation_id"], name: "index_occupation_standards_on_occupation_id"
     t.index ["organization_id"], name: "index_occupation_standards_on_organization_id"

--- a/spec/views/occupation_standards/index_spec.rb
+++ b/spec/views/occupation_standards/index_spec.rb
@@ -2,9 +2,8 @@ require "rails_helper"
 
 RSpec.describe "occupation_standards/index.html.erb", type: :view do
   it "displays name and description", :admin do
-    occupation_standards = create_list(:occupation_standard, 1, title: "Mechanic")
-    occupation_standard = occupation_standards.first
-    assign(:occupation_standards, occupation_standards)
+    occupation_standard = create(:occupation_standard, title: "Mechanic")
+    assign(:occupation_standards, OccupationStandard.all)
 
     render
 

--- a/spec/views/occupation_standards/index_spec.rb
+++ b/spec/views/occupation_standards/index_spec.rb
@@ -1,21 +1,53 @@
 require "rails_helper"
 
 RSpec.describe "occupation_standards/index.html.erb", type: :view do
-  it "displays name and description", :admin do
-    occupation_standard = create(:occupation_standard, title: "Mechanic")
-    assign(:occupation_standards, OccupationStandard.all)
+  context "when occupation" do
+    it "displays table with attributes" do
+      ca = create(:state, name: "California", abbreviation: "CA")
+      agency = create(:registration_agency, state: ca, agency_type: :oa)
+      onet_code = create(:onet_code, code: "11-12345.0", name: "Dog Catching Human")
+      occupation = create(:occupation, name: "Dog Catcher", rapids_code: "12345", onet_code: onet_code)
+      occupation_standard = create(:occupation_standard, occupation: occupation, title: "Dog Catching Technician", registration_agency: agency)
 
-    render
+      assign(:occupation_standards, OccupationStandard.all)
+      render
 
-    expect(rendered).to have_selector("h1", text: "Occupation Standards")
-    expect(rendered).to have_columnheader("Title")
-    expect(rendered).to have_columnheader("Occupation")
-    expect(rendered).to have_columnheader("Registration Agency")
-    expect(rendered).to have_columnheader("RAPIDS code")
-    expect(rendered).to have_columnheader("ONET code")
+      expect(rendered).to have_selector("h1", text: "Occupation Standards")
+      expect(rendered).to have_columnheader("Title")
+      expect(rendered).to have_columnheader("Occupation")
+      expect(rendered).to have_columnheader("Registration Agency")
+      expect(rendered).to have_columnheader("ONET code")
+      expect(rendered).to have_columnheader("Status")
 
-    expect(rendered).to have_link(occupation_standard.title, href: occupation_standard_path(occupation_standard))
-    expect(rendered).to have_gridcell(occupation_standard.rapids_code)
-    expect(rendered).to have_gridcell(occupation_standard.onet_code)
+      expect(rendered).to have_link("Dog Catching Technician", href: occupation_standard_path(occupation_standard))
+      expect(rendered).to have_gridcell("Dog Catcher (12345)")
+      expect(rendered).to have_gridcell("California (OA)")
+      expect(rendered).to have_gridcell("Dog Catching Human (11-12345.0)")
+      expect(rendered).to have_gridcell("Importing")
+    end
+  end
+
+  context "when no occupation" do
+    it "displays table with attributes" do
+      ca = create(:state, name: "California", abbreviation: "CA")
+      agency = create(:registration_agency, state: ca, agency_type: :oa)
+      occupation_standard = create(:occupation_standard, onet_code: "11-12345.0", title: "Dog Catching Technician", registration_agency: agency)
+
+      assign(:occupation_standards, OccupationStandard.all)
+      render
+
+      expect(rendered).to have_selector("h1", text: "Occupation Standards")
+      expect(rendered).to have_columnheader("Title")
+      expect(rendered).to have_columnheader("Occupation")
+      expect(rendered).to have_columnheader("Registration Agency")
+      expect(rendered).to have_columnheader("ONET code")
+      expect(rendered).to have_columnheader("Status")
+
+      expect(rendered).to have_link("Dog Catching Technician", href: occupation_standard_path(occupation_standard))
+      expect(rendered).to have_gridcell("")
+      expect(rendered).to have_gridcell("California (OA)")
+      expect(rendered).to have_gridcell("11-12345.0")
+      expect(rendered).to have_gridcell("Importing")
+    end
   end
 end


### PR DESCRIPTION
Asana ticket: https://github.com/rails/tailwindcss-rails/blob/main/README.md#class-names-must-be-spelled-out

This PR does not add the Edit link, as new routes will be needed. That link will be added in a separate PR.

This modifies the Occupation Standards index view to otherwise match the [design document](https://projects.invisionapp.com/share/59136739JHCR#/screens/472144746). The code for displaying the status pills is a little clunkier than I would like [due to Tailwind requiring class names to be spelled out](https://github.com/rails/tailwindcss-rails/blob/main/README.md#class-names-must-be-spelled-out).

<img width="1583" alt="Screen Shot 2023-02-20 at 3 07 07 PM" src="https://user-images.githubusercontent.com/1938665/220211090-d387f3aa-5bf6-4c69-bb0c-15bdf237efe6.png">

