### PR TITLE
Update views for displaying work process and related instructions

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -18,7 +18,7 @@
 
 @layer base {
   a.default-colors {
-    @apply underline text-blue-600 hover:text-blue-800 visited:text-purple-600
+    @apply text-blue-600 hover:text-blue-800 visited:text-purple-600
   }
 
   .form-label, .show-label {

--- a/app/helpers/work_processes_helper.rb
+++ b/app/helpers/work_processes_helper.rb
@@ -1,0 +1,5 @@
+module WorkProcessesHelper
+  def hours_range(work_process)
+    [work_process.minimum_hours, work_process.maximum_hours].compact.uniq.join("-")
+  end
+end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -6,7 +6,7 @@ class OccupationStandard < ApplicationRecord
 
   has_many :related_instructions, dependent: :destroy
   has_many :wage_steps, dependent: :destroy
-  has_many :work_processes, dependent: :destroy
+  has_many :work_processes, -> { includes(:competencies) }, dependent: :destroy
 
   delegate :title, to: :organization, prefix: true, allow_nil: true
   delegate :title, to: :occupation, prefix: true, allow_nil: true

--- a/app/views/admin/occupation_standards/_subsections.html.erb
+++ b/app/views/admin/occupation_standards/_subsections.html.erb
@@ -18,3 +18,8 @@
   <h3 class="w-full max-w-prose text-left font-semibold text-xl mb-4">Related Instructions</h3>
   <%= render partial: "related_instructions/table", locals: {related_instructions: @occupation_standard.related_instructions} %>
 </section>
+
+<section id="wage-schedule" class="mb-10">
+  <h3 class="w-full max-w-prose text-left font-semibold text-xl mb-4">Wage Schedule</h3>
+  <%= render partial: "wage_steps/table", locals: {wage_steps: @occupation_standard.wage_steps} %>
+</section>

--- a/app/views/admin/occupation_standards/_subsections.html.erb
+++ b/app/views/admin/occupation_standards/_subsections.html.erb
@@ -9,12 +9,12 @@
   </div>
 </div>
 
-<div class="mb-10">
+<section id="work-processes" class="mb-10">
   <h3 class="w-full max-w-prose text-left font-semibold text-xl mb-4">Work Processes</h3>
   <%= render partial: "work_processes/table", locals: {work_processes: @occupation_standard.work_processes} %>
-</div>
+</section>
 
-<div class="mb-10">
+<section id="related-instruction" class="mb-10">
   <h3 class="w-full max-w-prose text-left font-semibold text-xl mb-4">Related Instructions</h3>
   <%= render partial: "related_instructions/table", locals: {related_instructions: @occupation_standard.related_instructions} %>
-</div>
+</section>

--- a/app/views/admin/occupation_standards/_subsections.html.erb
+++ b/app/views/admin/occupation_standards/_subsections.html.erb
@@ -9,17 +9,17 @@
   </div>
 </div>
 
-<section id="work-processes" class="mb-10">
-  <h3 class="w-full max-w-prose text-left font-semibold text-xl mb-4">Work Processes</h3>
+<section id="work-processes" class="mb-10" aria-labelledby="work-processes-id">
+  <h3 id="work-processes-id" class="w-full max-w-prose text-left font-semibold text-xl mb-4">Work Processes</h3>
   <%= render partial: "work_processes/table", locals: {work_processes: @occupation_standard.work_processes} %>
 </section>
 
-<section id="related-instruction" class="mb-10">
-  <h3 class="w-full max-w-prose text-left font-semibold text-xl mb-4">Related Instructions</h3>
+<section id="related-instruction" class="mb-10" aria-labelledby="related-instructions-id">
+  <h3 id="related-instructions-id" class="w-full max-w-prose text-left font-semibold text-xl mb-4">Related Instructions</h3>
   <%= render partial: "related_instructions/table", locals: {related_instructions: @occupation_standard.related_instructions} %>
 </section>
 
-<section id="wage-schedule" class="mb-10">
-  <h3 class="w-full max-w-prose text-left font-semibold text-xl mb-4">Wage Schedule</h3>
+<section id="wage-schedule" class="mb-10" aria-labelledby="wage-steps-id">
+  <h3 id="wage-steps-id" class="w-full max-w-prose text-left font-semibold text-xl mb-4">Wage Schedule</h3>
   <%= render partial: "wage_steps/table", locals: {wage_steps: @occupation_standard.wage_steps} %>
 </section>

--- a/app/views/related_instructions/_related_instruction.html.erb
+++ b/app/views/related_instructions/_related_instruction.html.erb
@@ -1,14 +1,8 @@
 <tr class="border-b">
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= related_instruction.id %>
-  </td>
-  <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= related_instruction.title %>
+    <%= link_to related_instruction.title, "#", class: "default-colors" %>
   </td>
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
     <%= related_instruction.hours %>
-  </td>
-  <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= related_instruction.elective %>
   </td>
 </tr>

--- a/app/views/related_instructions/_table.html.erb
+++ b/app/views/related_instructions/_table.html.erb
@@ -5,13 +5,7 @@
         Title
       </th>
       <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-        Sort Order
-      </th>
-      <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
         Hours
-      </th>
-      <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-        Elective
       </th>
     </tr>
   </thead>

--- a/app/views/wage_steps/_table.html.erb
+++ b/app/views/wage_steps/_table.html.erb
@@ -1,0 +1,18 @@
+<table class="min-w-full" role="grid" aria-label="Wage Schedule">
+  <thead class="border-b">
+    <tr>
+      <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
+        Step Title
+      </th>
+      <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
+        Minimum Hours
+      </th>
+      <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
+        Minimum OJT %
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render partial: "wage_steps/wage_step", collection: wage_steps %>
+  </tbody>
+</table>

--- a/app/views/wage_steps/_wage_step.html.erb
+++ b/app/views/wage_steps/_wage_step.html.erb
@@ -1,0 +1,11 @@
+<tr class="border-b">
+  <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
+    <%= link_to wage_step.title, "#", class: "default-colors" %>
+  </td>
+  <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
+    <%= wage_step.minimum_hours %>
+  </td>
+  <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
+    <%= number_to_percentage(wage_step.ojt_percentage, strip_insignificant_zeros: true) %>
+  </td>
+</tr>

--- a/app/views/work_processes/_table.html.erb
+++ b/app/views/work_processes/_table.html.erb
@@ -5,19 +5,10 @@
         Title
       </th>
       <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-        Sort Order
+        Skills
       </th>
       <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-        Description
-      </th>
-      <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-        Default Hours
-      </th>
-      <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-        Minimum Hours
-      </th>
-      <th scope="col" class="text-sm font-medium text-gray-900 px-6 py-4 text-left">
-        Maximum Hours
+        Hours
       </th>
     </tr>
   </thead>

--- a/app/views/work_processes/_work_process.html.erb
+++ b/app/views/work_processes/_work_process.html.erb
@@ -1,20 +1,15 @@
 <tr class="border-b">
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= work_process.title %>
+    <%= link_to work_process.title, "#", class: "default-colors" %>
   </td>
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= work_process.sort_order %>
+    <% if work_process.competencies.any? %>
+      <%= link_to work_process.competencies.count, "#" %>
+    <% else %>
+      0
+    <% end %>
   </td>
   <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= work_process.description %>
-  </td>
-  <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= work_process.default_hours %>
-  </td>
-  <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= work_process.minimum_hours %>
-  </td>
-  <td class="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap text-left">
-    <%= work_process.maximum_hours %>
+    <%= hours_range(work_process) %>
   </td>
 </tr>

--- a/spec/factories/competencies.rb
+++ b/spec/factories/competencies.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     work_process
     title { "Competency" }
     description { "Competency Description" }
-    sort_order { 1 }
+    sequence(:sort_order) { |n| n }
   end
 end

--- a/spec/factories/wage_steps.rb
+++ b/spec/factories/wage_steps.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :wage_step do
     occupation_standard
-    sort_order { 1 }
+    sequence(:sort_order) { |n| n }
     title { "1st 12 months" }
     minimum_hours { 120 }
     ojt_percentage { "20.00" }

--- a/spec/helpers/work_processes_helper_spec.rb
+++ b/spec/helpers/work_processes_helper_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+# Specs in this file have access to a helper object that includes
+# the WorkProcessesHelper. For example:
+#
+# describe WorkProcessesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe WorkProcessesHelper, type: :helper do
+  describe "#hours_range" do
+    it "returns the range with a hyphen when different min and max" do
+      work_process = build(:work_process, minimum_hours: 10, maximum_hours: 20)
+
+      expect(helper.hours_range(work_process)).to eq "10-20"
+    end
+
+    it "returns a single value when min and max are the same" do
+      work_process = build(:work_process, minimum_hours: 10, maximum_hours: 10)
+
+      expect(helper.hours_range(work_process)).to eq "10"
+    end
+
+    it "returns a single value when min is present and max is nil" do
+      work_process = build(:work_process, minimum_hours: 10, maximum_hours: nil)
+
+      expect(helper.hours_range(work_process)).to eq "10"
+    end
+
+    it "returns a single value when max is present and min is nil" do
+      work_process = build(:work_process, minimum_hours: nil, maximum_hours: 10)
+
+      expect(helper.hours_range(work_process)).to eq "10"
+    end
+  end
+end

--- a/spec/system/admin/occupation_standards/edit_spec.rb
+++ b/spec/system/admin/occupation_standards/edit_spec.rb
@@ -17,19 +17,25 @@ RSpec.describe "admin/occupation_standards/edit" do
 
     expect(page).to have_selector("h3", text: "Source File")
 
-    expect(page).to have_selector("h3", text: "Work Processes")
-    expect(page).to have_columnheader("Title")
-    expect(page).to have_columnheader("Sort Order")
-    expect(page).to have_columnheader("Description")
-    expect(page).to have_columnheader("Default Hours")
-    expect(page).to have_columnheader("Minimum Hours")
-    expect(page).to have_columnheader("Maximum Hours")
+    within "#work-processes" do
+      expect(page).to have_selector("h3", text: "Work Processes")
+      expect(page).to have_columnheader("Title")
+      expect(page).to have_columnheader("Skills")
+      expect(page).to have_columnheader("Hours")
+    end
 
-    expect(page).to have_selector("h3", text: "Related Instructions")
-    expect(page).to have_columnheader("Title")
-    expect(page).to have_columnheader("Sort Order")
-    expect(page).to have_columnheader("Hours")
-    expect(page).to have_columnheader("Elective")
+    within "#related-instruction" do
+      expect(page).to have_selector("h3", text: "Related Instructions")
+      expect(page).to have_columnheader("Title")
+      expect(page).to have_columnheader("Hours")
+    end
+
+    within "#wage-schedule" do
+      expect(page).to have_selector("h3", text: "Wage Schedule")
+      expect(page).to have_columnheader("Step Title")
+      expect(page).to have_columnheader("Minimum Hours")
+      expect(page).to have_columnheader("Minimum OJT %")
+    end
 
     fill_in "Title", with: "New title"
     fill_in "ONET Code", with: "2345.67"

--- a/spec/system/admin/occupation_standards/show_spec.rb
+++ b/spec/system/admin/occupation_standards/show_spec.rb
@@ -3,9 +3,14 @@ require "rails_helper"
 RSpec.describe "admin/occupation_standards/show" do
   it "displays title and description", :admin do
     occupation_standard = create(:occupation_standard, title: "Mechanic")
-    work_process1 = create(:work_process, occupation_standard: occupation_standard, minimum_hours: 10, maximum_hours: 20, title: "WP1")
-    create_pair(:competency, work_process: work_process1)
+
+    work_process = create(:work_process, occupation_standard: occupation_standard, minimum_hours: 10, maximum_hours: 20, title: "WP1")
+    create_pair(:competency, work_process: work_process)
     create(:work_process, occupation_standard: occupation_standard, minimum_hours: 4567, maximum_hours: 4567, title: "WP2")
+
+    create(:related_instruction, occupation_standard: occupation_standard, title: "RS1", hours: 1234)
+    create(:related_instruction, occupation_standard: occupation_standard, title: "RS2", hours: 5678)
+
     create(:data_import, occupation_standard: occupation_standard)
     admin = create(:admin)
 
@@ -49,9 +54,13 @@ RSpec.describe "admin/occupation_standards/show" do
     within "#related-instruction" do
       expect(page).to have_selector("h3", text: "Related Instructions")
       expect(page).to have_columnheader("Title")
-      expect(page).to have_columnheader("Sort Order")
       expect(page).to have_columnheader("Hours")
-      expect(page).to have_columnheader("Elective")
+
+      expect(page).to have_link("RS1", href: "#")
+      expect(page).to have_text "1234"
+
+      expect(page).to have_link("RS2", href: "#")
+      expect(page).to have_text "5678"
     end
 
     expect(page).to have_link("Edit", href: edit_admin_occupation_standard_path(occupation_standard))

--- a/spec/system/admin/occupation_standards/show_spec.rb
+++ b/spec/system/admin/occupation_standards/show_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 RSpec.describe "admin/occupation_standards/show" do
   it "displays title and description", :admin do
     occupation_standard = create(:occupation_standard, title: "Mechanic")
+    work_process1 = create(:work_process, occupation_standard: occupation_standard, minimum_hours: 10, maximum_hours: 20, title: "WP1")
+    create_pair(:competency, work_process: work_process1)
+    create(:work_process, occupation_standard: occupation_standard, minimum_hours: 4567, maximum_hours: 4567, title: "WP2")
     create(:data_import, occupation_standard: occupation_standard)
     admin = create(:admin)
 
@@ -27,21 +30,29 @@ RSpec.describe "admin/occupation_standards/show" do
     expect(page).to have_selector("dd", text: occupation_standard.created_at)
     expect(page).to have_selector("dd", text: occupation_standard.updated_at)
 
-    expect(page).to have_selector("h3", text: "Related Instructions")
+    within "#work-processes" do
+      expect(page).to have_selector("h3", text: "Work Processes")
+      expect(page).to have_columnheader("Title")
+      expect(page).to have_columnheader("Skills")
+      expect(page).to have_columnheader("Hours")
 
-    expect(page).to have_columnheader("Title")
-    expect(page).to have_columnheader("Sort Order")
-    expect(page).to have_columnheader("Hours")
-    expect(page).to have_columnheader("Elective")
+      expect(page).to have_link("WP1", href: "#")
+      expect(page).to have_link("2", href: "#")
+      expect(page).to have_text "10-20"
 
-    expect(page).to have_selector("h3", text: "Work Processes")
+      expect(page).to have_link("WP2", href: "#")
+      expect(page).to have_text("0")
+      expect(page).to_not have_link("0")
+      expect(page).to have_text "4567"
+    end
 
-    expect(page).to have_columnheader("Title")
-    expect(page).to have_columnheader("Sort Order")
-    expect(page).to have_columnheader("Description")
-    expect(page).to have_columnheader("Default Hours")
-    expect(page).to have_columnheader("Minimum Hours")
-    expect(page).to have_columnheader("Maximum Hours")
+    within "#related-instruction" do
+      expect(page).to have_selector("h3", text: "Related Instructions")
+      expect(page).to have_columnheader("Title")
+      expect(page).to have_columnheader("Sort Order")
+      expect(page).to have_columnheader("Hours")
+      expect(page).to have_columnheader("Elective")
+    end
 
     expect(page).to have_link("Edit", href: edit_admin_occupation_standard_path(occupation_standard))
   end

--- a/spec/system/admin/occupation_standards/show_spec.rb
+++ b/spec/system/admin/occupation_standards/show_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe "admin/occupation_standards/show" do
     create(:related_instruction, occupation_standard: occupation_standard, title: "RS1", hours: 1234)
     create(:related_instruction, occupation_standard: occupation_standard, title: "RS2", hours: 5678)
 
+    create(:wage_step, occupation_standard: occupation_standard, title: "WS1", minimum_hours: 3456, ojt_percentage: 50)
+    create(:wage_step, occupation_standard: occupation_standard, title: "WS2", minimum_hours: 7890, ojt_percentage: 75)
+
     create(:data_import, occupation_standard: occupation_standard)
     admin = create(:admin)
 
@@ -61,6 +64,20 @@ RSpec.describe "admin/occupation_standards/show" do
 
       expect(page).to have_link("RS2", href: "#")
       expect(page).to have_text "5678"
+    end
+
+    within "#wage-schedule" do
+      expect(page).to have_selector("h3", text: "Wage Schedule")
+      expect(page).to have_columnheader("Step Title")
+      expect(page).to have_columnheader("Minimum Hours")
+      expect(page).to have_columnheader("Minimum OJT %")
+
+      expect(page).to have_link("WS1", href: "#")
+      expect(page).to have_text "3456"
+      expect(page).to have_text "50%"
+
+      expect(page).to have_link("WS2", href: "#")
+      expect(page).to have_text "75%"
     end
 
     expect(page).to have_link("Edit", href: edit_admin_occupation_standard_path(occupation_standard))

--- a/spec/views/related_instructions/index_spec.rb
+++ b/spec/views/related_instructions/index_spec.rb
@@ -11,13 +11,9 @@ RSpec.describe "related_instructions/index.html.erb", type: :view do
     expect(rendered).to have_selector("h1", text: "Related Instructions")
 
     expect(rendered).to have_columnheader("Title")
-    expect(rendered).to have_columnheader("Sort Order")
     expect(rendered).to have_columnheader("Hours")
-    expect(rendered).to have_columnheader("Elective")
 
-    expect(rendered).to have_gridcell(related_instruction.id)
     expect(rendered).to have_gridcell(related_instruction.title)
     expect(rendered).to have_gridcell(related_instruction.hours.to_s)
-    expect(rendered).to have_gridcell(related_instruction.elective)
   end
 end

--- a/spec/views/work_processes/table_spec.rb
+++ b/spec/views/work_processes/table_spec.rb
@@ -2,23 +2,16 @@ require "rails_helper"
 
 RSpec.describe "work_processes/_table.html.erb", type: :view do
   it "displays title, sort order, description, default hours, minimum hours and maximum hours", :admin do
-    work_processes = create_list(:work_process, 1)
+    work_processes = create_list(:work_process, 1, minimum_hours: 10, maximum_hours: 20)
     work_process = work_processes.first
 
     render partial: "work_processes/table", locals: {work_processes: work_processes}
 
     expect(rendered).to have_columnheader("Title")
-    expect(rendered).to have_columnheader("Sort Order")
-    expect(rendered).to have_columnheader("Description")
-    expect(rendered).to have_columnheader("Default Hours")
-    expect(rendered).to have_columnheader("Minimum Hours")
-    expect(rendered).to have_columnheader("Maximum Hours")
+    expect(rendered).to have_columnheader("Skills")
+    expect(rendered).to have_columnheader("Hours")
 
     expect(rendered).to have_gridcell(work_process.title)
-    expect(rendered).to have_gridcell(work_process.sort_order)
-    expect(rendered).to have_gridcell(work_process.description)
-    expect(rendered).to have_gridcell(work_process.default_hours)
-    expect(rendered).to have_gridcell(work_process.minimum_hours)
-    expect(rendered).to have_gridcell(work_process.maximum_hours)
+    expect(rendered).to have_gridcell("10-20")
   end
 end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203989414842282/f

Modified the occupation standard view to display work processes, related instructions, and wage steps per the design doc. This is WIP, but pausing since we are going to implement Administrate.
