### PR TITLE
Overwrite existing occupation standard with same title if new data_import is uploaded

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -22,11 +22,11 @@ class DataImport < ApplicationRecord
   ]
 
   def related_occupation_standard(title)
-    source_file
-      .data_imports
-      .where.not(id: id)
-      .detect{|di| di.occupation_standard.title == title}
-      &.occupation_standard
+    OccupationStandard
+      .joins(data_imports: :source_file)
+      .where.not(data_imports: {id: id})
+      .where(source_files: {id: source_file_id})
+      .first
   end
 
   private

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -21,6 +21,14 @@ class DataImport < ApplicationRecord
     text/csv
   ]
 
+  def related_occupation_standard(title)
+    source_file
+      .data_imports
+      .where.not(id: id)
+      .detect{|di| di.occupation_standard.title == title}
+      &.occupation_standard
+  end
+
   private
 
   def file_presence

--- a/app/services/import_occupation_standard_details.rb
+++ b/app/services/import_occupation_standard_details.rb
@@ -12,7 +12,7 @@ class ImportOccupationStandardDetails
       sheet = xlsx.sheet(0)
 
       @row = sheet.parse(headers: true)[1]
-      occupation_standard = data_import.occupation_standard || data_import.build_occupation_standard
+      occupation_standard = build_or_retrieve_occupation_standard
 
       remove_existing_associations(occupation_standard)
 
@@ -43,6 +43,18 @@ class ImportOccupationStandardDetails
   end
 
   private
+
+  def build_or_retrieve_occupation_standard
+    standard = data_import.occupation_standard ||
+      data_import.source_file.data_imports.where.not(id: data_import.id).first&.occupation_standard ||
+      data_import.build_occupation_standard
+
+    unless standard.data_imports.include?(data_import)
+      standard.data_imports << data_import
+    end
+
+    standard
+  end
 
   def registration_agency
     state = State.find_by(abbreviation: row["Registration State"])

--- a/app/services/import_occupation_standard_details.rb
+++ b/app/services/import_occupation_standard_details.rb
@@ -46,11 +46,7 @@ class ImportOccupationStandardDetails
 
   def build_or_retrieve_occupation_standard
     standard = data_import.occupation_standard ||
-      data_import
-        .source_file
-        .data_imports
-        .where.not(id: data_import.id)
-      .detect{|di| di.occupation_standard.title == row["Occupation Title"]}&.occupation_standard ||
+      data_import.related_occupation_standard(row["Occupation Title"]) ||
       data_import.build_occupation_standard
 
     if standard.persisted? && standard.data_imports.exclude?(data_import)

--- a/app/services/import_occupation_standard_details.rb
+++ b/app/services/import_occupation_standard_details.rb
@@ -13,6 +13,7 @@ class ImportOccupationStandardDetails
 
       @row = sheet.parse(headers: true)[1]
       occupation_standard = build_or_retrieve_occupation_standard
+      data_import.occupation_standard = occupation_standard
 
       remove_existing_associations(occupation_standard)
 
@@ -45,15 +46,9 @@ class ImportOccupationStandardDetails
   private
 
   def build_or_retrieve_occupation_standard
-    standard = data_import.occupation_standard ||
+    data_import.occupation_standard ||
       data_import.related_occupation_standard(row["Occupation Title"]) ||
       data_import.build_occupation_standard
-
-    if standard.persisted? && standard.data_imports.exclude?(data_import)
-      standard.data_imports << data_import
-    end
-
-    standard
   end
 
   def registration_agency

--- a/app/services/import_occupation_standard_details.rb
+++ b/app/services/import_occupation_standard_details.rb
@@ -46,10 +46,14 @@ class ImportOccupationStandardDetails
 
   def build_or_retrieve_occupation_standard
     standard = data_import.occupation_standard ||
-      data_import.source_file.data_imports.where.not(id: data_import.id).first&.occupation_standard ||
+      data_import
+        .source_file
+        .data_imports
+        .where.not(id: data_import.id)
+      .detect{|di| di.occupation_standard.title == row["Occupation Title"]}&.occupation_standard ||
       data_import.build_occupation_standard
 
-    unless standard.data_imports.include?(data_import)
+    if standard.persisted? && standard.data_imports.exclude?(data_import)
       standard.data_imports << data_import
     end
 

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -31,16 +31,19 @@ RSpec.describe DataImport, type: :model do
 
   describe "#related_occupation_standard" do
     it "returns occupation standard linked to same source file with same name" do
-      os = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
-      data_import1 = create(:data_import, occupation_standard: os)
+      os_original = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
+      data_import_with_some_errors = create(:data_import, occupation_standard: os_original)
+      source_file = data_import_with_some_errors.source_file
 
-      os_other = create(:occupation_standard, title: "NOT HUMAN RESOURCE SPECIALIST")
-      _data_import2 = create(:data_import, occupation_standard: os_other, source_file: data_import1.source_file)
+      os_from_same_source_file = create(:occupation_standard, title: "NOT HUMAN RESOURCE SPECIALIST")
+      _data_import_from_same_source_file = create(:data_import, occupation_standard: os_from_same_source_file, source_file: source_file)
 
-      data_import3 = create(:data_import, occupation_standard: nil, source_file: data_import1.source_file)
+      os_from_a_different_source_file = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
+      create(:data_import, occupation_standard: os_from_a_different_source_file)
 
+      data_import_corrected = create(:data_import, occupation_standard: nil, source_file: source_file)
 
-      expect(data_import3.related_occupation_standard("HUMAN RESOURCE SPECIALIST")).to eq os
+      expect(data_import_corrected.related_occupation_standard("HUMAN RESOURCE SPECIALIST")).to eq os_original
     end
   end
 end

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -28,4 +28,19 @@ RSpec.describe DataImport, type: :model do
       expect(data_import).to_not be_valid
     end
   end
+
+  describe "#related_occupation_standard" do
+    it "returns occupation standard linked to same source file with same name" do
+      os = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
+      data_import1 = create(:data_import, occupation_standard: os)
+
+      os_other = create(:occupation_standard, title: "NOT HUMAN RESOURCE SPECIALIST")
+      _data_import2 = create(:data_import, occupation_standard: os_other, source_file: data_import1.source_file)
+
+      data_import3 = create(:data_import, occupation_standard: nil, source_file: data_import1.source_file)
+
+
+      expect(data_import3.related_occupation_standard("HUMAN RESOURCE SPECIALIST")).to eq os
+    end
+  end
 end

--- a/spec/services/import_occupation_standard_details_spec.rb
+++ b/spec/services/import_occupation_standard_details_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe ImportOccupationStandardDetails do
         expect(os.ojt_hours_max).to be_nil
         expect(os.rsi_hours_min).to be_nil
         expect(os.rsi_hours_max).to be_nil
-    end
+      end
     end
 
     context "when data_import already has an occupation_standard associated" do

--- a/spec/services/import_occupation_standard_details_spec.rb
+++ b/spec/services/import_occupation_standard_details_spec.rb
@@ -236,5 +236,42 @@ RSpec.describe ImportOccupationStandardDetails do
         expect(os.rsi_hours_max).to be_nil
       end
     end
+
+    context "when occupation_standard exists from previously upload from source_file" do
+      it "updates the occupation standards record" do
+        ca = create(:state, abbreviation: "CA")
+        ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
+
+        create(:onet, code: "13-1071.01")
+        occupation = create(:occupation, rapids_code: "0157")
+
+        original_data_import = create(:data_import)
+        os = original_data_import.occupation_standard
+
+        new_data_import = create(:data_import, occupation_standard: nil, source_file: original_data_import.source_file)
+
+        expect {
+          described_class.new(new_data_import).call
+        }.to_not change(OccupationStandard, :count)
+
+        os.reload
+        expect(os.data_import).to eq new_data_import
+        expect(os.occupation).to eq occupation
+        expect(os.registration_agency).to eq ca_oa
+        expect(os.title).to eq "HUMAN RESOURCE SPECIALIST"
+        expect(os.existing_title).to eq "Career Development Technician"
+        expect(os.term_months).to eq 12
+        expect(os).to be_competency_based
+        expect(os.probationary_period_months).to eq 3
+        expect(os.onet_code).to eq "13-1071.01"
+        expect(os.rapids_code).to eq "0157"
+        expect(os.apprenticeship_to_journeyworker_ratio).to eq "5:1"
+        expect(os.organization_title).to eq "Hardy Corporation"
+        expect(os.ojt_hours_min).to be_nil
+        expect(os.ojt_hours_max).to be_nil
+        expect(os.rsi_hours_min).to be_nil
+        expect(os.rsi_hours_max).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/import_occupation_standard_details_spec.rb
+++ b/spec/services/import_occupation_standard_details_spec.rb
@@ -200,6 +200,44 @@ RSpec.describe ImportOccupationStandardDetails do
         os = OccupationStandard.last
         expect(os.onet_code).to be_nil
       end
+
+      it "finds and updates the occupation standard record linked to the same source file with the same name if one exists" do
+        ca = create(:state, abbreviation: "CA")
+        ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
+
+        create(:onet, code: "13-1071.01")
+        occupation = create(:occupation, rapids_code: "0157")
+
+        os = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
+        original_data_import = create(:data_import, occupation_standard: os)
+
+        os_other = create(:occupation_standard, title: "NOT HUMAN RESOURCE SPECIALIST")
+        create(:data_import, occupation_standard: os_other, source_file: original_data_import.source_file)
+
+        new_data_import = create(:data_import, occupation_standard: nil, source_file: original_data_import.source_file)
+
+        expect {
+          described_class.new(new_data_import).call
+        }.to_not change(OccupationStandard, :count)
+
+        os.reload
+        expect(os.data_import).to eq new_data_import
+        expect(os.occupation).to eq occupation
+        expect(os.registration_agency).to eq ca_oa
+        expect(os.title).to eq "HUMAN RESOURCE SPECIALIST"
+        expect(os.existing_title).to eq "Career Development Technician"
+        expect(os.term_months).to eq 12
+        expect(os).to be_competency_based
+        expect(os.probationary_period_months).to eq 3
+        expect(os.onet_code).to eq "13-1071.01"
+        expect(os.rapids_code).to eq "0157"
+        expect(os.apprenticeship_to_journeyworker_ratio).to eq "5:1"
+        expect(os.organization_title).to eq "Hardy Corporation"
+        expect(os.ojt_hours_min).to be_nil
+        expect(os.ojt_hours_max).to be_nil
+        expect(os.rsi_hours_min).to be_nil
+        expect(os.rsi_hours_max).to be_nil
+    end
     end
 
     context "when data_import already has an occupation_standard associated" do
@@ -219,43 +257,6 @@ RSpec.describe ImportOccupationStandardDetails do
 
         os.reload
         expect(os.data_import).to eq data_import
-        expect(os.occupation).to eq occupation
-        expect(os.registration_agency).to eq ca_oa
-        expect(os.title).to eq "HUMAN RESOURCE SPECIALIST"
-        expect(os.existing_title).to eq "Career Development Technician"
-        expect(os.term_months).to eq 12
-        expect(os).to be_competency_based
-        expect(os.probationary_period_months).to eq 3
-        expect(os.onet_code).to eq "13-1071.01"
-        expect(os.rapids_code).to eq "0157"
-        expect(os.apprenticeship_to_journeyworker_ratio).to eq "5:1"
-        expect(os.organization_title).to eq "Hardy Corporation"
-        expect(os.ojt_hours_min).to be_nil
-        expect(os.ojt_hours_max).to be_nil
-        expect(os.rsi_hours_min).to be_nil
-        expect(os.rsi_hours_max).to be_nil
-      end
-    end
-
-    context "when occupation_standard exists from previously upload from source_file" do
-      it "updates the occupation standards record" do
-        ca = create(:state, abbreviation: "CA")
-        ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
-
-        create(:onet, code: "13-1071.01")
-        occupation = create(:occupation, rapids_code: "0157")
-
-        original_data_import = create(:data_import)
-        os = original_data_import.occupation_standard
-
-        new_data_import = create(:data_import, occupation_standard: nil, source_file: original_data_import.source_file)
-
-        expect {
-          described_class.new(new_data_import).call
-        }.to_not change(OccupationStandard, :count)
-
-        os.reload
-        expect(os.data_import).to eq new_data_import
         expect(os.occupation).to eq occupation
         expect(os.registration_agency).to eq ca_oa
         expect(os.title).to eq "HUMAN RESOURCE SPECIALIST"


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204508571932551/f

When a new data import is processed it tries to find an existing occupation standard with the same source file and same title. If one cannot be found, then it will create a new occupation standard
