### PR TITLE
Setup dependabot by including a dependabot.yml file

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,8 +2,4 @@ version: 2
 updates:
   - package-ecosystem: 'bundler'
     directory: '/'
-    schedule:
-      interval: 'weekly'
-      time: '08:00'
-      timezone: America/New_York
     open-pull-requests-limit: 3

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      time: '08:00'
+      timezone: America/New_York
+    open-pull-requests-limit: 3


### PR DESCRIPTION
There are a number of vulnerabilities with the current versions of our dependencies. Setting up dependabot will help us keep up to date with security patches and other dependency updates.  

Add a dependabot.yml configuration file. Up to 3 PRs will be opened by dependabot at once.