### PR TITLE
Show only Urban institute in occupational frameworks

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -49,10 +49,15 @@ class OccupationStandard < ApplicationRecord
   end
 
   scope :by_national_standard_type, ->(standard_types) do
-    if standard_types.present? && standard_types == ["occupational_framework"]
-      occupational_framework_from_urban_institute
-    elsif standard_types.present?
-      where(national_standard_type: standard_types)
+    if standard_types.present?
+      types = [standard_types].flatten
+      occupational_framework = types.delete("occupational_framework")
+
+      query = where(national_standard_type: types)
+      if occupational_framework
+        query = query.or(occupational_framework_from_urban_institute)
+      end
+      query
     end
   end
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -49,9 +49,18 @@ class OccupationStandard < ApplicationRecord
   end
 
   scope :by_national_standard_type, ->(standard_types) do
-    if standard_types.present?
+    if standard_types.present? && standard_types == ["occupational_framework"]
+      occupational_framework_from_urban_institute
+    elsif standard_types.present?
       where(national_standard_type: standard_types)
     end
+  end
+
+  scope :occupational_framework_from_urban_institute, -> do
+    where(
+      national_standard_type: :occupational_framework,
+      organization: Organization.urban_institute
+    )
   end
 
   scope :by_ojt_type, ->(ojt_types) do

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -11,6 +11,6 @@ class Organization < ApplicationRecord
   end
 
   def self.urban_institute
-    @@urban_institute ||= Organization.find_by(title: "Urban Institute")
+    Organization.find_by(title: "Urban Institute")
   end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -45,7 +45,7 @@
             <svg aria-label="briefcase icon" class="w-5 h-5 text-primary-600 lg:w-6 lg:h-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M6 6V5a3 3 0 013-3h2a3 3 0 013 3v1h2a2 2 0 012 2v3.57A22.952 22.952 0 0110 13a22.95 22.95 0 01-8-1.43V8a2 2 0 012-2h2zm2-1a1 1 0 011-1h2a1 1 0 011 1v1H8V5zm1 5a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"></path><path d="M2 13.692V16a2 2 0 002 2h12a2 2 0 002-2v-2.308A24.974 24.974 0 0110 15c-2.796 0-5.487-.46-8-1.308z"></path></svg>
           </div>
           <h3 class="text-xl font-bold">Occupational Frameworks</h3>
-          <p class="font-bold text-seafoam-900"><%= OccupationStandard.national_occupational_framework.count %> Apprenticeships</p>
+          <p class="font-bold text-seafoam-900"><%= OccupationStandard.occupational_framework_from_urban_institute.count %> Apprenticeships</p>
         </div>
       <% end %>
       <%= link_to occupation_standards_path(state_id: washington_state.id), id: "washington" do %>

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -114,6 +114,33 @@ RSpec.describe OccupationStandard, type: :model do
       expect(described_class.by_national_standard_type("program_standard")).to contain_exactly(os1, os2)
     end
 
+    it "if only occupational_framework passed as string, returns Urban Institute standards only" do
+      org = create(:organization, title: "Urban Institute")
+      os1 = create(:occupation_standard, :occupational_framework, organization: org)
+      create(:occupation_standard, :occupational_framework)
+      create(:occupation_standard, :program_standard)
+
+      expect(described_class.by_national_standard_type("occupational_framework")).to contain_exactly(os1)
+    end
+
+    it "if only occupational_framework passed as array, returns Urban Institute standards only" do
+      org = create(:organization, title: "Urban Institute")
+      os1 = create(:occupation_standard, :occupational_framework, organization: org)
+      create(:occupation_standard, :occupational_framework)
+      create(:occupation_standard, :program_standard)
+
+      expect(described_class.by_national_standard_type(%w[occupational_framework])).to contain_exactly(os1)
+    end
+
+    it "never includes non-Urban occupational_framework standards" do
+      org = create(:organization, title: "Urban Institute")
+      os1 = create(:occupation_standard, :occupational_framework, organization: org)
+      os2 = create(:occupation_standard, :program_standard)
+      create(:occupation_standard, :occupational_framework)
+
+      expect(described_class.by_national_standard_type(%w[program_standard occupational_framework])).to contain_exactly(os1, os2)
+    end
+
     it "returns all records if empty string provided" do
       standards = create_pair(:occupation_standard, :program_standard)
 

--- a/spec/system/pages/home_spec.rb
+++ b/spec/system/pages/home_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "pages/home" do
       organization = Organization.urban_institute || create(:organization, title: "Urban Institute")
       mechanic = create(:occupation_standard, :with_data_import, :occupational_framework, title: "Mechanic", organization: organization)
       hr = create(:occupation_standard, :with_data_import, :occupational_framework, title: "HR", organization: organization)
+      create(:occupation_standard, :with_data_import, :occupational_framework, title: "Dental Assistant")
       create(:occupation_standard, :guideline_standard, title: "Pipe Fitter")
 
       visit home_page_path
@@ -62,6 +63,7 @@ RSpec.describe "pages/home" do
 
       expect(page).to have_link "Mechanic", href: occupation_standard_path(mechanic)
       expect(page).to have_link "HR", href: occupation_standard_path(hr)
+      expect(page).to_not have_link "Dental Assistant"
       expect(page).to_not have_link "Pipe Fitter"
     end
 

--- a/spec/system/pages/home_spec.rb
+++ b/spec/system/pages/home_spec.rb
@@ -46,8 +46,9 @@ RSpec.describe "pages/home" do
     it "displays Occupational Frameworks box" do
       allow(State).to receive(:find_by).and_return(build_stubbed(:state))
 
-      mechanic = create(:occupation_standard, :with_data_import, :occupational_framework, title: "Mechanic")
-      hr = create(:occupation_standard, :with_data_import, :occupational_framework, title: "HR")
+      organization = Organization.urban_institute || create(:organization, title: "Urban Institute")
+      mechanic = create(:occupation_standard, :with_data_import, :occupational_framework, title: "Mechanic", organization: organization)
+      hr = create(:occupation_standard, :with_data_import, :occupational_framework, title: "HR", organization: organization)
       create(:occupation_standard, :guideline_standard, title: "Pipe Fitter")
 
       visit home_page_path


### PR DESCRIPTION
This ensures that only Occupation Standards linked to Urban Institute and of type `occupational_framework` are considered to be standards with National Occupational Framework.
