### PR TITLE
Use after_commit for standards_import creation when calling mailer

### DIFF
--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -1,7 +1,7 @@
 class StandardsImport < ApplicationRecord
   has_many_attached :files
 
-  after_create :notify_admin
+  after_commit :notify_admin, on: :create
 
   def file_count
     files.count

--- a/spec/models/standards_import_spec.rb
+++ b/spec/models/standards_import_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe StandardsImport, type: :model do
   end
 
   describe "#notify_admin" do
-    it "calls new_standards_import mailer on create" do
+    it "calls new_standards_import mailer on create but not update" do
       stub_const "ENV", ENV.to_h.merge("ENABLE_STANDARDS_IMPORTS_NOTIFICATIONS" => "true")
       si = build(:standards_import)
 
@@ -42,10 +42,6 @@ RSpec.describe StandardsImport, type: :model do
       expect(mailer).to receive(:deliver_later)
 
       si.save!
-    end
-
-    it "does not call mailer when updated" do
-      si = create(:standards_import)
 
       expect(AdminMailer).to_not receive(:new_standards_import)
 


### PR DESCRIPTION
There was a race condition where the StandardsImport after_create hook was triggering the admin notification mailer, but the record had not been committed to the database yet.

[Rollbar ticket](https://rollbar.com/apprenticeship-standards-dot-o/apprenticeship-standards-dot-o/items/7/)
