### PR TITLE
Do not display standards with no work processes on index page

### DIFF
--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -35,6 +35,7 @@
         <% end %>
 
         <% @occupation_standards.each do |occupation_standard| %>
+          <% next if occupation_standard.work_processes.empty? %>
         <div class="my-6 border border-primary-200 rounded-lg bg-white p-6 lg:mb-8">
             <div class="flex justify-between">
                 <div>

--- a/spec/factories/occupation_standards.rb
+++ b/spec/factories/occupation_standards.rb
@@ -8,6 +8,11 @@ FactoryBot.define do
     ojt_type { :hybrid }
     registration_agency
 
+    trait :with_wp_and_ri do
+      work_processes { build_list(:work_process, 1) }
+      related_instructions { build_list(:related_instruction, 1) }
+    end
+
     trait :state_standard do
       national_standard_type { nil }
     end

--- a/spec/requests/national_standards_spec.rb
+++ b/spec/requests/national_standards_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "NationalStandards", type: :request do
   describe "GET /index" do
     context "when guest" do
       it "returns http success" do
-        create_pair(:occupation_standard, :program_standard, :with_data_import)
+        create_pair(:occupation_standard, :with_wp_and_ri, :program_standard, :with_data_import)
 
         get national_standards_path
 

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "OccupationStandard", type: :request do
   describe "GET /index" do
     context "when guest" do
       it "returns http success" do
-        create_pair(:occupation_standard, :with_data_import)
+        create_pair(:occupation_standard, :with_wp_and_ri, :with_data_import)
 
         get occupation_standards_path
 

--- a/spec/system/national_standards/index_spec.rb
+++ b/spec/system/national_standards/index_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "national_standards/index" do
   it "displays national standards only" do
-    mechanic = create(:occupation_standard, :program_standard, :with_data_import, title: "Mechanic")
-    pipe_fitter = create(:occupation_standard, :guideline_standard, :with_data_import, title: "Pipe Fitter")
-    hr = create(:occupation_standard, :occupational_framework, :with_data_import, title: "HR")
-    create(:occupation_standard, :state_standard, :with_data_import, title: "Medical Assistant")
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :program_standard, :with_data_import, title: "Mechanic")
+    pipe_fitter = create(:occupation_standard, :with_wp_and_ri, :guideline_standard, :with_data_import, title: "Pipe Fitter")
+    hr = create(:occupation_standard, :with_wp_and_ri, :occupational_framework, :with_data_import, title: "HR")
+    create(:occupation_standard, :with_wp_and_ri, :state_standard, :with_data_import, title: "Medical Assistant")
 
     visit national_standards_path
 
@@ -16,10 +16,10 @@ RSpec.describe "national_standards/index" do
   end
 
   it "filters national standards based on search term" do
-    dental = create(:occupation_standard, :program_standard, :with_data_import, title: "Dental Assistant")
-    create(:occupation_standard, :guideline_standard, :with_data_import, title: "Pipe Fitter")
-    create(:occupation_standard, :occupational_framework, :with_data_import, title: "HR")
-    create(:occupation_standard, :state_standard, :with_data_import, title: "Medical Assistant")
+    dental = create(:occupation_standard, :with_wp_and_ri, :program_standard, :with_data_import, title: "Dental Assistant")
+    create(:occupation_standard, :with_wp_and_ri, :guideline_standard, :with_data_import, title: "Pipe Fitter")
+    create(:occupation_standard, :with_wp_and_ri, :occupational_framework, :with_data_import, title: "HR")
+    create(:occupation_standard, :with_wp_and_ri, :state_standard, :with_data_import, title: "Medical Assistant")
 
     visit national_standards_path
 

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "occupation_standards/index" do
   it "displays titles" do
-    mechanic = create(:occupation_standard, :with_data_import, title: "Mechanic")
-    pipe_fitter = create(:occupation_standard, :with_data_import, :program_standard, title: "Pipe Fitter")
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Mechanic")
+    pipe_fitter = create(:occupation_standard, :with_wp_and_ri, :with_data_import, :program_standard, title: "Pipe Fitter")
 
     visit occupation_standards_path
 
@@ -14,6 +14,7 @@ RSpec.describe "occupation_standards/index" do
   it "displays only OJT hours and not skills for time-based standards" do
     mechanic = create(:occupation_standard, :time, :with_data_import, title: "Mechanic")
     work_process = create(:work_process, occupation_standard: mechanic, maximum_hours: 200)
+    create(:related_instruction, occupation_standard: mechanic)
     create(:competency, work_process: work_process)
 
     visit occupation_standards_path
@@ -26,6 +27,7 @@ RSpec.describe "occupation_standards/index" do
   it "displays only skills and not OJT hours for competency-based standards" do
     mechanic = create(:occupation_standard, :competency, :with_data_import, title: "Mechanic")
     work_process = create(:work_process, occupation_standard: mechanic, maximum_hours: 200)
+    create(:related_instruction, occupation_standard: mechanic)
     create(:competency, work_process: work_process)
 
     visit occupation_standards_path
@@ -38,6 +40,7 @@ RSpec.describe "occupation_standards/index" do
   it "displays skills and OJT hours for hybrid-based standards" do
     mechanic = create(:occupation_standard, :hybrid, :with_data_import, title: "Mechanic")
     work_process = create(:work_process, occupation_standard: mechanic, maximum_hours: 200)
+    create(:related_instruction, occupation_standard: mechanic)
     create(:competency, work_process: work_process)
 
     visit occupation_standards_path
@@ -48,9 +51,9 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "filters occupations based on search term" do
-    dental = create(:occupation_standard, :with_data_import, title: "Dental Assistant")
-    medical = create(:occupation_standard, :program_standard, :with_data_import, title: "Medical Assistant")
-    create(:occupation_standard, :with_data_import, title: "Pipe Fitter")
+    dental = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Dental Assistant")
+    medical = create(:occupation_standard, :with_wp_and_ri, :program_standard, :with_data_import, title: "Medical Assistant")
+    create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Pipe Fitter")
 
     visit occupation_standards_path
 
@@ -67,9 +70,9 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "filters occupations based on rapids_code search term" do
-    mechanic = create(:occupation_standard, :with_data_import, title: "Mechanic", rapids_code: "1234")
-    pipe_fitter = create(:occupation_standard, :with_data_import, title: "Pipe Fitter", rapids_code: "1234CB")
-    create(:occupation_standard, :with_data_import, title: "HR", rapids_code: "9876")
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Mechanic", rapids_code: "1234")
+    pipe_fitter = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Pipe Fitter", rapids_code: "1234CB")
+    create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "HR", rapids_code: "9876")
 
     visit occupation_standards_path
 
@@ -86,9 +89,9 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "filters occupations based on onet_code search term" do
-    mechanic = create(:occupation_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
-    pipe_fitter = create(:occupation_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
-    create(:occupation_standard, :with_data_import, title: "HR", onet_code: "12.34")
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Mechanic", onet_code: "12.3456")
+    pipe_fitter = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
+    create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "HR", onet_code: "12.34")
 
     visit occupation_standards_path
 
@@ -107,9 +110,9 @@ RSpec.describe "occupation_standards/index" do
   it "filters occupations based on onet_code search term and state filter", :js do
     wa = create(:state, name: "Washington")
     ra = create(:registration_agency, state: wa)
-    mechanic = create(:occupation_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
-    create(:occupation_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
-    create(:occupation_standard, :with_data_import, title: "HR", onet_code: "12.34")
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
+    create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
+    create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "HR", onet_code: "12.34")
 
     visit occupation_standards_path
 
@@ -129,10 +132,10 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "filters occupations based on onet_code search term and national_standard_type filter", :js do
-    mechanic = create(:occupation_standard, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
-    medical_assistant = create(:occupation_standard, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
-    create(:occupation_standard, :guideline_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
-    create(:occupation_standard, :with_data_import, title: "HR", onet_code: "12.3456")
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
+    medical_assistant = create(:occupation_standard, :with_wp_and_ri, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
+    create(:occupation_standard, :with_wp_and_ri, :guideline_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
+    create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "HR", onet_code: "12.3456")
 
     visit occupation_standards_path
 
@@ -158,9 +161,9 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "filters occupations based on onet_code search term and ojt_type filter", :js do
-    mechanic = create(:occupation_standard, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
-    medical_assistant = create(:occupation_standard, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
-    create(:occupation_standard, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
+    medical_assistant = create(:occupation_standard, :with_wp_and_ri, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
+    create(:occupation_standard, :with_wp_and_ri, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
 
     visit occupation_standards_path
 
@@ -188,9 +191,9 @@ RSpec.describe "occupation_standards/index" do
   it "can clear form", :js do
     wa = create(:state, name: "Washington")
     ra = create(:registration_agency, state: wa)
-    mechanic = create(:occupation_standard, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
-    medical_assistant = create(:occupation_standard, :program_standard, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567", registration_agency: ra)
-    create(:occupation_standard, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
+    medical_assistant = create(:occupation_standard, :with_wp_and_ri, :program_standard, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567", registration_agency: ra)
+    create(:occupation_standard, :with_wp_and_ri, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
 
     visit occupation_standards_path
 
@@ -255,7 +258,7 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "shows registration date if available" do
-    create(:occupation_standard, :with_data_import, title: "Mechanic", registration_date: Date.parse("October 17, 1989"))
+    create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Mechanic", registration_date: Date.parse("October 17, 1989"))
 
     visit occupation_standards_path
 
@@ -263,7 +266,7 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "shows latest updated date if available" do
-    create(:occupation_standard, :with_data_import, title: "Mechanic", latest_update_date: Date.parse("October 17, 1989"))
+    create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Mechanic", latest_update_date: Date.parse("October 17, 1989"))
 
     visit occupation_standards_path
 

--- a/spec/system/pages/home_spec.rb
+++ b/spec/system/pages/home_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe "pages/home" do
   it "filters occupations based on search term" do
     allow(State).to receive(:find_by).and_return(build_stubbed(:state))
-    mechanic = create(:occupation_standard, :with_data_import, title: "Mechanic")
-    pipe_fitter = create(:occupation_standard, :with_data_import, title: "Pipe Fitter")
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Mechanic")
+    pipe_fitter = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Pipe Fitter")
 
     visit home_page_path
 
@@ -23,9 +23,9 @@ RSpec.describe "pages/home" do
   describe "featured section" do
     it "displays National Guidelines box" do
       allow(State).to receive(:find_by).and_return(build_stubbed(:state))
-      mechanic = create(:occupation_standard, :with_data_import, :guideline_standard, title: "Mechanic")
-      hr = create(:occupation_standard, :with_data_import, :guideline_standard, title: "HR")
-      create(:occupation_standard, :occupational_framework, title: "Pipe Fitter")
+      mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, :guideline_standard, title: "Mechanic")
+      hr = create(:occupation_standard, :with_wp_and_ri, :with_data_import, :guideline_standard, title: "HR")
+      create(:occupation_standard, :with_wp_and_ri, :occupational_framework, title: "Pipe Fitter")
 
       visit home_page_path
 
@@ -47,10 +47,10 @@ RSpec.describe "pages/home" do
       allow(State).to receive(:find_by).and_return(build_stubbed(:state))
 
       organization = Organization.urban_institute || create(:organization, title: "Urban Institute")
-      mechanic = create(:occupation_standard, :with_data_import, :occupational_framework, title: "Mechanic", organization: organization)
-      hr = create(:occupation_standard, :with_data_import, :occupational_framework, title: "HR", organization: organization)
-      create(:occupation_standard, :with_data_import, :occupational_framework, title: "Dental Assistant")
-      create(:occupation_standard, :guideline_standard, title: "Pipe Fitter")
+      mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, :occupational_framework, title: "Mechanic", organization: organization)
+      hr = create(:occupation_standard, :with_wp_and_ri, :with_data_import, :occupational_framework, title: "HR", organization: organization)
+      create(:occupation_standard, :with_wp_and_ri, :with_data_import, :occupational_framework, title: "Dental Assistant")
+      create(:occupation_standard, :with_wp_and_ri, :guideline_standard, title: "Pipe Fitter")
 
       visit home_page_path
 
@@ -76,9 +76,9 @@ RSpec.describe "pages/home" do
       allow(State).to receive(:find_by).with(name: "California").and_return(state)
 
       ra = create(:registration_agency, state: wa)
-      mechanic = create(:occupation_standard, :with_data_import, registration_agency: ra, title: "Mechanic")
-      hr = create(:occupation_standard, :with_data_import, registration_agency: ra, title: "HR")
-      create(:occupation_standard, title: "Pipe Fitter")
+      mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, registration_agency: ra, title: "Mechanic")
+      hr = create(:occupation_standard, :with_wp_and_ri, :with_data_import, registration_agency: ra, title: "HR")
+      create(:occupation_standard, :with_wp_and_ri, title: "Pipe Fitter")
 
       visit home_page_path
 
@@ -103,9 +103,9 @@ RSpec.describe "pages/home" do
       allow(State).to receive(:find_by).with(name: "California").and_return(state)
 
       ra = create(:registration_agency, state: ny)
-      mechanic = create(:occupation_standard, :with_data_import, registration_agency: ra, title: "Mechanic")
-      hr = create(:occupation_standard, :with_data_import, registration_agency: ra, title: "HR")
-      create(:occupation_standard, title: "Pipe Fitter")
+      mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, registration_agency: ra, title: "Mechanic")
+      hr = create(:occupation_standard, :with_wp_and_ri, :with_data_import, registration_agency: ra, title: "HR")
+      create(:occupation_standard, :with_wp_and_ri, title: "Pipe Fitter")
 
       visit home_page_path
 
@@ -130,9 +130,9 @@ RSpec.describe "pages/home" do
       allow(State).to receive(:find_by).with(name: "California").and_return(ca)
 
       ra = create(:registration_agency, state: ca)
-      mechanic = create(:occupation_standard, :with_data_import, registration_agency: ra, title: "Mechanic")
-      hr = create(:occupation_standard, :with_data_import, registration_agency: ra, title: "HR")
-      create(:occupation_standard, title: "Pipe Fitter")
+      mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, registration_agency: ra, title: "Mechanic")
+      hr = create(:occupation_standard, :with_wp_and_ri, :with_data_import, registration_agency: ra, title: "HR")
+      create(:occupation_standard, :with_wp_and_ri, title: "Pipe Fitter")
 
       visit home_page_path
 
@@ -157,9 +157,9 @@ RSpec.describe "pages/home" do
       allow(State).to receive(:find_by).with(name: "California").and_return(state)
 
       ra = create(:registration_agency, state: ore)
-      mechanic = create(:occupation_standard, :with_data_import, registration_agency: ra, title: "Mechanic")
-      hr = create(:occupation_standard, :with_data_import, registration_agency: ra, title: "HR")
-      create(:occupation_standard, title: "Pipe Fitter")
+      mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, registration_agency: ra, title: "Mechanic")
+      hr = create(:occupation_standard, :with_wp_and_ri, :with_data_import, registration_agency: ra, title: "HR")
+      create(:occupation_standard, :with_wp_and_ri, title: "Pipe Fitter")
 
       visit home_page_path
 
@@ -178,9 +178,9 @@ RSpec.describe "pages/home" do
     it "displays Installation etc. industry box" do
       allow(State).to receive(:find_by).and_return(build_stubbed(:state))
 
-      mechanic = create(:occupation_standard, :with_data_import, onet_code: "49-1234", title: "Mechanic")
-      hr = create(:occupation_standard, :with_data_import, onet_code: "49-5678", title: "HR")
-      create(:occupation_standard, onet_code: "35-1234", title: "Pipe Fitter")
+      mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, onet_code: "49-1234", title: "Mechanic")
+      hr = create(:occupation_standard, :with_wp_and_ri, :with_data_import, onet_code: "49-5678", title: "HR")
+      create(:occupation_standard, :with_wp_and_ri, onet_code: "35-1234", title: "Pipe Fitter")
 
       visit home_page_path
 
@@ -199,9 +199,9 @@ RSpec.describe "pages/home" do
     it "displays Healthcare Support industry box" do
       allow(State).to receive(:find_by).and_return(build_stubbed(:state))
 
-      mechanic = create(:occupation_standard, :with_data_import, onet_code: "31-1234", title: "Mechanic")
-      hr = create(:occupation_standard, :with_data_import, onet_code: "31-5678", title: "HR")
-      create(:occupation_standard, onet_code: "35-1234", title: "Pipe Fitter")
+      mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, onet_code: "31-1234", title: "Mechanic")
+      hr = create(:occupation_standard, :with_wp_and_ri, :with_data_import, onet_code: "31-5678", title: "HR")
+      create(:occupation_standard, :with_wp_and_ri, onet_code: "35-1234", title: "Pipe Fitter")
 
       visit home_page_path
 

--- a/spec/system/states/index_spec.rb
+++ b/spec/system/states/index_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "states/index" do
     wa_reg_agency = create(:registration_agency, state: wa)
     al_reg_agency = create(:registration_agency, state: al)
 
-    mechanic = create(:occupation_standard, :with_data_import, title: "Mechanic", registration_agency: wa_reg_agency)
-    create(:occupation_standard, :with_data_import, :program_standard, title: "Pipe Fitter", registration_agency: al_reg_agency)
+    mechanic = create(:occupation_standard, :with_wp_and_ri, :with_data_import, title: "Mechanic", registration_agency: wa_reg_agency)
+    create(:occupation_standard, :with_wp_and_ri, :with_data_import, :program_standard, title: "Pipe Fitter", registration_agency: al_reg_agency)
 
     visit states_path
 


### PR DESCRIPTION
This is overkill in the factory generation right now, but trying to get this out quickly for a demo. Will clean up afterwards.
