### PR TITLE
The Convert link should go directly to the Data Import page

### DIFF
--- a/app/views/admin/source_files/_collection.html.erb
+++ b/app/views/admin/source_files/_collection.html.erb
@@ -56,7 +56,7 @@
           </td>
         <% end %>
         <td class="cell-data cell-data--convert">
-          <%= link_to "Convert", admin_source_file_path(resource) %>
+          <%= link_to "Convert", new_admin_source_file_data_import_path(resource) %>
         </td>
 
         <%= render(

--- a/spec/system/admin/source_files/index_spec.rb
+++ b/spec/system/admin/source_files/index_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "admin/source_files/index", :admin do
     source_file = SourceFile.last
     expect(page).to have_content("Pending").once
     expect(page).to have_link("pixel1x1.pdf")
-    expect(page).to have_link("Convert", href: admin_source_file_path(source_file))
+    expect(page).to have_link("Convert", href: new_admin_source_file_data_import_path(source_file))
     expect(page).to have_link("Edit", href: edit_admin_source_file_path(source_file))
     expect(page).to have_link("New source file", href: new_standards_import_path)
   end
@@ -26,7 +26,7 @@ RSpec.describe "admin/source_files/index", :admin do
 
     expect(page).to have_content("Pending").once
     expect(page).to have_link("pixel1x1.pdf")
-    expect(page).to have_link("Convert", href: admin_source_file_path(source_file))
+    expect(page).to have_link("Convert", href: new_admin_source_file_data_import_path(source_file))
     expect(page).to have_link("Edit", href: edit_admin_source_file_path(source_file))
     expect(page).to have_link("New source file", href: new_standards_import_path)
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204445583694537/f

Currently the Convert link just goes to the Show page for the Source File, and you have to click another button to go to the Data Import upload page. This change has the Convert link take you directly to the Data Import upload page.

<img width="1384" alt="Screen Shot 2023-04-20 at 4 29 01 PM" src="https://user-images.githubusercontent.com/1938665/233507401-a52672ac-a13e-488b-a1aa-1579a072e177.png">
<img width="1135" alt="Screen Shot 2023-04-20 at 4 29 09 PM" src="https://user-images.githubusercontent.com/1938665/233507413-3330cda7-be55-4bd8-b9f7-3799c7f886f9.png">

