### PR TITLE
One source file has many data imports

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -17,6 +17,10 @@
 }
 
 @layer base {
+  a.default-colors {
+    @apply underline text-blue-600 hover:text-blue-800 visited:text-purple-600
+  }
+
   .form-label, .show-label {
     @apply block text-gray-700 text-sm font-bold mb-2
   }

--- a/app/controllers/data_imports_controller.rb
+++ b/app/controllers/data_imports_controller.rb
@@ -11,7 +11,7 @@ class DataImportsController < ApplicationController
     @data_import.user = current_user
 
     if @data_import.save
-      ProcessDataImportJob.perform_later(@data_import)
+      ProcessDataImportJob.perform_later(data_import: @data_import)
       flash[:notice] = "Thank you for submitting your occupation standard!"
       redirect_to source_file_data_import_path(@source_file, @data_import)
     else
@@ -30,7 +30,7 @@ class DataImportsController < ApplicationController
   def update
     @data_import = DataImport.find(params[:id])
     if @data_import.update(permitted_params)
-      ProcessDataImportJob.perform_later(@data_import)
+      ProcessDataImportJob.perform_later(data_import: @data_import)
       redirect_to source_file_data_import_path(@source_file, @data_import)
     else
       render :edit

--- a/app/controllers/data_imports_controller.rb
+++ b/app/controllers/data_imports_controller.rb
@@ -3,11 +3,11 @@ class DataImportsController < ApplicationController
   before_action :set_source_file
 
   def new
-    @data_import = @source_file.build_data_import
+    @data_import = @source_file.data_imports.build
   end
 
   def create
-    @data_import = @source_file.build_data_import(permitted_params)
+    @data_import = @source_file.data_imports.build(permitted_params)
     @data_import.user = current_user
 
     if @data_import.save

--- a/app/controllers/data_imports_controller.rb
+++ b/app/controllers/data_imports_controller.rb
@@ -53,7 +53,7 @@ class DataImportsController < ApplicationController
   end
 
   def permitted_params
-    params.require(:data_import).permit(:description, :file, :last_file)
+    params.require(:data_import).permit(:description, :file)
   end
 
   def last_file_flag

--- a/app/controllers/data_imports_controller.rb
+++ b/app/controllers/data_imports_controller.rb
@@ -11,7 +11,7 @@ class DataImportsController < ApplicationController
     @data_import.user = current_user
 
     if @data_import.save
-      ProcessDataImportJob.perform_later(data_import: @data_import)
+      ProcessDataImportJob.perform_later(data_import: @data_import, last_file: last_file_flag)
       flash[:notice] = "Thank you for submitting your occupation standard!"
       redirect_to source_file_data_import_path(@source_file, @data_import)
     else
@@ -30,7 +30,7 @@ class DataImportsController < ApplicationController
   def update
     @data_import = DataImport.find(params[:id])
     if @data_import.update(permitted_params)
-      ProcessDataImportJob.perform_later(data_import: @data_import)
+      ProcessDataImportJob.perform_later(data_import: @data_import, last_file: last_file_flag)
       redirect_to source_file_data_import_path(@source_file, @data_import)
     else
       render :edit
@@ -53,6 +53,10 @@ class DataImportsController < ApplicationController
   end
 
   def permitted_params
-    params.require(:data_import).permit(:description, :file)
+    params.require(:data_import).permit(:description, :file, :last_file)
+  end
+
+  def last_file_flag
+    params[:last_file] == "1"
   end
 end

--- a/app/controllers/source_files_controller.rb
+++ b/app/controllers/source_files_controller.rb
@@ -5,6 +5,10 @@ class SourceFilesController < ApplicationController
     @source_files = SourceFile.includes(:data_imports, active_storage_attachment: :blob)
   end
 
+  def show
+    @source_file = SourceFile.find(params[:id])
+  end
+
   def edit
     @source_file = SourceFile.find(params[:id])
   end

--- a/app/controllers/source_files_controller.rb
+++ b/app/controllers/source_files_controller.rb
@@ -2,7 +2,7 @@ class SourceFilesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @source_files = SourceFile.includes(:data_import, active_storage_attachment: :blob)
+    @source_files = SourceFile.includes(:data_imports, active_storage_attachment: :blob)
   end
 
   def edit

--- a/app/jobs/process_data_import_job.rb
+++ b/app/jobs/process_data_import_job.rb
@@ -1,7 +1,7 @@
 class ProcessDataImportJob < ApplicationJob
   queue_as :default
 
-  def perform(data_import)
+  def perform(data_import:)
     occupation_standard = import_occupation_standard_details(data_import)
     import_occupation_standard_related_instruction(occupation_standard, data_import)
     import_occupation_standard_wage_schedule(occupation_standard, data_import)

--- a/app/jobs/process_data_import_job.rb
+++ b/app/jobs/process_data_import_job.rb
@@ -1,11 +1,12 @@
 class ProcessDataImportJob < ApplicationJob
   queue_as :default
 
-  def perform(data_import:)
+  def perform(data_import:, last_file: false)
     occupation_standard = import_occupation_standard_details(data_import)
     import_occupation_standard_related_instruction(occupation_standard, data_import)
     import_occupation_standard_wage_schedule(occupation_standard, data_import)
     import_occupation_standard_work_processes(occupation_standard, data_import)
+    mark_source_file_status(data_import, last_file)
   end
 
   private
@@ -30,5 +31,11 @@ class ProcessDataImportJob < ApplicationJob
     ImportOccupationStandardWorkProcesses.new(
       occupation_standard: occupation_standard, data_import: data_import
     ).call
+  end
+
+  def mark_source_file_status(data_import, last_file)
+    if last_file
+      data_import.source_file.completed!
+    end
   end
 end

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -1,6 +1,6 @@
 class SourceFile < ApplicationRecord
   belongs_to :active_storage_attachment, class_name: "ActiveStorage::Attachment"
-  has_many :data_imports, -> { includes(file_attachment: :blob) }
+  has_many :data_imports, -> { includes(:occupation_standard, file_attachment: :blob) }
 
   enum :status, [:pending, :processing, :completed]
 

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -1,6 +1,6 @@
 class SourceFile < ApplicationRecord
   belongs_to :active_storage_attachment, class_name: "ActiveStorage::Attachment"
-  has_one :data_import
+  has_many :data_imports
 
   enum :status, [:pending, :processing, :completed]
 

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -1,6 +1,6 @@
 class SourceFile < ApplicationRecord
   belongs_to :active_storage_attachment, class_name: "ActiveStorage::Attachment"
-  has_many :data_imports
+  has_many :data_imports, -> { includes(file_attachment: :blob) }
 
   enum :status, [:pending, :processing, :completed]
 

--- a/app/views/data_imports/_form.html.erb
+++ b/app/views/data_imports/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col w-full mx-auto">
   <div class="w-full max-w-prose mx-auto bg-slate-300 my-5 p-3">
-  The file imported on this screen should be based on the <%= link_to "import template", "#", class: "default-colors" %>. Please review instructions for filling that template on the <%= link_to "ApprenticeshipStandards Notion", "https://www.notion.so/Instructions-060de1705e7d471fa8bee7a7c535a2d6", class: "default-colors" %>.
+  The file imported on this screen should be based on the <%= link_to "import template", "https://www.notion.so/888b37991598495cb22d0dabc08ae3b2?v=f29055b156fa471ea9c30e9467238e66", class: "default-colors", target: :_blank %>. Please review instructions for filling that template on the <%= link_to "ApprenticeshipStandards Notion", "https://www.notion.so/Instructions-060de1705e7d471fa8bee7a7c535a2d6", class: "default-colors", target: :_blank %>.
   </div>
   <div class="w-full max-w-prose mx-auto">
     <%= form_with model: [@source_file, @data_import], class: "bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4" do |f| %>

--- a/app/views/data_imports/_form.html.erb
+++ b/app/views/data_imports/_form.html.erb
@@ -1,4 +1,7 @@
 <div class="flex flex-col w-full mx-auto">
+  <div class="w-full max-w-prose mx-auto bg-slate-300 my-5 p-3">
+  The file imported on this screen should be based on the <%= link_to "import template", "#", class: "default-colors" %>. Please review instructions for filling that template on the <%= link_to "ApprenticeshipStandards Notion", "https://www.notion.so/Instructions-060de1705e7d471fa8bee7a7c535a2d6", class: "default-colors" %>.
+  </div>
   <div class="w-full max-w-prose mx-auto">
     <%= form_with model: [@source_file, @data_import], class: "bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4" do |f| %>
       <% if @data_import.errors.any? %>

--- a/app/views/data_imports/_form.html.erb
+++ b/app/views/data_imports/_form.html.erb
@@ -20,7 +20,7 @@
         <%= f.file_field :file, class: "form-field" %>
       </div>
       <div class="mb-6">
-        <%= label_tag :last_file, "This is the last import for #{@source_file.filename}. Change its status to Completed.", class: "form-label" %>
+        <%= label_tag :last_file, "This is the last import for #{@source_file.filename}. Change its status to Completed after the import completes.", class: "form-label" %>
         <%= check_box_tag :last_file %>
       </div>
       <div>

--- a/app/views/data_imports/_form.html.erb
+++ b/app/views/data_imports/_form.html.erb
@@ -19,6 +19,10 @@
         <%= f.label :file, class: "form-label" %>
         <%= f.file_field :file, class: "form-field" %>
       </div>
+      <div class="mb-6">
+        <%= label_tag :last_file, "This is the last import for #{@source_file.filename}. Change its status to Completed.", class: "form-label" %>
+        <%= check_box_tag :last_file %>
+      </div>
       <div>
         <%= f.submit "Submit", class: "btn-primary" %>
         <%= link_to "Cancel", :back, class: "btn-secondary" %>

--- a/app/views/data_imports/new.html.erb
+++ b/app/views/data_imports/new.html.erb
@@ -1,3 +1,3 @@
-<h1 class="w-full max-w-prose mx-auto text-center">Upload Occupation Standards</h1>
+<h1 class="w-full max-w-prose mx-auto text-center">Import data for source file: <%= @source_file.filename %></h1>
 
 <%= render "form" %>

--- a/app/views/source_files/index.html.erb
+++ b/app/views/source_files/index.html.erb
@@ -4,11 +4,7 @@
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= link_to source_file.filename, source_file.url %></p>
       <p class="text-sm rounded-full py-2 px-4 bg-amber-300"><%= source_file.status.titleize %></p>
-      <% if source_file.data_imports.any? %>
-        <%= link_to "Convert", edit_source_file_data_import_path(source_file, source_file.data_imports.first) %>
-      <% else %>
-        <%= link_to "Convert", new_source_file_data_import_path(source_file) %>
-      <% end %>
+      <%= link_to "Convert", source_file_path(source_file) %>
       <%= link_to "Edit", edit_source_file_path(source_file) %>
     </div>
   <% end %>

--- a/app/views/source_files/index.html.erb
+++ b/app/views/source_files/index.html.erb
@@ -4,8 +4,8 @@
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= link_to source_file.filename, source_file.url %></p>
       <p class="text-sm rounded-full py-2 px-4 bg-amber-300"><%= source_file.status.titleize %></p>
-      <% if source_file.data_import %>
-        <%= link_to "Convert", edit_source_file_data_import_path(source_file, source_file.data_import) %>
+      <% if source_file.data_imports.any? %>
+        <%= link_to "Convert", edit_source_file_data_import_path(source_file, source_file.data_imports.first) %>
       <% else %>
         <%= link_to "Convert", new_source_file_data_import_path(source_file) %>
       <% end %>

--- a/app/views/source_files/show.html.erb
+++ b/app/views/source_files/show.html.erb
@@ -1,13 +1,15 @@
 <h1 class="w-full max-w-prose mx-auto text-center">Source file: <%= @source_file.filename %></h1>
 
-<div class="mt-3">
+<div class="mt-5">
   <% @source_file.data_imports.each do |data_import| %>
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= link_to data_import.file.filename, source_file_data_import_path(@source_file, data_import) %></p>
       <p class="font-medium"><%= link_to data_import.occupation_standard_title, occupation_standard_path(data_import.occupation_standard) %></p>
       <%= link_to "Edit", edit_source_file_data_import_path(@source_file, data_import) %>
-      <%#= link_to "Convert", source_file_path(source_file) %>
     </div>
   <% end %>
 </div>
-<%#= render "data_imports/form" %>
+
+<div class="mt-5">
+  <%= link_to "New data import", new_source_file_data_import_path(@source_file), class: "btn-primary" %>
+</div>

--- a/app/views/source_files/show.html.erb
+++ b/app/views/source_files/show.html.erb
@@ -4,7 +4,9 @@
   <% @source_file.data_imports.each do |data_import| %>
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= link_to data_import.file.filename, source_file_data_import_path(@source_file, data_import) %></p>
-      <p class="font-medium"><%= link_to data_import.occupation_standard_title, occupation_standard_path(data_import.occupation_standard) %></p>
+      <% if data_import.occupation_standard.present? %>
+        <p class="font-medium"><%= link_to data_import.occupation_standard_title, occupation_standard_path(data_import.occupation_standard) %></p>
+      <% end %>
       <%= link_to "Edit", edit_source_file_data_import_path(@source_file, data_import) %>
     </div>
   <% end %>

--- a/app/views/source_files/show.html.erb
+++ b/app/views/source_files/show.html.erb
@@ -4,6 +4,7 @@
   <% @source_file.data_imports.each do |data_import| %>
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= link_to data_import.file.filename, source_file_data_import_path(@source_file, data_import) %></p>
+      <p class="font-medium"><%= link_to data_import.occupation_standard_title, occupation_standard_path(data_import.occupation_standard) %></p>
       <%#= link_to "Convert", source_file_path(source_file) %>
       <%#= link_to "Edit", edit_source_file_path(source_file) %>
     </div>

--- a/app/views/source_files/show.html.erb
+++ b/app/views/source_files/show.html.erb
@@ -5,8 +5,8 @@
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= link_to data_import.file.filename, source_file_data_import_path(@source_file, data_import) %></p>
       <p class="font-medium"><%= link_to data_import.occupation_standard_title, occupation_standard_path(data_import.occupation_standard) %></p>
+      <%= link_to "Edit", edit_source_file_data_import_path(@source_file, data_import) %>
       <%#= link_to "Convert", source_file_path(source_file) %>
-      <%#= link_to "Edit", edit_source_file_path(source_file) %>
     </div>
   <% end %>
 </div>

--- a/app/views/source_files/show.html.erb
+++ b/app/views/source_files/show.html.erb
@@ -1,0 +1,12 @@
+<h1 class="w-full max-w-prose mx-auto text-center">Source file: <%= @source_file.filename %></h1>
+
+<div class="mt-3">
+  <% @source_file.data_imports.each do |data_import| %>
+    <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
+      <p class="font-medium"><%= link_to data_import.file.filename, source_file_data_import_path(@source_file, data_import) %></p>
+      <%#= link_to "Convert", source_file_path(source_file) %>
+      <%#= link_to "Edit", edit_source_file_path(source_file) %>
+    </div>
+  <% end %>
+</div>
+<%#= render "data_imports/form" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :source_files, only: [:index, :edit, :update] do
+    resources :source_files, only: [:index, :edit, :show, :update] do
       resources :data_imports, except: [:index]
     end
     resources :occupation_standards, only: [:index, :show, :edit, :update]

--- a/spec/factories/data_imports.rb
+++ b/spec/factories/data_imports.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
       occupation_standard { nil }
     end
 
-    factory :data_import_for_hybrid do
+    trait :hybrid do
       file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "comp-occupation-standards-template.xlsx"), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") }
     end
   end

--- a/spec/factories/standards_imports.rb
+++ b/spec/factories/standards_imports.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :standards_import do
     trait :with_files do
-      files { [Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.jpg"), "image/jpeg")] }
+      files { [Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"), "application/pdf")] }
     end
   end
 end

--- a/spec/jobs/process_data_import_job_spec.rb
+++ b/spec/jobs/process_data_import_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ProcessDataImportJob, type: :job do
       ).and_return(work_processes_mock)
       expect(work_processes_mock).to receive(:call)
 
-      described_class.new.perform(data_import)
+      described_class.new.perform(data_import: data_import)
     end
 
     it "deletes old related instructions, wage schedules, work processes when editing" do
@@ -42,7 +42,7 @@ RSpec.describe ProcessDataImportJob, type: :job do
       work_process = create(:work_process, occupation_standard: occupation_standard, sort_order: 99)
       create(:competency, work_process: work_process)
 
-      described_class.new.perform(data_import)
+      described_class.new.perform(data_import: data_import)
 
       occupation_standard.reload
       aggregate_failures do

--- a/spec/requests/data_imports_spec.rb
+++ b/spec/requests/data_imports_spec.rb
@@ -20,13 +20,14 @@ RSpec.describe "DataImports", type: :request, admin: true do
         source_file = create(:source_file)
 
         sign_in admin
-        expect(ProcessDataImportJob).to receive(:perform_later).with(data_import: kind_of(DataImport))
+        expect(ProcessDataImportJob).to receive(:perform_later).with(data_import: kind_of(DataImport), last_file: true)
         expect {
           post source_file_data_imports_path(source_file), params: {
             data_import: {
               description: "A new occupation standard",
               file: fixture_file_upload("spec/fixtures/files/pixel1x1.jpg", "image/jpeg")
-            }
+            },
+            last_file: "1"
           }
         }.to change(DataImport, :count).by(1)
           .and change(ActiveStorage::Attachment, :count).by(1)

--- a/spec/requests/data_imports_spec.rb
+++ b/spec/requests/data_imports_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "DataImports", type: :request, admin: true do
           source_file = data_import.source_file
 
           sign_in admin
-          expect(ProcessDataImportJob).to receive(:perform_later).with(data_import: data_import)
+          expect(ProcessDataImportJob).to receive(:perform_later).with(data_import: data_import, last_file: false)
           patch source_file_data_import_path(source_file, data_import),
             params: {
               data_import: {

--- a/spec/requests/data_imports_spec.rb
+++ b/spec/requests/data_imports_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "DataImports", type: :request, admin: true do
         source_file = create(:source_file)
 
         sign_in admin
-        expect(ProcessDataImportJob).to receive(:perform_later).with(kind_of(DataImport))
+        expect(ProcessDataImportJob).to receive(:perform_later).with(data_import: kind_of(DataImport))
         expect {
           post source_file_data_imports_path(source_file), params: {
             data_import: {
@@ -124,7 +124,7 @@ RSpec.describe "DataImports", type: :request, admin: true do
           source_file = data_import.source_file
 
           sign_in admin
-          expect(ProcessDataImportJob).to receive(:perform_later).with(data_import)
+          expect(ProcessDataImportJob).to receive(:perform_later).with(data_import: data_import)
           patch source_file_data_import_path(source_file, data_import),
             params: {
               data_import: {

--- a/spec/services/import_occupation_standard_work_processes_spec.rb
+++ b/spec/services/import_occupation_standard_work_processes_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ImportOccupationStandardWorkProcesses do
     context "when occupation standard is hybrid with max and min hours" do
       it "creates work process records with its corresponding competencies" do
         occupation_standard = create(:occupation_standard)
-        data_import = create(:data_import_for_hybrid)
+        data_import = create(:data_import, :hybrid)
 
         expect {
           described_class.new(

--- a/spec/system/data_imports/edit_spec.rb
+++ b/spec/system/data_imports/edit_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 
 RSpec.describe "data_imports/edit" do
   it "allows admin user to edit data import", :admin do
-    data_import = create(:data_import)
-    source_file = data_import.source_file
+    create(:standards_import, :with_files)
+    source_file = SourceFile.first
+    data_import = create(:data_import, source_file: source_file)
     admin = create :admin
 
     login_as admin
@@ -12,6 +13,9 @@ RSpec.describe "data_imports/edit" do
     expect(page).to have_content("Edit #{data_import.file.filename}")
     fill_in "Description", with: "New desc"
     attach_file "File", "spec/fixtures/files/pixel1x1.pdf"
+    check "This is the last import for pixel1x1.pdf. Change its status to Completed"
+
+    expect(ProcessDataImportJob).to receive(:perform_later).with(data_import: kind_of(DataImport), last_file: true)
 
     click_on "Submit"
 

--- a/spec/system/data_imports/new_spec.rb
+++ b/spec/system/data_imports/new_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "data_imports/new" do
     within("h1") do
       expect(page).to have_content("Import data for source file: pixel1x1.pdf")
     end
-    expect(page).to have_link("import template", href: "#")
+    expect(page).to have_link("import template", href: "https://www.notion.so/888b37991598495cb22d0dabc08ae3b2?v=f29055b156fa471ea9c30e9467238e66")
     expect(page).to have_link("ApprenticeshipStandards Notion", href: "https://www.notion.so/Instructions-060de1705e7d471fa8bee7a7c535a2d6")
 
     fill_in "Description", with: "Some desc"

--- a/spec/system/data_imports/new_spec.rb
+++ b/spec/system/data_imports/new_spec.rb
@@ -18,6 +18,40 @@ RSpec.describe "data_imports/new" do
     fill_in "Description", with: "Some desc"
     attach_file "File", "spec/fixtures/files/pixel1x1.pdf"
 
+    expect(ProcessDataImportJob).to receive(:perform_later).with(data_import: kind_of(DataImport), last_file: false)
+
+    click_on "Submit"
+
+    within("h1") do
+      expect(page).to have_content("Data Import")
+    end
+    expect(page).to have_content("Description")
+    expect(page).to have_content("Some desc")
+    expect(page).to have_content("File")
+    expect(page).to have_content("pixel1x1.pdf")
+    expect(page).to_not have_content("Occupation standard")
+  end
+
+  it "allows admin user to process file with last_file flag", :admin do
+    create(:standards_import, :with_files)
+    source_file = SourceFile.first
+    admin = create :admin
+
+    login_as admin
+    visit new_source_file_data_import_path(source_file)
+
+    within("h1") do
+      expect(page).to have_content("Import data for source file: pixel1x1.pdf")
+    end
+    expect(page).to have_link("import template", href: "https://www.notion.so/888b37991598495cb22d0dabc08ae3b2?v=f29055b156fa471ea9c30e9467238e66")
+    expect(page).to have_link("ApprenticeshipStandards Notion", href: "https://www.notion.so/Instructions-060de1705e7d471fa8bee7a7c535a2d6")
+
+    fill_in "Description", with: "Some desc"
+    attach_file "File", "spec/fixtures/files/pixel1x1.pdf"
+    check "This is the last import for pixel1x1.pdf. Change its status to Completed"
+
+    expect(ProcessDataImportJob).to receive(:perform_later).with(data_import: kind_of(DataImport), last_file: true)
+
     click_on "Submit"
 
     within("h1") do

--- a/spec/system/data_imports/new_spec.rb
+++ b/spec/system/data_imports/new_spec.rb
@@ -2,15 +2,19 @@ require "rails_helper"
 
 RSpec.describe "data_imports/new" do
   it "allows admin user to create data import", :admin do
-    source_file = create(:source_file)
+    create(:standards_import, :with_files)
+    source_file = SourceFile.first
     admin = create :admin
 
     login_as admin
     visit new_source_file_data_import_path(source_file)
 
     within("h1") do
-      expect(page).to have_content("Upload Occupation Standards")
+      expect(page).to have_content("Import data for source file: pixel1x1.pdf")
     end
+    expect(page).to have_link("import template", href: "#")
+    expect(page).to have_link("ApprenticeshipStandards Notion", href: "https://www.notion.so/Instructions-060de1705e7d471fa8bee7a7c535a2d6")
+
     fill_in "Description", with: "Some desc"
     attach_file "File", "spec/fixtures/files/pixel1x1.pdf"
 

--- a/spec/system/source_files/index_spec.rb
+++ b/spec/system/source_files/index_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "source_files/index" do
 
     source_file = SourceFile.last
     expect(page).to have_content("Pending").once
-    expect(page).to have_link("pixel1x1.jpg")
+    expect(page).to have_link("pixel1x1.pdf")
     expect(page).to have_link("Convert", href: source_file_path(source_file))
     expect(page).to have_link("Edit", href: edit_source_file_path(source_file))
   end

--- a/spec/system/source_files/index_spec.rb
+++ b/spec/system/source_files/index_spec.rb
@@ -11,20 +11,7 @@ RSpec.describe "source_files/index" do
     source_file = SourceFile.last
     expect(page).to have_content("Pending").once
     expect(page).to have_link("pixel1x1.jpg")
-    expect(page).to have_link("Convert", href: new_source_file_data_import_path(source_file))
-    expect(page).to have_link("Edit", href: edit_source_file_path(source_file))
-  end
-
-  it "convert link allows editing existing data import", :admin do
-    data_import = create(:data_import)
-    source_file = data_import.source_file
-    admin = create :admin
-
-    login_as admin
-    visit source_files_path
-
-    expect(page).to have_content("Pending").once
-    expect(page).to have_link("Convert", href: edit_source_file_data_import_path(source_file, data_import))
+    expect(page).to have_link("Convert", href: source_file_path(source_file))
     expect(page).to have_link("Edit", href: edit_source_file_path(source_file))
   end
 end

--- a/spec/system/source_files/show_spec.rb
+++ b/spec/system/source_files/show_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "source_files/show" do
     occupation_standard1 = create(:occupation_standard, title: "Mechanic")
     data_import1 = create(:data_import, source_file: source_file, occupation_standard: occupation_standard1)
 
-    occupation_standard2 = create(:occupation_standard, title: "Pipe Fitter")
-    data_import2 = create(:data_import, :hybrid, source_file: source_file, occupation_standard: occupation_standard2)
+    data_import2 = create(:data_import, :hybrid, source_file: source_file, occupation_standard: nil)
 
     login_as admin
     visit source_file_path(source_file)
@@ -21,8 +20,6 @@ RSpec.describe "source_files/show" do
     expect(page).to have_link "Mechanic", href: occupation_standard_path(occupation_standard1)
 
     expect(page).to have_link "Edit", href: edit_source_file_data_import_path(source_file, data_import2)
-    expect(page).to have_link "comp-occupation-standards-template.xlsx", href: source_file_data_import_path(source_file, data_import2)
-    expect(page).to have_link "Pipe Fitter", href: occupation_standard_path(occupation_standard2)
 
     expect(page).to have_link "New data import", href: new_source_file_data_import_path(source_file)
   end

--- a/spec/system/source_files/show_spec.rb
+++ b/spec/system/source_files/show_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "source_files/show" do
     login_as admin
     visit source_file_path(source_file)
 
-    expect(page).to have_content "Source file: #{source_file.filename}" 
+    expect(page).to have_content "Source file: #{source_file.filename}"
 
     expect(page).to have_link "Edit", href: edit_source_file_data_import_path(source_file, data_import1)
     expect(page).to have_link "occupation-standards-template.xlsx", href: source_file_data_import_path(source_file, data_import1)

--- a/spec/system/source_files/show_spec.rb
+++ b/spec/system/source_files/show_spec.rb
@@ -2,16 +2,24 @@ require "rails_helper"
 
 RSpec.describe "source_files/show" do
   it "displays existing data imports and button to upload another", :admin do
-    source_file = create(:source_file)
-    data_import1 = create(:data_import, source_file: source_file)
-    data_import2 = create(:data_import, :hybrid, source_file: source_file)
     admin = create(:admin)
+    source_file = create(:source_file)
+
+    occupation_standard1 = create(:occupation_standard, title: "Mechanic")
+    data_import1 = create(:data_import, source_file: source_file, occupation_standard: occupation_standard1)
+
+    occupation_standard2 = create(:occupation_standard, title: "Pipe Fitter")
+    data_import2 = create(:data_import, :hybrid, source_file: source_file, occupation_standard: occupation_standard2)
 
     login_as admin
     visit source_file_path(source_file)
 
     expect(page).to have_content "Source file: #{source_file.filename}" 
+
     expect(page).to have_link "occupation-standards-template.xlsx", href: source_file_data_import_path(source_file, data_import1)
+    expect(page).to have_link "Mechanic", href: occupation_standard_path(occupation_standard1)
+
     expect(page).to have_link "comp-occupation-standards-template.xlsx", href: source_file_data_import_path(source_file, data_import2)
+    expect(page).to have_link "Pipe Fitter", href: occupation_standard_path(occupation_standard2)
   end
 end

--- a/spec/system/source_files/show_spec.rb
+++ b/spec/system/source_files/show_spec.rb
@@ -23,5 +23,7 @@ RSpec.describe "source_files/show" do
     expect(page).to have_link "Edit", href: edit_source_file_data_import_path(source_file, data_import2)
     expect(page).to have_link "comp-occupation-standards-template.xlsx", href: source_file_data_import_path(source_file, data_import2)
     expect(page).to have_link "Pipe Fitter", href: occupation_standard_path(occupation_standard2)
+
+    expect(page).to have_link "New data import", href: new_source_file_data_import_path(source_file)
   end
 end

--- a/spec/system/source_files/show_spec.rb
+++ b/spec/system/source_files/show_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "source_files/show" do
+  it "displays existing data imports and button to upload another", :admin do
+    source_file = create(:source_file)
+    data_import1 = create(:data_import, source_file: source_file)
+    data_import2 = create(:data_import, :hybrid, source_file: source_file)
+    admin = create(:admin)
+
+    login_as admin
+    visit source_file_path(source_file)
+
+    expect(page).to have_content "Source file: #{source_file.filename}" 
+    expect(page).to have_link "occupation-standards-template.xlsx", href: source_file_data_import_path(source_file, data_import1)
+    expect(page).to have_link "comp-occupation-standards-template.xlsx", href: source_file_data_import_path(source_file, data_import2)
+  end
+end

--- a/spec/system/source_files/show_spec.rb
+++ b/spec/system/source_files/show_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe "source_files/show" do
 
     expect(page).to have_content "Source file: #{source_file.filename}" 
 
+    expect(page).to have_link "Edit", href: edit_source_file_data_import_path(source_file, data_import1)
     expect(page).to have_link "occupation-standards-template.xlsx", href: source_file_data_import_path(source_file, data_import1)
     expect(page).to have_link "Mechanic", href: occupation_standard_path(occupation_standard1)
 
+    expect(page).to have_link "Edit", href: edit_source_file_data_import_path(source_file, data_import2)
     expect(page).to have_link "comp-occupation-standards-template.xlsx", href: source_file_data_import_path(source_file, data_import2)
     expect(page).to have_link "Pipe Fitter", href: occupation_standard_path(occupation_standard2)
   end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204128782886218/f

This adds a new `source_files#show` intermediate page when the "Convert" button is clicked. This show page lists the existing data_imports and has a button for adding a new data import. The data import form was also updated to match the designs and includes a check box to indicate if the source file should be marked as completed.

**Click "Convert" button"**
<img width="1409" alt="source-file-index" src="https://user-images.githubusercontent.com/1938665/224138121-3f9d039d-d601-4595-8eef-68ba7ab55fef.png">


**brings you to `source_files#show` page**
<img width="1376" alt="source-file-show" src="https://user-images.githubusercontent.com/1938665/224138151-f7990ecd-bff9-4bfa-b92f-a24f5c1f1163.png">


**which then can bring you to the data_import form**
<img width="652" alt="data-import-new" src="https://user-images.githubusercontent.com/1938665/224138167-59de74e8-f0fe-48f0-b82e-638b54e29f1b.png">

