### PR TITLE
Do not index occupation standards after commit until versions conflict is fixed

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -34,10 +34,6 @@ class OccupationStandard < ApplicationRecord
     end
   end
 
-  after_commit on: [:create] do
-    __elasticsearch__.index_document
-  end
-
   scope :by_title, ->(title) do
     if title.present?
       where("title ILIKE ?", "%#{sanitize_sql_like(title).split.join("%")}%")


### PR DESCRIPTION
We're getting some notifications on Rollbar when trying to index documents: 

`The client noticed that the server is not a supported distribution of Elasticsearch.`

I'm not sure how to fix it yet, so I'm removing this after commit callback so we stop getting these erros until this problem with versions if fixed.