### PR TITLE
Stub industries page

### DIFF
--- a/app/controllers/industries_controller.rb
+++ b/app/controllers/industries_controller.rb
@@ -1,0 +1,5 @@
+class IndustriesController < ApplicationController
+  def index
+    @industries = Industry.current.order(:name)
+  end
+end

--- a/app/models/industry.rb
+++ b/app/models/industry.rb
@@ -5,4 +5,6 @@ class Industry < ApplicationRecord
 
   validates :name, :version, presence: true
   validates :prefix, presence: true, uniqueness: {scope: :version}
+
+  scope :current, -> { where(version: CURRENT_VERSION) }
 end

--- a/app/views/industries/index.html.erb
+++ b/app/views/industries/index.html.erb
@@ -1,0 +1,5 @@
+<% @industries.each do |industry| %>
+  <div>
+    <%= link_to industry.name, occupation_standards_path(q: "#{industry.prefix}-") %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   end
   resources :standards_imports, only: [:new, :create, :show]
   resources :occupation_standards, only: [:index, :show]
+  resources :industries, only: [:index]
   get "home", as: :home_page, to: "pages#home"
   get "about", as: :about_page, to: "pages#about"
   get "definitions", as: :definitions_page, to: "pages#definitions"

--- a/spec/factories/industries.rb
+++ b/spec/factories/industries.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :industry do
     name { "Healthcare Support Occupations" }
     version { Industry::CURRENT_VERSION }
-    prefix { "31" }
+    sequence(:prefix) { |n| n.to_s }
   end
 end

--- a/spec/requests/industries_spec.rb
+++ b/spec/requests/industries_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Industry", type: :request do
+  describe "GET /index" do
+    context "when guest" do
+      it "returns http success" do
+        create_pair(:industry)
+
+        get industries_path
+
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/system/industries/index_spec.rb
+++ b/spec/system/industries/index_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "industries/index" do
+  it "displays industry names" do
+    create(:industry, name: "Health", prefix: "39")
+    create(:industry, name: "Business", prefix: "41")
+
+    visit industries_path
+
+    expect(page).to have_link "Health", href: occupation_standards_path(q: "39-")
+    expect(page).to have_link "Business", href: occupation_standards_path(q: "41-")
+  end
+end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204546181205113/f

This adds a route for an Industry page, and displays an unstyled page of industries. When the links are clicked, currently it searches on the ONET code. This will be updated in the future so that we can search on the actual industry id.

<img width="530" alt="Screen Shot 2023-05-18 at 7 24 31 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/9b528f4d-332e-4f50-9787-2d67febca548">
<img width="1399" alt="Screen Shot 2023-05-18 at 7 24 42 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/abe8be8a-1756-49ed-b8cd-ec9da07d1d9e">

