### PR TITLE
Reorder State List and Break Columns Gracefully

### DIFF
--- a/app/views/states/index.html.erb
+++ b/app/views/states/index.html.erb
@@ -29,13 +29,13 @@
       <h3 class="font-bold text-2xl mt-4 mb-2">Browse by State</h3>
       <div>
 
-        <div class="grid grid-flow-row grid-cols-3">
+        <div class="md:columns-2 lg:columns-3">
             <% @names_by_letter.each do |letter, names| %>
             <div class="letter-group flex items-start py-4">
-                <div class="w-14 bg-seafoam-800 text-white uppercase font-bold text-xl text-center py-2 rounded">
+                <div class="flex-none w-14 bg-seafoam-800 text-white uppercase font-bold text-xl text-center py-2 rounded">
                 <%= letter.first %>
                 </div>
-                    <div class="px-4 flex-grow">
+                    <div class="break-inside-avoid-column px-4 flex-grow">
                     <% names.each do |name, id| %>
                         <%= link_to occupation_standards_path(state_id: id), class: "hover:font-bold" do %>
                             <span class="block"><%= name %></span>


### PR DESCRIPTION
This update prevents columns from splitting in the middle of a letter.

<img width="1320" alt="Screen Shot 2023-05-18 at 6 11 11 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/2006263/529cead6-e9ac-4d86-a50d-e51b5df4724c">
