### PR TITLE
Use less verbose time format

### DIFF
--- a/app/dashboards/occupation_standard_dashboard.rb
+++ b/app/dashboards/occupation_standard_dashboard.rb
@@ -3,7 +3,7 @@ require "administrate/base_dashboard"
 class OccupationStandardDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     apprenticeship_to_journeyworker_ratio: Field::String,
-    created_at: Field::DateTime.with_options(format: :short),
+    created_at: Field::DateTime,
     data_imports: Field::HasMany,
     existing_title: Field::String,
     id: Field::String,
@@ -24,7 +24,7 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
     status: EnumField,
     term_months: Field::Number,
     title: Field::String,
-    updated_at: Field::DateTime.with_options(format: :short),
+    updated_at: Field::DateTime,
     url: Field::Url,
     wage_steps: Field::HasMany,
     work_processes: Field::HasMany
@@ -39,7 +39,6 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[
-
     title
     onet_code
     rapids_code

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module ApprenticeshipStandardsDotOrg
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Eastern Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,3 +12,6 @@ en:
         rsi_hours_max: Max RSI hours
         rsi_hours_min: Min RSI hours
         url: URL
+  time:
+    formats:
+      default: "%Y-%m-%d %H:%M:%S %Z"

--- a/spec/system/admin/occupation_standards/show_spec.rb
+++ b/spec/system/admin/occupation_standards/show_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "admin/occupation_standards/show" do
   it "displays title and description", :admin do
-    occupation_standard = create(:occupation_standard, title: "Mechanic")
+    occupation_standard = create(:occupation_standard, title: "Mechanic", created_at: Time.zone.local(2022,1,15,1,2,3), updated_at: Time.zone.local(2022,6,17,10,11,12))
 
     work_process = create(:work_process, occupation_standard: occupation_standard, minimum_hours: 10, maximum_hours: 20, title: "WP1")
     create_pair(:competency, work_process: work_process)
@@ -51,8 +51,8 @@ RSpec.describe "admin/occupation_standards/show" do
     expect(page).to have_selector("dd", text: occupation_standard.term_months)
     expect(page).to have_selector("dd", text: occupation_standard.url)
     expect(page).to have_selector("dd", text: occupation_standard.status.titleize)
-    expect(page).to have_selector("dd", text: occupation_standard.created_at.to_s(:short))
-    expect(page).to have_selector("dd", text: occupation_standard.updated_at.to_s(:short))
+    expect(page).to have_selector("dd", text: "2022-01-15 01:02:03 EST")
+    expect(page).to have_selector("dd", text: "2022-06-17 10:11:12 EDT")
 
     expect(page).to have_selector("dd", text: occupation_standard.apprenticeship_to_journeyworker_ratio)
     expect(page).to have_selector("dd", text: occupation_standard.existing_title)

--- a/spec/system/admin/occupation_standards/show_spec.rb
+++ b/spec/system/admin/occupation_standards/show_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "admin/occupation_standards/show" do
   it "displays title and description", :admin do
-    occupation_standard = create(:occupation_standard, title: "Mechanic", created_at: Time.zone.local(2022,1,15,1,2,3), updated_at: Time.zone.local(2022,6,17,10,11,12))
+    occupation_standard = create(:occupation_standard, title: "Mechanic", created_at: Time.zone.local(2022, 1, 15, 1, 2, 3), updated_at: Time.zone.local(2022, 6, 17, 10, 11, 12))
 
     work_process = create(:work_process, occupation_standard: occupation_standard, minimum_hours: 10, maximum_hours: 20, title: "WP1")
     create_pair(:competency, work_process: work_process)


### PR DESCRIPTION
Also set default timezone to be Eastern for now. Can change later if needed.

**Old**:
<img width="1390" alt="Screen Shot 2023-04-17 at 3 08 40 PM" src="https://user-images.githubusercontent.com/1938665/232621449-a2272f35-2bdd-46d3-8984-60bcdc6cd73c.png">

**New**:
<img width="1381" alt="Screen Shot 2023-04-17 at 3 08 29 PM" src="https://user-images.githubusercontent.com/1938665/232621474-a0c04b58-e258-4666-a2d3-af760ab90874.png">

