### PR TITLE
Fix metadata saved as string instead of hash

### DIFF
--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -11,4 +11,10 @@ class SourceFile < ApplicationRecord
   def url
     active_storage_attachment.blob.url
   end
+
+  # This saves the metadata as JSON instead of string.
+  # See https://github.com/codica2/administrate-field-jsonb/issues/1
+  def metadata=(value)
+    self[:metadata] = value.is_a?(String) ? JSON.parse(value) : value
+  end
 end

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -6,4 +6,13 @@ RSpec.describe SourceFile, type: :model do
 
     expect(source_file).to be_valid
   end
+
+  it "saves metadata as JSON when updating the record" do
+    source_file = build(:source_file)
+
+    source_file.metadata = "{\"date\":\"03/29/2023\"}"
+    source_file.save
+
+    expect(source_file.metadata).to eq({"date" => "03/29/2023"})
+  end
 end


### PR DESCRIPTION
Asana ticket:

While working on https://app.asana.com/0/1203289004376659/1204327785987150/f, I noticed that updating a SourceFile that has metadata changes the value from JSON to String due to the way Administrate JSONB Field works.

See https://github.com/codica2/administrate-field-jsonb/issues/1 for more information

This PR overrides the `metadata=` method to parse the string back into a hash 