### PR TITLE
Show occupation standard 'Download Working Copy' button

### DIFF
--- a/app/views/occupation_standards/show.html.erb
+++ b/app/views/occupation_standards/show.html.erb
@@ -130,7 +130,7 @@
                         <% else %>
                           <p class="text-white">No documents available at this time</p>
                         <% end %>
-                        <%= link_to occupation_standard_path(@occupation_standard, format: :docx), class: "hidden" do %>
+                        <%= link_to occupation_standard_path(@occupation_standard, format: :docx) do %>
                           <button class="flex w-full items-center space-x-4 rounded bg-slate-700 p-2 text-left text-white hover:bg-slate-600">
                             <div>
                                 <svg aria-label="download icon" xmlns="http://www.w3.org/2000/svg" width="49" height="48" fill="none">


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204546181205130/f

On previous PR, we added the feature to download a working copy of occupation standards, but the button to access it was added hidden until we had validated that the downloads would be working correctly. 

## Screenshot

![Screenshot 2023-05-18 at 14 26 48](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/14362964/edbb664d-8584-4d68-8ff2-ff0a07779a9b)

