### PR TITLE
Fix duplicates for import tasks

### DIFF
--- a/app/jobs/scraper/california_job.rb
+++ b/app/jobs/scraper/california_job.rb
@@ -21,14 +21,21 @@ class Scraper::CaliforniaJob < ApplicationJob
       standards_import = StandardsImport.where(
         name: protocol + query,
         organization: link_text
-      ).first_or_create!(
+      ).first_or_initialize(
         notes: "From Scraper::CaliforniaJob: #{fetch_url}"
       )
 
-      # protocol needs to be hardcoded to avoid Rubocop error:
-      # Security/Open: The use of `URI.open` is a serious security risk
-      # https://github.com/rubocop/rubocop/issues/6216#issuecomment-1252449855
-      standards_import.files.attach(io: URI.open("https://#{query}"), filename: File.basename(path))
+      if standards_import.new_record?
+        standards_import.save!
+
+        # protocol needs to be hardcoded to avoid Rubocop error:
+        # Security/Open: The use of `URI.open` is a serious security risk
+        # https://github.com/rubocop/rubocop/issues/6216#issuecomment-1252449855
+        standards_import.files.attach(
+          io: URI.open("https://#{query}"),
+          filename: File.basename(path)
+        )
+      end
     end
   end
 end

--- a/app/jobs/scraper/oregon_job.rb
+++ b/app/jobs/scraper/oregon_job.rb
@@ -35,11 +35,18 @@ class Scraper::OregonJob < ApplicationJob
           standards_import = StandardsImport.where(
             name: base + file_path,
             organization: organization
-          ).first_or_create!(
+          ).first_or_initialize(
             notes: "From Scraper::OregonJob"
           )
 
-          standards_import.files.attach(io: URI.open("https://www.oregon.gov#{file_path}"), filename: File.basename(file_name))
+          if standards_import.new_record?
+            standards_import.save!
+
+            standards_import.files.attach(
+              io: URI.open("https://www.oregon.gov#{file_path}"),
+              filename: File.basename(file_name)
+            )
+          end
         end
       end
     end

--- a/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
+++ b/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Scraper::AppreticeshipBulletinsJob, type: :job do
 
   context "when some files have been downloaded previously" do
     it "downloads any new file to a standards import record" do
-      create(:standards_import,
+      old_import = create(:standards_import, :with_files,
         name: "https://www.apprenticeship.gov/sites/default/files/bulletins/Bulletin_2016-22.pdf",
         organization: "Wildland Fire Fighter Specialist")
       stub_responses
@@ -35,7 +35,9 @@ RSpec.describe Scraper::AppreticeshipBulletinsJob, type: :job do
       expect(standard_import.files.count).to eq 1
 
       file_import = FileImport.last
-      expect(file_import.metadata).to eq({"date" => "03/11/16"})
+      expect(file_import.metadata).to eq({"date" => "03/01/22"})
+
+      expect(old_import.reload.files.count).to eq 1
     end
   end
 

--- a/spec/jobs/scraper/california_job_spec.rb
+++ b/spec/jobs/scraper/california_job_spec.rb
@@ -9,24 +9,26 @@ RSpec.describe Scraper::CaliforniaJob, type: :job do
           described_class.new.perform
         }.to change(StandardsImport, :count).by(6)
 
-        standard_import = StandardsImport.last
-        expect(standard_import.files.count).to eq 1
-        expect(standard_import.name).to eq "https://www.dir.ca.gov/das/standards/101015_SB%20ECE_Standards.pdf"
-        expect(standard_import.organization).to eq "Santa Barbara County Education Office (SBCEO) Early Childhood Educator Apprenticeship Program"
-        expect(standard_import.notes).to eq "From Scraper::CaliforniaJob: https://www.dir.ca.gov/das/ProgramStandards.htm"
+        standards_import = StandardsImport.last
+        expect(standards_import.files.count).to eq 1
+        expect(standards_import.name).to eq "https://www.dir.ca.gov/das/standards/101015_SB%20ECE_Standards.pdf"
+        expect(standards_import.organization).to eq "Santa Barbara County Education Office (SBCEO) Early Childhood Educator Apprenticeship Program"
+        expect(standards_import.notes).to eq "From Scraper::CaliforniaJob: https://www.dir.ca.gov/das/ProgramStandards.htm"
       end
     end
 
     context "when some files have been downloaded previously" do
       it "downloads new pdf files to a standards import record" do
-        create(:standards_import, name: "https://www.dir.ca.gov/das/standards/100859_SETA%20ECE_Standards.pdf", organization: "Sacramento Employment and Training Agency (SETA) Early Childhood Education Apprenticeship Program")
+        old_standards_import = create(:standards_import, :with_files, name: "https://www.dir.ca.gov/das/standards/100859_SETA%20ECE_Standards.pdf", organization: "Sacramento Employment and Training Agency (SETA) Early Childhood Education Apprenticeship Program")
         stub_responses
         expect {
           described_class.new.perform
         }.to change(StandardsImport, :count).by(5)
 
-        standard_import = StandardsImport.last
-        expect(standard_import.files.count).to eq 1
+        standards_import = StandardsImport.last
+        expect(standards_import.files.count).to eq 1
+
+        expect(old_standards_import.reload.files.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
Duplicate file_imports were getting created since the original StandardsImport record that was retrieved was just getting the same file attached multiple times. This change will only add files for new StandardsImport records.
