### PR TITLE
Mark source_file as not searchable in admin/occupation_standards search

### DIFF
--- a/app/dashboards/occupation_standard_dashboard.rb
+++ b/app/dashboards/occupation_standard_dashboard.rb
@@ -20,7 +20,7 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
     related_instructions: Field::HasMany,
     rsi_hours_max: Field::Number,
     rsi_hours_min: Field::Number,
-    source_file: Field::String,
+    source_file: Field::String.with_options(searchable: false),
     status: EnumField,
     term_months: Field::Number,
     title: Field::String,

--- a/spec/requests/admin/occupation_standards_spec.rb
+++ b/spec/requests/admin/occupation_standards_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe "Admin::OccupationStandard", type: :request do
 
           expect(response).to be_successful
         end
+
+        it "can search" do
+          admin = create(:admin)
+
+          sign_in admin
+          get admin_occupation_standards_path(search: "foo")
+
+          expect(response).to be_successful
+        end
       end
 
       context "when converter" do


### PR DESCRIPTION
Getting 500 error when searching in occupation standards
