### PR TITLE
Show skills count and OJT hours based on occupation standard type

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -103,9 +103,13 @@ class OccupationStandard < ApplicationRecord
   end
 
   def work_processes_hours
-    maximum_hours = work_processes.uniq(&:title).pluck(:maximum_hours).compact.sum
-    minimum_hours = work_processes.uniq(&:title).pluck(:minimum_hours).compact.sum
-    ([maximum_hours, minimum_hours] - [0]).first
+    if competency_based?
+      0
+    else
+      maximum_hours = work_processes.uniq(&:title).pluck(:maximum_hours).compact.sum
+      minimum_hours = work_processes.uniq(&:title).pluck(:minimum_hours).compact.sum
+      ([maximum_hours, minimum_hours] - [0]).first
+    end
   end
 
   def related_instructions_hours

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -87,7 +87,11 @@ class OccupationStandard < ApplicationRecord
   end
 
   def competencies_count
-    Competency.joins(work_process: :occupation_standard).where(occupation_standards: {id: id}).count
+    if time_based?
+      0
+    else
+      Competency.joins(work_process: :occupation_standard).where(occupation_standards: {id: id}).count
+    end
   end
 
   def rsi_hours

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -108,7 +108,7 @@ class OccupationStandard < ApplicationRecord
     else
       maximum_hours = work_processes.uniq(&:title).pluck(:maximum_hours).compact.sum
       minimum_hours = work_processes.uniq(&:title).pluck(:minimum_hours).compact.sum
-      ([maximum_hours, minimum_hours] - [0]).first
+      ([maximum_hours, minimum_hours] - [0]).first || 0
     end
   end
 

--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -99,7 +99,7 @@
                                 <div class="text-sm font-bold text-yonder-600">Skills</div>
                             </div>
                         <% end %>
-                        <% if occupation_standard.work_processes_hours.present? %>
+                        <% if occupation_standard.work_processes_hours.positive? %>
                             <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center">
                                 <div class="text-3xl font-bold text-rust-800">
                                     <%= hours_in_human_format(occupation_standard.work_processes_hours) %>

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -205,6 +205,14 @@ RSpec.describe OccupationStandard, type: :model do
 
       expect(occupation_standard.competencies_count).to eq 3
     end
+
+    it "is 0 if standard is time-based" do
+      occupation_standard = create(:occupation_standard, :time)
+      wp = create(:work_process, occupation_standard: occupation_standard)
+      create(:competency, work_process: wp)
+
+      expect(occupation_standard.competencies_count).to eq 0
+    end
   end
 
   describe "#rsi_hours" do

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -272,12 +272,12 @@ RSpec.describe OccupationStandard, type: :model do
       expect(occupation_standard.work_processes_hours).to eq 800
     end
 
-    it "returns nil if maximum hours and minimum hours are not present" do
+    it "returns 0 if maximum hours and minimum hours are not present" do
       occupation_standard = create(:occupation_standard)
       create(:work_process, occupation_standard: occupation_standard, maximum_hours: nil, minimum_hours: nil)
       create(:work_process, occupation_standard: occupation_standard, maximum_hours: nil, minimum_hours: nil)
 
-      expect(occupation_standard.work_processes_hours).to eq nil
+      expect(occupation_standard.work_processes_hours).to eq 0
     end
 
     it "sums only one work process with the same title" do

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -288,6 +288,14 @@ RSpec.describe OccupationStandard, type: :model do
 
       expect(occupation_standard.work_processes_hours).to eq 2000
     end
+
+    it "returns 0 for competency-based standard" do
+      occupation_standard = create(:occupation_standard, :competency)
+      create(:work_process, occupation_standard: occupation_standard, maximum_hours: 1000, minimum_hours: 400)
+
+      expect(occupation_standard.work_processes_hours).to eq 0
+    end
+
   end
 
   describe "#related_instructions_hours" do

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -295,7 +295,6 @@ RSpec.describe OccupationStandard, type: :model do
 
       expect(occupation_standard.work_processes_hours).to eq 0
     end
-
   end
 
   describe "#related_instructions_hours" do

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -11,6 +11,42 @@ RSpec.describe "occupation_standards/index" do
     expect(page).to have_link "Pipe Fitter", href: occupation_standard_path(pipe_fitter)
   end
 
+  it "displays only OJT hours and not skills for time-based standards" do
+    mechanic = create(:occupation_standard, :time, :with_data_import, title: "Mechanic")
+    work_process = create(:work_process, occupation_standard: mechanic, maximum_hours: 200)
+    create(:competency, work_process: work_process)
+
+    visit occupation_standards_path
+
+    expect(page).to have_link "Mechanic", href: occupation_standard_path(mechanic)
+    expect(page).to have_text "OJT hours"
+    expect(page).to_not have_text "Skills"
+  end
+
+  it "displays only skills and not OJT hours for competency-based standards" do
+    mechanic = create(:occupation_standard, :competency, :with_data_import, title: "Mechanic")
+    work_process = create(:work_process, occupation_standard: mechanic, maximum_hours: 200)
+    create(:competency, work_process: work_process)
+
+    visit occupation_standards_path
+
+    expect(page).to have_link "Mechanic", href: occupation_standard_path(mechanic)
+    expect(page).to_not have_text "OJT hours"
+    expect(page).to have_text "Skills"
+  end
+
+  it "displays skills and OJT hours for hybrid-based standards" do
+    mechanic = create(:occupation_standard, :hybrid, :with_data_import, title: "Mechanic")
+    work_process = create(:work_process, occupation_standard: mechanic, maximum_hours: 200)
+    create(:competency, work_process: work_process)
+
+    visit occupation_standards_path
+
+    expect(page).to have_link "Mechanic", href: occupation_standard_path(mechanic)
+    expect(page).to have_text "OJT hours"
+    expect(page).to have_text "Skills"
+  end
+
   it "filters occupations based on search term" do
     dental = create(:occupation_standard, :with_data_import, title: "Dental Assistant")
     medical = create(:occupation_standard, :program_standard, :with_data_import, title: "Medical Assistant")


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204614576547725/f

Skills count should only be shown for Hybrid- and Competency-based standards.
OJT Hours should only be shown for Hybrid- and Time-based standards.

**Old view:**
<img width="1304" alt="Screen Shot 2023-05-18 at 9 49 09 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/9c1b66e4-6070-48b7-a1e2-1d990790192d">
<img width="1276" alt="Screen Shot 2023-05-18 at 11 03 38 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/b1c9532a-554f-4a2d-a696-6165511d8215">


**New view:**
<img width="1332" alt="Screen Shot 2023-05-18 at 10 53 04 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/8120bc28-30e0-4f21-a557-8873950bf003">
<img width="1294" alt="Screen Shot 2023-05-18 at 10 59 56 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/4a8d76ca-b383-4e97-a261-2cc3d4d4e5c7">



