### PR TITLE
Add source_file to data_imports#show page

### DIFF
--- a/app/dashboards/data_import_dashboard.rb
+++ b/app/dashboards/data_import_dashboard.rb
@@ -21,6 +21,7 @@ class DataImportDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     description
     file
+    source_file
     occupation_standard
   ].freeze
 


### PR DESCRIPTION
In trying to debug some of the import errors, it is going to be easiest to hand over the `admin/data_imports#show` page, and it will be helpful to have the associated `source_file` linked.
