### PR TITLE
Fix binary path for Chrome

### DIFF
--- a/app/jobs/scraper/watir_job.rb
+++ b/app/jobs/scraper/watir_job.rb
@@ -10,7 +10,7 @@ class Scraper::WatirJob < ApplicationJob
       args: %w[--headless --no-sandbox --disable-dev-shm-usage --disable-gpu]
     }
     if (chrome_bin = ENV.fetch("GOOGLE_CHROME_SHIM", nil))
-      options[:options] = {binary: chrome_bin}
+      options[:binary] = chrome_bin
     end
 
     Watir::Browser.new(:chrome, options: options)


### PR DESCRIPTION
After testing this fix on prod
before deploying, I got the following
error:

session not created: This version of ChromeDriver
only supports Chrome version 112
(Selenium::WebDriver::Error::SessionNotCreatedError) Current browser version is 111.0.5563.146 with
binary path /app/.apt/usr/bin/google-chrome-stable

Setting the CHROMEDRIVER_VERSION variable per the
instructions in
https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-chromedriver did not solve the problem.

However, clearing the Heroku cache did solve the issue: https://github.com/heroku/heroku-buildpack-google-chrome/issues/86#issuecomment-611858168

Asana ticket: https://app.asana.com/0/1203289004376659/1204285218375647/f
