### PR TITLE
Add industry model and association to occupation standards

### DIFF
--- a/app/models/industry.rb
+++ b/app/models/industry.rb
@@ -1,4 +1,6 @@
 class Industry < ApplicationRecord
+  has_many :occupation_standards
+
   validates :name, :version, presence: true
   validates :prefix, presence: true, uniqueness: {scope: :version}
 end

--- a/app/models/industry.rb
+++ b/app/models/industry.rb
@@ -1,0 +1,3 @@
+class Industry < ApplicationRecord
+  validates :name, :version, :prefix, presence: true
+end

--- a/app/models/industry.rb
+++ b/app/models/industry.rb
@@ -1,4 +1,6 @@
 class Industry < ApplicationRecord
+  CURRENT_VERSION = "2018"
+
   has_many :occupation_standards
 
   validates :name, :version, presence: true

--- a/app/models/industry.rb
+++ b/app/models/industry.rb
@@ -1,3 +1,4 @@
 class Industry < ApplicationRecord
-  validates :name, :version, :prefix, presence: true
+  validates :name, :version, presence: true
+  validates :prefix, presence: true, uniqueness: {scope: :version}
 end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -2,6 +2,7 @@ class OccupationStandard < ApplicationRecord
   belongs_to :occupation, optional: true
   belongs_to :registration_agency, optional: true
   belongs_to :organization, optional: true
+  belongs_to :industry, optional: true
 
   has_many :data_imports
   has_many :related_instructions, -> { order(:sort_order) }, dependent: :destroy

--- a/app/services/import_occupation_standard_details.rb
+++ b/app/services/import_occupation_standard_details.rb
@@ -25,6 +25,7 @@ class ImportOccupationStandardDetails
         existing_title: row["Existing Title"],
         term_months: row["Term (in months)"],
         onet_code: onet_code,
+        industry: industry,
         rapids_code: rapids_code,
         ojt_type: ojt_type,
         probationary_period_months: row["Probationary Period"],
@@ -76,7 +77,16 @@ class ImportOccupationStandardDetails
   end
 
   def onet_code
-    row["Onet Code"].presence || occupation&.onet_code
+    @_onet_code ||= row["Onet Code"].presence || occupation&.onet_code
+  end
+
+  def industry
+    if onet_code
+      matches = onet_code.match(/\A(?<prefix>\d{2})/)
+      if matches
+        Industry.where(prefix: matches[:prefix], version: Industry::CURRENT_VERSION).sole
+      end
+    end
   end
 
   def ojt_type

--- a/db/migrate/20230517170559_create_industries.rb
+++ b/db/migrate/20230517170559_create_industries.rb
@@ -1,0 +1,11 @@
+class CreateIndustries < ActiveRecord::Migration[7.0]
+  def change
+    create_table :industries, id: :uuid do |t|
+      t.string :name
+      t.string :version
+      t.string :prefix
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230517222024_add_industry_id_to_occupation_standards.rb
+++ b/db/migrate/20230517222024_add_industry_id_to_occupation_standards.rb
@@ -1,0 +1,5 @@
+class AddIndustryIdToOccupationStandards < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :occupation_standards, :industry, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_17_170559) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_17_222024) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -126,6 +126,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_17_170559) do
     t.integer "national_standard_type"
     t.date "registration_date"
     t.date "latest_update_date"
+    t.uuid "industry_id"
+    t.index ["industry_id"], name: "index_occupation_standards_on_industry_id"
     t.index ["occupation_id"], name: "index_occupation_standards_on_occupation_id"
     t.index ["organization_id"], name: "index_occupation_standards_on_organization_id"
     t.index ["registration_agency_id"], name: "index_occupation_standards_on_registration_agency_id"
@@ -273,6 +275,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_17_170559) do
   add_foreign_key "data_imports", "occupation_standards"
   add_foreign_key "data_imports", "source_files"
   add_foreign_key "data_imports", "users"
+  add_foreign_key "occupation_standards", "industries"
   add_foreign_key "occupation_standards", "occupations"
   add_foreign_key "occupation_standards", "organizations"
   add_foreign_key "occupation_standards", "registration_agencies"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_15_180608) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_17_170559) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -93,6 +93,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_180608) do
     t.index ["occupation_standard_id"], name: "index_data_imports_on_occupation_standard_id"
     t.index ["source_file_id"], name: "index_data_imports_on_source_file_id"
     t.index ["user_id"], name: "index_data_imports_on_user_id"
+  end
+
+  create_table "industries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.string "version"
+    t.string "prefix"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "occupation_standards", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/deployment/20230517170839_populate_industries.rake
+++ b/lib/tasks/deployment/20230517170839_populate_industries.rake
@@ -1,0 +1,43 @@
+namespace :after_party do
+  desc "Deployment task: populate_industries"
+  task populate_industries: :environment do
+    puts "Running deploy task 'populate_industries'"
+
+    industries = [
+      ["11", "Management Occupations"],
+      ["13", "Business and Financial Operations Occupations"],
+      ["15", "Computer and Mathematical Occupations"],
+      ["17", "Architecture and Engineering Occupations"],
+      ["19", "Life, Physical, and Social Science Occupations"],
+      ["21", "Community and Social Service Occupations"],
+      ["23", "Legal Occupations"],
+      ["25", "Educational Instruction and Library Occupations"],
+      ["27", "Arts, Design, Entertainment, Sports, and Media Occupations"],
+      ["29", "Healthcare Practitioners and Technical Occupations"],
+      ["31", "Healthcare Support Occupations"],
+      ["33", "Protective Service Occupations"],
+      ["35", "Food Preparation and Serving Related Occupations"],
+      ["37", "Building and Grounds Cleaning and Maintenance Occupations"],
+      ["39", "Personal Care and Service Occupations"],
+      ["41", "Sales and Related Occupations"],
+      ["43", "Office and Administrative Support Occupations"],
+      ["45", "Farming, Fishing, and Forestry Occupations"],
+      ["47", "Construction and Extraction Occupations"],
+      ["49", "Installation, Maintenance, and Repair Occupations"],
+      ["51", "Production Occupations"],
+      ["53", "Transportation and Material Moving Occupations"],
+      ["55", "Military Specific Occupations"]
+    ]
+
+    industries.each do |prefix, name|
+      Rails.error.handle(context: {prefix: prefix, name: name}) do
+        Industry.create_with(name: name).find_or_create_by!(prefix: prefix, version: "2018")
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20230517222114_link_standards_to_industry.rake
+++ b/lib/tasks/deployment/20230517222114_link_standards_to_industry.rake
@@ -6,7 +6,7 @@ namespace :after_party do
     OccupationStandard.where("onet_code IS NOT NULL AND onet_code != ''").find_each do |standard|
       if (matches = standard.onet_code.match(/\A(?<prefix>\d{2})/))
         Rails.error.handle(context: {standard_id: standard.id}) do
-          industry = Industry.where(prefix: matches[:prefix], version: "2018").sole
+          industry = Industry.where(prefix: matches[:prefix], version: Industry::CURRENT_VERSION).sole
           standard.update_columns(industry_id: industry.id)
         end
       else

--- a/lib/tasks/deployment/20230517222114_link_standards_to_industry.rake
+++ b/lib/tasks/deployment/20230517222114_link_standards_to_industry.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc "Deployment task: link_standards_to_industry"
+  task link_standards_to_industry: :environment do
+    puts "Running deploy task 'link_standards_to_industry'"
+
+    OccupationStandard.where("onet_code IS NOT NULL AND onet_code != ''").find_each do |standard|
+      if (matches = standard.onet_code.match(/\A(?<prefix>\d{2})/))
+        Rails.error.handle(context: {standard_id: standard.id}) do
+          industry = Industry.where(prefix: matches[:prefix], version: "2018").sole
+          standard.update_columns(industry_id: industry.id)
+        end
+      else
+        Rails.error.report("Missing industry for standard", context: {standard_id: standard.id, onet_code: standard.onet_code}, handled: false)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/factories/industries.rb
+++ b/spec/factories/industries.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :industry do
     name { "Healthcare Support Occupations" }
-    version { "2018" }
+    version { Industry::CURRENT_VERSION }
     prefix { "31" }
   end
 end

--- a/spec/factories/industries.rb
+++ b/spec/factories/industries.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :industry do
+    name { "Healthcare Support Occupations" }
+    version { "2018" }
+    prefix { "31" }
+  end
+end

--- a/spec/jobs/process_data_import_job_spec.rb
+++ b/spec/jobs/process_data_import_job_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ProcessDataImportJob, type: :job do
       ca = create(:state, abbreviation: "CA")
       create(:registration_agency, state: ca, agency_type: :oa)
       data_import = create(:data_import, :pending)
+      create(:industry, prefix: "13")
 
       related_inst_mock = instance_double("ImportOccupationStandardRelatedInstruction")
       wage_schedule_mock = instance_double("ImportOccupationStandardWageSchedule")
@@ -43,6 +44,7 @@ RSpec.describe ProcessDataImportJob, type: :job do
       create(:wage_step, occupation_standard: occupation_standard, sort_order: 99)
       work_process = create(:work_process, occupation_standard: occupation_standard, sort_order: 99)
       create(:competency, work_process: work_process)
+      create(:industry, prefix: "13")
 
       described_class.new.perform(data_import: data_import)
 
@@ -59,6 +61,7 @@ RSpec.describe ProcessDataImportJob, type: :job do
       ca = create(:state, abbreviation: "CA")
       create(:registration_agency, state: ca, agency_type: :oa)
       data_import = create(:data_import, :pending)
+      create(:industry, prefix: "13")
 
       related_inst_mock = instance_double("ImportOccupationStandardRelatedInstruction")
       wage_schedule_mock = instance_double("ImportOccupationStandardWageSchedule")

--- a/spec/models/industry_spec.rb
+++ b/spec/models/industry_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Industry, type: :model do
+  it "has a valid factory" do
+    industry = build(:industry)
+
+    expect(industry).to be_valid
+  end
+end

--- a/spec/models/industry_spec.rb
+++ b/spec/models/industry_spec.rb
@@ -1,9 +1,18 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Industry, type: :model do
   it "has a valid factory" do
     industry = build(:industry)
 
+    expect(industry).to be_valid
+  end
+
+  it "is unique wrt prefix, version" do
+    create(:industry, prefix: "11", version: "2018")
+    industry = build(:industry, prefix: "11", version: "2018")
+
+    expect(industry).to_not be_valid
+    industry.version = "2022"
     expect(industry).to be_valid
   end
 end

--- a/spec/services/import_occupation_standard_details_spec.rb
+++ b/spec/services/import_occupation_standard_details_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ImportOccupationStandardDetails do
     it "returns an occupation standards record" do
       ca = create(:state, abbreviation: "CA")
       create(:registration_agency, state: ca, agency_type: :oa)
+      create(:industry, prefix: "13")
 
       data_import = create(:data_import, :pending)
 
@@ -18,6 +19,7 @@ RSpec.describe ImportOccupationStandardDetails do
         ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
         _ca_saa = create(:registration_agency, state: ca, agency_type: :saa)
         onet = create(:onet, code: "13-1071.01")
+        industry = create(:industry, prefix: "13")
 
         occupation1 = create(:occupation, rapids_code: "0157")
         _occupation2 = create(:occupation, onet: onet)
@@ -38,6 +40,7 @@ RSpec.describe ImportOccupationStandardDetails do
         expect(os).to be_competency_based
         expect(os.probationary_period_months).to eq 3
         expect(os.onet_code).to eq "13-1071.01"
+        expect(os.industry).to eq industry
         expect(os.rapids_code).to eq "0157"
         expect(os.apprenticeship_to_journeyworker_ratio).to eq "5:1"
         expect(os.organization_title).to eq "Hardy Corporation"
@@ -54,6 +57,7 @@ RSpec.describe ImportOccupationStandardDetails do
         ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
 
         create(:onet, code: "13-1071.01")
+        industry = create(:industry, prefix: "13")
         occupation = create(:occupation, rapids_code: "0157")
 
         data_import = create(:data_import, :hybrid, :pending)
@@ -72,6 +76,7 @@ RSpec.describe ImportOccupationStandardDetails do
         expect(os).to be_competency_based
         expect(os.probationary_period_months).to eq 3
         expect(os.onet_code).to eq "13-1071.01"
+        expect(os.industry).to eq industry
         expect(os.rapids_code).to eq "0157"
         expect(os.apprenticeship_to_journeyworker_ratio).to eq "5:1"
         expect(os.organization_title).to eq "Hardy Corporation"
@@ -86,6 +91,7 @@ RSpec.describe ImportOccupationStandardDetails do
         ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
 
         onet = create(:onet, code: "31-1071.01")
+        industry = create(:industry, prefix: "31")
         occupation = create(:occupation, onet: onet)
 
         data_import = create(:data_import, :no_rapids, :pending)
@@ -104,6 +110,7 @@ RSpec.describe ImportOccupationStandardDetails do
         expect(os).to be_time_based
         expect(os.probationary_period_months).to eq 7
         expect(os.onet_code).to eq "31-1071.01"
+        expect(os.industry).to eq industry
         expect(os.rapids_code).to be_nil
         expect(os.apprenticeship_to_journeyworker_ratio).to eq "5:1"
         expect(os.organization_title).to eq "Hardy Corporation"
@@ -116,6 +123,7 @@ RSpec.describe ImportOccupationStandardDetails do
       it "sets national standard type when no registration agency" do
         occupation = create(:occupation, rapids_code: "0157")
         data_import = create(:data_import, :national_program_standard, :pending)
+        industry = create(:industry, prefix: "13")
 
         expect {
           described_class.new(data_import).call
@@ -132,6 +140,7 @@ RSpec.describe ImportOccupationStandardDetails do
         expect(os).to be_competency_based
         expect(os.probationary_period_months).to eq 3
         expect(os.onet_code).to eq "13-1071.01"
+        expect(os.industry).to eq industry
         expect(os.rapids_code).to eq "0157"
         expect(os.apprenticeship_to_journeyworker_ratio).to eq "5:1"
         expect(os.organization_title).to eq "Hardy Corporation"
@@ -146,6 +155,7 @@ RSpec.describe ImportOccupationStandardDetails do
         create(:registration_agency, state: ca, agency_type: :oa)
 
         onet = create(:onet, code: "31-1071.01")
+        create(:industry, prefix: "31")
         create(:occupation, onet: onet, rapids_code: "8765")
 
         data_import = create(:data_import, :no_rapids, :pending)
@@ -161,6 +171,7 @@ RSpec.describe ImportOccupationStandardDetails do
       it "does not set RAPIDS code if blank and occupation does not exist" do
         ca = create(:state, abbreviation: "CA")
         create(:registration_agency, state: ca, agency_type: :oa)
+        create(:industry, prefix: "31")
 
         data_import = create(:data_import, :no_rapids, :pending)
 
@@ -177,6 +188,7 @@ RSpec.describe ImportOccupationStandardDetails do
         create(:registration_agency, state: ca, agency_type: :oa)
 
         onet = create(:onet, code: "13-1081.01")
+        create(:industry, prefix: "13")
         create(:occupation, onet: onet, rapids_code: "1057")
 
         data_import = create(:data_import, :no_onet, :pending)
@@ -208,6 +220,7 @@ RSpec.describe ImportOccupationStandardDetails do
         ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
 
         create(:onet, code: "13-1071.01")
+        industry = create(:industry, prefix: "13")
         occupation = create(:occupation, rapids_code: "0157")
 
         os = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
@@ -232,6 +245,7 @@ RSpec.describe ImportOccupationStandardDetails do
         expect(os).to be_competency_based
         expect(os.probationary_period_months).to eq 3
         expect(os.onet_code).to eq "13-1071.01"
+        expect(os.industry).to eq industry
         expect(os.rapids_code).to eq "0157"
         expect(os.apprenticeship_to_journeyworker_ratio).to eq "5:1"
         expect(os.organization_title).to eq "Hardy Corporation"
@@ -248,6 +262,7 @@ RSpec.describe ImportOccupationStandardDetails do
         ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
 
         create(:onet, code: "13-1071.01")
+        industry = create(:industry, prefix: "13")
         occupation = create(:occupation, rapids_code: "0157")
 
         data_import = create(:data_import)
@@ -267,6 +282,7 @@ RSpec.describe ImportOccupationStandardDetails do
         expect(os).to be_competency_based
         expect(os.probationary_period_months).to eq 3
         expect(os.onet_code).to eq "13-1071.01"
+        expect(os.industry).to eq industry
         expect(os.rapids_code).to eq "0157"
         expect(os.apprenticeship_to_journeyworker_ratio).to eq "5:1"
         expect(os.organization_title).to eq "Hardy Corporation"


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204546181205113/f

This PR is a precursor to displaying the Occupation Standards by Industry. This adds an industry model, and links occupation standards to an industry based on the first two digits of the ONET code.
