### PR TITLE
List no-sandbox option first for Watir error

### DIFF
--- a/app/jobs/scraper/watir_job.rb
+++ b/app/jobs/scraper/watir_job.rb
@@ -7,7 +7,7 @@ class Scraper::WatirJob < ApplicationJob
     end
 
     options = {
-      args: %w[--headless --no-sandbox --disable-dev-shm-usage --disable-gpu]
+      args: %w[--no-sandbox --headless --disable-dev-shm-usage --disable-gpu]
     }
     if (chrome_bin = ENV.fetch("GOOGLE_CHROME_SHIM", nil))
       options[:binary] = chrome_bin


### PR DESCRIPTION
On Rollbar, we are seeing [errors](https://rollbar.com/apprenticeship-standards-dot-o/apprenticeship-standards-dot-o/items/86/):

```
Selenium::WebDriver::Error::UnknownError:
unknown error: Chrome failed to start: crashed.
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /app/.apt/usr/bin/google-chrome-stable is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

Trying out this solution from [SO](https://stackoverflow.com/a/54638309/1753903).
