### PR TITLE
Destroy occupation_standard if no associated data_imports

### DIFF
--- a/app/controllers/admin/data_imports_controller.rb
+++ b/app/controllers/admin/data_imports_controller.rb
@@ -45,7 +45,12 @@ module Admin
     end
 
     def destroy
+      authorize(requested_resource)
       if requested_resource.destroy
+        occupation_standard = requested_resource.occupation_standard
+        if occupation_standard && occupation_standard.data_imports.empty?
+          occupation_standard.destroy!
+        end
         flash[:notice] = translate_with_resource("destroy.success")
       else
         flash[:error] = requested_resource.errors.full_messages.join("<br/>")


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204561933013232/f

Destroy occupation_standard if destroying data_import
leaves an occupation_standard with no data_imports