### PR TITLE
Add Needs support button

### DIFF
--- a/app/dashboards/source_file_dashboard.rb
+++ b/app/dashboards/source_file_dashboard.rb
@@ -24,6 +24,7 @@ class SourceFileDashboard < Administrate::BaseDashboard
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[
+    status
     data_imports
     metadata
     organization

--- a/app/policies/source_file_policy.rb
+++ b/app/policies/source_file_policy.rb
@@ -23,7 +23,7 @@ class SourceFilePolicy < ApplicationPolicy
 
   def permitted_attributes
     if user.converter?
-      [:assignee_id]
+      [:assignee_id, :status]
     else
       [:metadata, :status, :assignee_id]
     end

--- a/app/policies/source_file_policy.rb
+++ b/app/policies/source_file_policy.rb
@@ -23,9 +23,9 @@ class SourceFilePolicy < ApplicationPolicy
 
   def permitted_attributes
     if user.converter?
-      [:assignee_id, :status]
+      [:status, :assignee_id]
     else
-      [:metadata, :status, :assignee_id]
+      [:status, :assignee_id, :metadata]
     end
   end
 end

--- a/app/views/admin/source_files/show.html.erb
+++ b/app/views/admin/source_files/show.html.erb
@@ -6,6 +6,19 @@
   </h1>
 
   <div>
+    <%= if current_user.converter?
+          button_to(
+            "Needs support",
+            admin_source_file_path(page.resource),
+            params: {
+              source_file: {status: "needs_support"},
+              redirect_back_to: admin_source_file_path(page.resource)
+            },
+            method: :patch,
+            class: "button",
+            form_class: "form-button"
+          )
+        end %>
     <%= link_to(
           "New data import",
           new_admin_source_file_data_import_path(page.resource),

--- a/spec/requests/admin/source_files_spec.rb
+++ b/spec/requests/admin/source_files_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Admin::SourceFiles", type: :request do
       end
 
       context "when converter" do
-        it "can update assignee only" do
+        it "can update assignee and status only" do
           assignee = create(:user, :converter)
           admin = create(:user, :converter)
           file = create(:source_file)
@@ -145,15 +145,17 @@ RSpec.describe "Admin::SourceFiles", type: :request do
           sign_in admin
           file_params = {
             source_file: {
-              status: "completed",
-              assignee_id: assignee.id
+              status: "needs_support",
+              assignee_id: assignee.id,
+              metadata: {foo: "bob"}.to_json
             }
           }
           patch admin_source_file_path(file), params: file_params
 
           file.reload
-          expect(file).to be_pending
+          expect(file).to be_needs_support
           expect(file.assignee).to eq assignee
+          expect(file.metadata).to be_empty
           expect(response).to redirect_to admin_source_files_path
         end
 

--- a/spec/system/admin/source_files/show_spec.rb
+++ b/spec/system/admin/source_files/show_spec.rb
@@ -22,5 +22,30 @@ RSpec.describe "admin/source_files/show", :admin do
     expect(page).to have_link "Edit", href: edit_admin_source_file_data_import_path(source_file, data_import2)
 
     expect(page).to have_link "New data import", href: new_admin_source_file_data_import_path(source_file)
+#    expect(page).to_not have_button "Need support"
+  end
+
+  it "has Need support button viewable for converters" do
+    converter = create(:user, :converter)
+    source_file = create(:source_file)
+
+    occupation_standard1 = create(:occupation_standard, title: "Mechanic")
+    data_import1 = create(:data_import, source_file: source_file, occupation_standard: occupation_standard1)
+
+    data_import2 = create(:data_import, :hybrid, source_file: source_file, occupation_standard: nil)
+
+    login_as converter
+    visit admin_source_file_path(source_file)
+
+    expect(page).to have_content "Show #{source_file.filename}"
+
+    expect(page).to_not have_link "Edit", href: edit_admin_source_file_data_import_path(source_file, data_import1)
+    expect(page).to have_link "occupation-standards-template.xlsx", href: admin_source_file_data_import_path(source_file, data_import1)
+    expect(page).to_not have_link "Mechanic", href: admin_occupation_standard_path(occupation_standard1)
+
+    expect(page).to_not have_link "Edit", href: edit_admin_source_file_data_import_path(source_file, data_import2)
+
+    expect(page).to have_link "New data import", href: new_admin_source_file_data_import_path(source_file)
+#    expect(page).to have_button "Need support"
   end
 end

--- a/spec/system/admin/source_files/show_spec.rb
+++ b/spec/system/admin/source_files/show_spec.rb
@@ -22,30 +22,35 @@ RSpec.describe "admin/source_files/show", :admin do
     expect(page).to have_link "Edit", href: edit_admin_source_file_data_import_path(source_file, data_import2)
 
     expect(page).to have_link "New data import", href: new_admin_source_file_data_import_path(source_file)
-#    expect(page).to_not have_button "Need support"
+    expect(page).to_not have_button "Needs support"
   end
 
-  it "has Need support button viewable for converters" do
+  it "has Needs support button viewable for converters" do
     converter = create(:user, :converter)
     source_file = create(:source_file)
 
     occupation_standard1 = create(:occupation_standard, title: "Mechanic")
     data_import1 = create(:data_import, source_file: source_file, occupation_standard: occupation_standard1)
 
-    data_import2 = create(:data_import, :hybrid, source_file: source_file, occupation_standard: nil)
-
     login_as converter
     visit admin_source_file_path(source_file)
 
     expect(page).to have_content "Show #{source_file.filename}"
 
+    within("dd", match: :first) do
+      expect(page).to have_text "Pending"
+    end
     expect(page).to_not have_link "Edit", href: edit_admin_source_file_data_import_path(source_file, data_import1)
     expect(page).to have_link "occupation-standards-template.xlsx", href: admin_source_file_data_import_path(source_file, data_import1)
     expect(page).to_not have_link "Mechanic", href: admin_occupation_standard_path(occupation_standard1)
 
-    expect(page).to_not have_link "Edit", href: edit_admin_source_file_data_import_path(source_file, data_import2)
-
     expect(page).to have_link "New data import", href: new_admin_source_file_data_import_path(source_file)
-#    expect(page).to have_button "Need support"
+    expect(page).to have_button "Needs support"
+
+    click_on "Needs support"
+
+    within("dd", match: :first) do
+      expect(page).to have_text "Needs Support"
+    end
   end
 end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204653711879360/f

There is a `needs_support` status for Source Files, but currently the converters don't have any way to actually set that status. This adds a button on the `source_files#show` page that a converter can click.


https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/9405517e-2573-4dfe-b4c8-4e2f2f8fe4fb


