### PR TITLE
Run dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
     directory: '/'
     open-pull-requests-limit: 3
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
       time: '08:00'
       timezone: America/New_York


### PR DESCRIPTION
There are a number of dependencies outdated, so setting dependabot to run daily will help us fix them faster. 
AFAIK, there's no way to have them just get created in real-time as they come up, we have to setup a schedule that can be daily, weekly or monthly. 