### PR TITLE
Add converter role and fix admin user creation

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -13,6 +13,7 @@ class UserDashboard < Administrate::BaseDashboard
     current_sign_in_at: Field::DateTime,
     current_sign_in_ip: Field::String,
     email: Field::String,
+    password: Field::Password,
     encrypted_password: Field::String,
     last_sign_in_at: Field::DateTime,
     last_sign_in_ip: Field::String,
@@ -65,6 +66,7 @@ class UserDashboard < Administrate::BaseDashboard
     name
     email
     role
+    password
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
     :recoverable, :rememberable, :validatable,
     :trackable
 
-  enum :role, [:basic, :admin]
+  enum :role, {basic: 0, admin: 1, converter: 2}
 
   has_many :api_keys, dependent: :destroy
 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,46 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name, singular: true)
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes(controller.action_name).each do |attribute| -%>
+    <% next if attribute.attribute == :password && page.resource.persisted? %>
+    <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+      <%= render_field attribute, f: f %>
+    </div>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204452198889943/f

This adds a Converter role and modifies the admin User form to allow setting a password when creating a user. The password field is absent when editing a user so other fields can be updated. We should add a separate action for updating a user's password.

<img width="1169" alt="Screen Shot 2023-04-23 at 12 02 02 PM" src="https://user-images.githubusercontent.com/1938665/233859641-40904e42-8649-4c71-9386-b4b5099f803b.png">

<img width="1120" alt="Screen Shot 2023-04-23 at 12 03 04 PM" src="https://user-images.githubusercontent.com/1938665/233859681-5070fede-673e-49d0-afb6-a8bb30c161b0.png">


