### PR TITLE
Add oregon job to scraper task and update to be headless

### DIFF
--- a/app/jobs/scraper/oregon_job.rb
+++ b/app/jobs/scraper/oregon_job.rb
@@ -4,7 +4,7 @@ class Scraper::OregonJob < ApplicationJob
   def perform
     base = "https://www.oregon.gov"
     apprenticeship_url = base + "/boli/apprenticeship/Pages/"
-    browser = Watir::Browser.new
+    browser = Watir::Browser.new :chrome, options: {args: %w[--headless --no-sandbox --disable-dev-shm-usage --disable-gpu --remote-debugging-port=9222]}
     browser.goto(apprenticeship_url + "apprenticeship-opportunities.aspx")
     js_doc = browser.element(css: "tbody").wait_until(&:present?)
     body = Nokogiri::HTML(js_doc.inner_html)

--- a/lib/tasks/scraper.rake
+++ b/lib/tasks/scraper.rake
@@ -3,6 +3,7 @@ namespace :scraper do
     if Date.current.wday.eql?(0) || ENV["FORCE"] == "true"
       puts "Running scraping jobs"
       Scraper::CaliforniaJob.perform_later
+      Scraper::OregonJob.perform_later
     else
       puts "Not Sunday, skipping"
       puts "Use FORCE=true to force this task"


### PR DESCRIPTION
I followed this tutorial to make the Oregon scraper headless for production. It looks like I will also need to add some buildpacks in heroku to make sure everything works correctly.

[https://medium.com/@franciscoantunesbarreto1997/configuring-watir-with-ruby-on-rails-for-heroku-e96433854430](https://medium.com/@franciscoantunesbarreto1997/configuring-watir-with-ruby-on-rails-for-heroku-e96433854430)
