### PR TITLE
Downgrade elasticsearch gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "3.1.2"
 
 gem "bonsai-elasticsearch-rails", "~> 7"
-gem "elasticsearch-model", "< 7.14"
-gem "elasticsearch-rails", "< 7.14"
+gem "elasticsearch", "< 7.14"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,17 +158,17 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    elasticsearch (7.17.7)
-      elasticsearch-api (= 7.17.7)
-      elasticsearch-transport (= 7.17.7)
-    elasticsearch-api (7.17.7)
+    elasticsearch (7.13.3)
+      elasticsearch-api (= 7.13.3)
+      elasticsearch-transport (= 7.13.3)
+    elasticsearch-api (7.13.3)
       multi_json
     elasticsearch-model (7.2.1)
       activesupport (> 3)
       elasticsearch (~> 7)
       hashie
     elasticsearch-rails (7.2.1)
-    elasticsearch-transport (7.17.7)
+    elasticsearch-transport (7.13.3)
       faraday (~> 1)
       multi_json
     erb_lint (0.3.1)
@@ -487,8 +487,7 @@ DEPENDENCIES
   devise
   docx
   dotenv-rails
-  elasticsearch-model (< 7.14)
-  elasticsearch-rails (< 7.14)
+  elasticsearch (< 7.14)
   erb_lint
   erblint-github
   factory_bot_rails


### PR DESCRIPTION
When trying to import data into elasticsearch on our production instance, I got an error: Elasticsearch::UnsupportedProductError

Our current gem version and the Elasticsearch version used on Heroku are not compatible.

I've tried to set versions on the elasticsearch-model and elasticsearch-rails gems, but these didn't work, as they still keep using uncompatible versions. So I'm experimenting with installing the elasticsearch gem and setting it to a version lower than 7.14, which doesn't have compatibility issues.
