### PR TITLE
Do not set source file for data_imports#show action

### DIFF
--- a/app/controllers/admin/data_imports_controller.rb
+++ b/app/controllers/admin/data_imports_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class DataImportsController < Admin::ApplicationController
-    before_action :set_source_file
+    before_action :set_source_file, except: [:show]
 
     def new
       resource = new_resource


### PR DESCRIPTION
When the row itself is clicked, Administrate
links to the admin_data_imports_path,
rather than the nested resource, causing an error. 
Since the source_file instance is not necessary
for correctly displaying the data_imports#show
page, this skips setting it.

Asana ticket: https://app.asana.com/0/1203289004376659/1204471974619399/f

Clicking on the filename itself brings you to the source_files_data_import nested route:
<img width="1649" alt="Screen Shot 2023-04-25 at 10 50 04 AM" src="https://user-images.githubusercontent.com/1938665/234361059-479d2a5a-65a6-40b6-b304-c3701f3d6439.png">

but clicking on the interstitial area brings you to the data_import non-nested route:
<img width="942" alt="Screen Shot 2023-04-25 at 10 50 35 AM" src="https://user-images.githubusercontent.com/1938665/234361052-cb3983f3-5355-46bb-97b3-c164a6e7376a.png">


