### PR TITLE
Let Bulletin scraper job fail so it can retry

### DIFF
--- a/app/jobs/scraper/appreticeship_bulletins_job.rb
+++ b/app/jobs/scraper/appreticeship_bulletins_job.rb
@@ -26,7 +26,5 @@ class Scraper::AppreticeshipBulletinsJob < ApplicationJob
         )
       end
     end
-  rescue OpenURI::HTTPError
-    Rails.logger.debug "Error while trying to download #{file_uri}"
   end
 end


### PR DESCRIPTION
This removes the error catching in the
ApprenticeshipBulletinsJob so that the
job can be retried through SideKiq.

[Rollbar ticket](https://rollbar.com/apprenticeship-standards-dot-o/apprenticeship-standards-dot-o/items/18/)
