### PR TITLE
Fix duplicate source files

### DIFF
--- a/app/jobs/scraper/washington_job.rb
+++ b/app/jobs/scraper/washington_job.rb
@@ -46,11 +46,18 @@ class Scraper::WashingtonJob < Scraper::WatirJob
       begin
         standards_import = StandardsImport.where(
           name: file
-        ).first_or_create!(
+        ).first_or_initialize(
           notes: "From Scraper::WashingtonJob: #{program_link}"
         )
 
-        standards_import.files.attach(io: URI.open("https://#{file_path}"), filename: File.basename(file))
+        if standards_import.new_record?
+          standards_import.save!
+
+          standards_import.files.attach(
+            io: URI.open("https://#{file_path}"),
+            filename: File.basename(file)
+          )
+        end
       rescue OpenURI::HTTPError
         next
       rescue Watir::Exception::UnknownObjectException => e

--- a/lib/tasks/deployment/20230417225619_cleanup_duplicate_source_files.rake
+++ b/lib/tasks/deployment/20230417225619_cleanup_duplicate_source_files.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc "Deployment task: cleanup_duplicate_source_files"
+  task cleanup_duplicate_source_files: :environment do
+    puts "Running deploy task 'cleanup_duplicate_source_files'"
+
+    StandardsImport.where("notes LIKE ?", "From Scraper::WashingtonJob%").each do |si|
+      si.files.each_with_index do |attachment, index|
+        next if index.zero?
+
+        source_file = attachment.source_file
+        source_file.destroy!
+
+        attachment.purge
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204375229874460/f

The Washington Scraper job was missing the check to see if the Standards Import already existed. If it does exist, don't re-add the file to it. This also adds a rake task to clean up duplicates.
