### PR TITLE
Add data_import status to source_file#show page

### DIFF
--- a/app/dashboards/data_import_dashboard.rb
+++ b/app/dashboards/data_import_dashboard.rb
@@ -9,12 +9,14 @@ class DataImportDashboard < Administrate::BaseDashboard
     occupation_standard: Field::BelongsTo,
     occupation_standard_title: Field::String,
     source_file: Field::BelongsTo,
+    status: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[
     filename
+    status
     occupation_standard
   ].freeze
 
@@ -23,6 +25,8 @@ class DataImportDashboard < Administrate::BaseDashboard
     file
     source_file
     occupation_standard
+    created_at
+    updated_at
   ].freeze
 
   FORM_ATTRIBUTES = %i[


### PR DESCRIPTION
The converters who are uploading data imports
for each source file need more insight into
the status of the previously uploaded
data_import records. This also adds
the created_at and updated_at timestamps
to the admin/data_imports#show page.

Asana ticket: https://app.asana.com/0/1203289004376659/1204504222387376/f

<img width="1422" alt="Screen Shot 2023-05-09 at 11 35 26 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/fc360f44-5f10-43ee-a82e-fb3ea0f83c08">
<img width="1044" alt="Screen Shot 2023-05-09 at 11 35 46 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/2869c5fe-2d48-4941-8f02-a35cbd8fc25f">

