### PR TITLE
Loosen subdomain matching of admin

### DIFF
--- a/app/lib/subdomain.rb
+++ b/app/lib/subdomain.rb
@@ -1,7 +1,7 @@
 class Subdomain
   class << self
     def matches?(request)
-      request.subdomain == "admin"
+      request.subdomain&.match?(/admin/)
     end
   end
 end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204653711879344/f

The admin staging site is staging-admin.apprenticeshipstandards.org, so we need to check for a partial match to "admin" in the route constraints, rather than an exact subdomain match.
