### PR TITLE
Update importer to handle Apprenticeship::HourOccupation notation

### DIFF
--- a/app/services/import_occupation_standard_details.rb
+++ b/app/services/import_occupation_standard_details.rb
@@ -74,7 +74,7 @@ class ImportOccupationStandardDetails
     case row["Type"]
     when /competency/i
       :competency
-    when /time/i
+    when /time|hour/i
       :time
     when /hybrid/i
       :hybrid


### PR DESCRIPTION
Updates importer to handle Apprenticeship::HourOccupation notation for time-based standards.

Asana ticket: https://app.asana.com/0/1203289004376659/1204532764328555/f
