### PR TITLE
Add ApprenticeshipBulletinsJob to scraper task file

### DIFF
--- a/lib/tasks/scraper.rake
+++ b/lib/tasks/scraper.rake
@@ -4,6 +4,7 @@ namespace :scraper do
       puts "Running scraping jobs"
       Scraper::CaliforniaJob.perform_later
       Scraper::OregonJob.perform_later
+      Scraper::AppreticeshipBulletinsJob.perform_later
     else
       puts "Not Sunday, skipping"
       puts "Use FORCE=true to force this task"


### PR DESCRIPTION
Just adds the AO Bulletin Jobs scraper to the scraper task so I can then run all the tasks in production
