### PR TITLE
Adjust watir headless arguments

### DIFF
--- a/app/jobs/scraper/oregon_job.rb
+++ b/app/jobs/scraper/oregon_job.rb
@@ -4,8 +4,8 @@ class Scraper::OregonJob < ApplicationJob
   def perform
     base = "https://www.oregon.gov"
     apprenticeship_url = base + "/boli/apprenticeship/Pages/"
-    browser = Watir::Browser.new :chrome, options: {args: %w[--headless --no-sandbox --disable-dev-shm-usage --disable-gpu --remote-debugging-port=9222]}
-    browser.goto(apprenticeship_url + "apprenticeship-opportunities.aspx")
+    browser = Watir::Browser.start(apprenticeship_url + "apprenticeship-opportunities.aspx", 
+      :chrome, options: {args: %w[--headless --no-sandbox --disable-dev-shm-usage --disable-gpu]})
     js_doc = browser.element(css: "tbody").wait_until(&:present?)
     body = Nokogiri::HTML(js_doc.inner_html)
 
@@ -43,6 +43,9 @@ class Scraper::OregonJob < ApplicationJob
         end
       end
     end
-    browser.close
+
+    while browser.exists?
+      browser.close
+    end
   end
 end

--- a/app/jobs/scraper/oregon_job.rb
+++ b/app/jobs/scraper/oregon_job.rb
@@ -4,7 +4,7 @@ class Scraper::OregonJob < ApplicationJob
   def perform
     base = "https://www.oregon.gov"
     apprenticeship_url = base + "/boli/apprenticeship/Pages/"
-    browser = Watir::Browser.start(apprenticeship_url + "apprenticeship-opportunities.aspx", 
+    browser = Watir::Browser.start(apprenticeship_url + "apprenticeship-opportunities.aspx",
       :chrome, options: {args: %w[--headless --no-sandbox --disable-dev-shm-usage --disable-gpu]})
     js_doc = browser.element(css: "tbody").wait_until(&:present?)
     body = Nokogiri::HTML(js_doc.inner_html)


### PR DESCRIPTION
Error: [https://rollbar.com/apprenticeship-standards-dot-o/apprenticeship-standards-dot-o/items/20/](https://rollbar.com/apprenticeship-standards-dot-o/apprenticeship-standards-dot-o/items/20/)

Seems like the remote debugging option that I added from the tutorial was causing issues. I removed it since it's not actually being used. Also seems like there are sometimes multiple browsers that need to be closed from all the visited pages


