### PR TITLE
Add link for admin to upload source file

### DIFF
--- a/app/controllers/admin/source_files_controller.rb
+++ b/app/controllers/admin/source_files_controller.rb
@@ -1,6 +1,6 @@
 class Admin::SourceFilesController < Admin::BaseController
   def index
-    @source_files = SourceFile.includes(:data_imports, active_storage_attachment: :blob)
+    @source_files = SourceFile.includes(:data_imports, active_storage_attachment: :blob).order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/standards_imports_controller.rb
+++ b/app/controllers/standards_imports_controller.rb
@@ -7,7 +7,11 @@ class StandardsImportsController < ApplicationController
     @standards_import = StandardsImport.new(create_params)
 
     if @standards_import.save
-      redirect_to standards_import_path(@standards_import)
+      if user_signed_in?
+        redirect_to admin_source_files_path
+      else
+        redirect_to standards_import_path(@standards_import)
+      end
     else
       render :new
     end

--- a/app/views/admin/source_files/index.html.erb
+++ b/app/views/admin/source_files/index.html.erb
@@ -5,8 +5,9 @@
     <%= link_to "New source file", new_standards_import_path, class: "btn-primary" %>
   </div>
 
-  <% @source_files.find_each do |source_file| %>
+  <% @source_files.each do |source_file| %>
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
+      <p><%= source_file.created_at %></p>
       <p class="font-medium"><%= link_to source_file.filename, source_file.url %></p>
       <p class="text-sm rounded-full py-2 px-4 bg-amber-300"><%= source_file.status.titleize %></p>
       <%= link_to "Convert", admin_source_file_path(source_file) %>

--- a/app/views/admin/source_files/index.html.erb
+++ b/app/views/admin/source_files/index.html.erb
@@ -1,5 +1,10 @@
 <div id="file-imports" class="w-full flex flex-col mx-auto">
   <h1 class="w-full max-w-prose mx-auto text-center font-semibold text-xl mb-4">Source files</h1>
+
+  <div class="mb-5">
+    <%= link_to "New source file", new_standards_import_path, class: "btn-primary" %>
+  </div>
+
   <% @source_files.find_each do |source_file| %>
     <div class="flex justify-between items-center bg-white shadow-md rounded mb-4 py-3 px-3">
       <p class="font-medium"><%= link_to source_file.filename, source_file.url %></p>

--- a/spec/requests/standards_imports_spec.rb
+++ b/spec/requests/standards_imports_spec.rb
@@ -11,28 +11,59 @@ RSpec.describe "StandardsImports", type: :request do
 
   describe "POST /create" do
     context "with valid parameters" do
-      it "creates new standards import record and redirects to show page" do
-        expect {
-          post standards_imports_path, params: {
-            standards_import: {
-              name: "Mickey Mouse",
-              email: "mickey@mouse.com",
-              organization: "Disney",
-              notes: "a" * 500,
-              files: [fixture_file_upload("spec/fixtures/files/pixel1x1.jpg", "image/jpeg")]
+      context "when guest" do
+        it "creates new standards import record and redirects to show page" do
+          expect {
+            post standards_imports_path, params: {
+              standards_import: {
+                name: "Mickey Mouse",
+                email: "mickey@mouse.com",
+                organization: "Disney",
+                notes: "a" * 500,
+                files: [fixture_file_upload("spec/fixtures/files/pixel1x1.jpg", "image/jpeg")]
+              }
             }
-          }
-        }.to change(StandardsImport, :count).by(1)
-          .and change(ActiveStorage::Attachment, :count).by(1)
+          }.to change(StandardsImport, :count).by(1)
+            .and change(ActiveStorage::Attachment, :count).by(1)
 
-        si = StandardsImport.last
-        expect(si.name).to eq "Mickey Mouse"
-        expect(si.email).to eq "mickey@mouse.com"
-        expect(si.organization).to eq "Disney"
-        expect(si.notes).to eq "a" * 500
-        expect(si.files.count).to eq 1
+          si = StandardsImport.last
+          expect(si.name).to eq "Mickey Mouse"
+          expect(si.email).to eq "mickey@mouse.com"
+          expect(si.organization).to eq "Disney"
+          expect(si.notes).to eq "a" * 500
+          expect(si.files.count).to eq 1
 
-        expect(response).to redirect_to standards_import_path(si)
+          expect(response).to redirect_to standards_import_path(si)
+        end
+      end
+
+      context "when admin", :admin do
+        it "creates new standards import record and redirects to source files page" do
+          admin = create(:admin)
+
+          sign_in admin
+          expect {
+            post standards_imports_path, params: {
+              standards_import: {
+                name: "Mickey Mouse",
+                email: "mickey@mouse.com",
+                organization: "Disney",
+                notes: "a" * 500,
+                files: [fixture_file_upload("spec/fixtures/files/pixel1x1.jpg", "image/jpeg")]
+              }
+            }
+          }.to change(StandardsImport, :count).by(1)
+            .and change(ActiveStorage::Attachment, :count).by(1)
+
+          si = StandardsImport.last
+          expect(si.name).to eq "Mickey Mouse"
+          expect(si.email).to eq "mickey@mouse.com"
+          expect(si.organization).to eq "Disney"
+          expect(si.notes).to eq "a" * 500
+          expect(si.files.count).to eq 1
+
+          expect(response).to redirect_to admin_source_files_path
+        end
       end
     end
 

--- a/spec/system/admin/source_files/index_spec.rb
+++ b/spec/system/admin/source_files/index_spec.rb
@@ -13,5 +13,6 @@ RSpec.describe "admin/source_files/index" do
     expect(page).to have_link("pixel1x1.pdf")
     expect(page).to have_link("Convert", href: admin_source_file_path(source_file))
     expect(page).to have_link("Edit", href: edit_admin_source_file_path(source_file))
+    expect(page).to have_link("New source file", href: new_standards_import_path)
   end
 end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203989413049375/f

This adds a "New source file" link to the source_files#index page, that goes to the standards_import#new page. If an admin fills out the form, then they are redirected back to the source_files#index page. 

This also sorts the source_files by the `created_at` timestamp descending, and displays the `created_at` timestamp.

<img width="1412" alt="Screen Shot 2023-03-14 at 4 11 16 PM" src="https://user-images.githubusercontent.com/1938665/225162445-92a920de-9959-4fae-9f07-414373847397.png">

<img width="658" alt="Screen Shot 2023-03-14 at 4 11 24 PM" src="https://user-images.githubusercontent.com/1938665/225162466-1f9622c2-2fcb-4521-a26b-dd3d6120d675.png">

