### PR TITLE
Add HTTP basic authentication for staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ command.
 The promotion can also be done through the Heroku Dashboard on the [Pipelines page](https://dashboard.heroku.com/pipelines/3657e91f-455e-4fa7-9da7-f6ddc1beb854).
 
 ## Staging access
-The current credentials for the staging site are:
+The public staging site is available at: https://staging.apprenticeshipstandards.org<br>
+The admin staging site is available at: https://staging-admin.apprenticeshipstandards.org
+
+The current credentials for the public staging site are:
 
 Username: ApprenticeshipStandardsAdmin<br>
 Password: Pipe Fitter

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ command.
 
 The promotion can also be done through the Heroku Dashboard on the [Pipelines page](https://dashboard.heroku.com/pipelines/3657e91f-455e-4fa7-9da7-f6ddc1beb854).
 
+## Staging access
+The current credentials for the staging site are:
+
+Username: ApprenticeshipStandardsAdmin<br>
+Password: Pipe Fitter
+
+These values are set in the `BASIC_AUTH_` environment variables on the staging
+app in Heroku.
+
 ## AWS Setup
 If you will have access to AWS to manage the S3 buckets, [view the setup
 documentation](doc/AWS.md).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ brew install mailcatcher
 
 [mailcatcher_brew]: https://formulae.brew.sh/formula/mailcatcher
 
+## Staging access
+The public staging site is available at: https://staging.apprenticeshipstandards.org<br>
+The admin staging site is available at: https://staging-admin.apprenticeshipstandards.org
+
+The current credentials for the public staging site are:
+
+Username: ApprenticeshipStandardsAdmin<br>
+Password: Pipe Fitter
+
+These values are set in the `BASIC_AUTH_` environment variables on the staging
+app in Heroku.
+
 ## Deployment
 We have a Heroku pipeline set up with a staging and a production app. The
 staging and production remotes can be added locally as follows:
@@ -79,18 +91,6 @@ replace "staging" with the name of your remote if using the `promote -r`
 command.
 
 The promotion can also be done through the Heroku Dashboard on the [Pipelines page](https://dashboard.heroku.com/pipelines/3657e91f-455e-4fa7-9da7-f6ddc1beb854).
-
-## Staging access
-The public staging site is available at: https://staging.apprenticeshipstandards.org<br>
-The admin staging site is available at: https://staging-admin.apprenticeshipstandards.org
-
-The current credentials for the public staging site are:
-
-Username: ApprenticeshipStandardsAdmin<br>
-Password: Pipe Fitter
-
-These values are set in the `BASIC_AUTH_` environment variables on the staging
-app in Heroku.
 
 ## AWS Setup
 If you will have access to AWS to manage the S3 buckets, [view the setup

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,19 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate, if: :staging?
+
   include ActiveStorage::SetCurrent
   include Pagy::Backend
+
+  private
+
+  def staging?
+    ENV.fetch("APP_ENVIRONMENT", Rails.env) == "staging"
+  end
+
+  def authenticate
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV.fetch("BASIC_AUTH_USERNAME", nil) &&
+        password == ENV.fetch("BASIC_AUTH_PASSWORD", nil)
+    end
+  end
 end

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -11,6 +11,34 @@ RSpec.describe "OccupationStandard", type: :request do
         expect(response).to be_successful
       end
     end
+
+    context "on staging" do
+      it "returns unauthorized if no http basic auth credentials" do
+        stub_const "ENV", ENV.to_h.merge("APP_ENVIRONMENT" => "staging", "BASIC_AUTH_USERNAME" => "admin", "BASIC_AUTH_PASSWORD" => "password")
+
+        get occupation_standards_path
+
+        expect(response).to be_unauthorized
+      end
+
+      it "returns unauthorized if incorrect http basic auth credentials passed" do
+        stub_const "ENV", ENV.to_h.merge("APP_ENVIRONMENT" => "staging", "BASIC_AUTH_USERNAME" => "admin", "BASIC_AUTH_PASSWORD" => "password")
+        authorization = ActionController::HttpAuthentication::Basic.encode_credentials("admin", "badpassword")
+
+        get occupation_standards_path, headers: {"HTTP_AUTHORIZATION" => authorization}
+
+        expect(response).to be_unauthorized
+      end
+
+      it "is successful if correct http basic auth credentials passed" do
+        stub_const "ENV", ENV.to_h.merge("APP_ENVIRONMENT" => "staging", "BASIC_AUTH_USERNAME" => "admin", "BASIC_AUTH_PASSWORD" => "password")
+        authorization = ActionController::HttpAuthentication::Basic.encode_credentials("admin", "password")
+
+        get occupation_standards_path, headers: {"HTTP_AUTHORIZATION" => authorization}
+
+        expect(response).to be_successful
+      end
+    end
   end
 
   describe "GET /show/:id" do


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204653711879344/f

Although the data on staging is all public, the DataImports do not match up to the SourceFile data, so we are requiring authentication to view the staging site.
