### PR TITLE
Add a schedule to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,3 +3,7 @@ updates:
   - package-ecosystem: 'bundler'
     directory: '/'
     open-pull-requests-limit: 3
+    schedule:
+      interval: 'weekly'
+      time: '08:00'
+      timezone: America/New_York


### PR DESCRIPTION
We're getting a failure on dependabot github actions:

```
The property '#/updates/0' did not contain a required property of 'schedule'
```

I had previously removed it in an attempt that not adding a schedule would allow dependabot open PRs continuously, but a schedule property is required.