### PR TITLE
Update standards import mailer to go to Patrick

### DIFF
--- a/app/controllers/standards_imports_controller.rb
+++ b/app/controllers/standards_imports_controller.rb
@@ -10,6 +10,7 @@ class StandardsImportsController < ApplicationController
       if user_signed_in?
         redirect_to admin_source_files_path
       else
+        @standards_import.notify_admin
         redirect_to standards_import_path(@standards_import)
       end
     else

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -7,7 +7,7 @@ class AdminMailer < ApplicationMailer
   def new_standards_import(standards_import)
     @standards_import = standards_import
 
-    mail to: "jeanine@thoughtbot.com",
+    mail to: "patrick@workhands.us",
       subject: "New standards import uploaded"
   end
 end

--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -1,8 +1,6 @@
 class StandardsImport < ApplicationRecord
   has_many_attached :files
 
-  after_commit :notify_admin, on: :create
-
   def file_count
     files.count
   end
@@ -11,11 +9,7 @@ class StandardsImport < ApplicationRecord
     files&.last&.url
   end
 
-  private
-
   def notify_admin
-    if ENV.fetch("ENABLE_STANDARDS_IMPORTS_NOTIFICATIONS", "false") == "true"
-      AdminMailer.new_standards_import(self).deliver_later
-    end
+    AdminMailer.new_standards_import(self).deliver_later
   end
 end

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AdminMailer, type: :mailer do
       mail = AdminMailer.new_standards_import(si)
 
       expect(mail.subject).to eq("New standards import uploaded")
-      expect(mail.to).to eq(["jeanine@thoughtbot.com"])
+      expect(mail.to).to eq(["patrick@workhands.us"])
       expect(mail.from).to eq(["no-reply@apprenticeshipstandards.org"])
 
       mail.body.parts.each do |part|

--- a/spec/models/standards_import_spec.rb
+++ b/spec/models/standards_import_spec.rb
@@ -33,19 +33,14 @@ RSpec.describe StandardsImport, type: :model do
   end
 
   describe "#notify_admin" do
-    it "calls new_standards_import mailer on create but not update" do
-      stub_const "ENV", ENV.to_h.merge("ENABLE_STANDARDS_IMPORTS_NOTIFICATIONS" => "true")
+    it "calls new_standards_import mailer" do
       si = build(:standards_import)
 
       mailer = double("mailer", deliver_later: nil)
       expect(AdminMailer).to receive(:new_standards_import).and_return(mailer)
       expect(mailer).to receive(:deliver_later)
 
-      si.save!
-
-      expect(AdminMailer).to_not receive(:new_standards_import)
-
-      si.update!(name: "Minnie Mouse")
+      si.notify_admin
     end
   end
 end

--- a/spec/requests/standards_imports_spec.rb
+++ b/spec/requests/standards_imports_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe "StandardsImports", type: :request do
   describe "POST /create" do
     context "with valid parameters" do
       context "when guest" do
-        it "creates new standards import record and redirects to show page" do
+        it "creates new standards import record, redirects to show page, and notifies admin" do
+          expect_any_instance_of(StandardsImport).to receive(:notify_admin)
           expect {
             post standards_imports_path, params: {
               standards_import: {
@@ -38,10 +39,11 @@ RSpec.describe "StandardsImports", type: :request do
       end
 
       context "when admin", :admin do
-        it "creates new standards import record and redirects to source files page" do
+        it "creates new standards import record, redirects to source files page, and does not notify admin" do
           admin = create(:admin)
 
           sign_in admin
+          expect_any_instance_of(StandardsImport).to_not receive(:notify_admin)
           expect {
             post standards_imports_path, params: {
               standards_import: {


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204651892096307/f

This removes the code that would notify an admin
on every new standards import (created from
scrapers, guest page, or internal admin upload).
    
The converters are currently actively working
on the site and do not need to be notified when
new files are added through the scrapers. In the
future we can add a separate mailer that gets
triggered when the scrapers add files.
