### PR TITLE
Remove extraneous About text on Industries page

### DIFF
--- a/app/views/industries/index.html.erb
+++ b/app/views/industries/index.html.erb
@@ -25,7 +25,6 @@
 
 <section aria-labelledby="occupation-title" class="bg-seafoam-50">
     <div class="mx-auto max-w-screen-xl py-10 px-4 sm:py-16 lg:px-6">
-      <h3 class="font-bold text-2xl mt-4 mb-2">About</h3>
 
         <div class="md:columns-2 lg:columns-3">
 


### PR DESCRIPTION
Old:

<img width="843" alt="Screen Shot 2023-05-23 at 2 04 56 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/10fd5a53-36a8-460a-8f2d-5f208e27879a">

New:

<img width="800" alt="Screen Shot 2023-05-23 at 2 30 27 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/d2a47304-c8dd-43a6-a22c-0a91ae0693ea">

