### PR TITLE
Allow an admin to set a standard as public

### DIFF
--- a/app/controllers/standards_imports_controller.rb
+++ b/app/controllers/standards_imports_controller.rb
@@ -4,7 +4,7 @@ class StandardsImportsController < ApplicationController
   end
 
   def create
-    @standards_import = StandardsImport.new(create_params)
+    @standards_import = StandardsImport.new(standards_import_params)
 
     if @standards_import.save
       if user_signed_in?
@@ -24,7 +24,26 @@ class StandardsImportsController < ApplicationController
 
   private
 
-  def create_params
+  def standards_import_params
+    if current_user&.admin?
+      admin_create_params
+    else
+      user_create_params
+    end
+  end
+
+  def user_create_params
     params.require(:standards_import).permit(:name, :email, :organization, :notes, files: [])
+  end
+
+  def admin_create_params
+    params.require(:standards_import).permit(
+      :name,
+      :email,
+      :organization,
+      :notes,
+      :public_document,
+      files: []
+    )
   end
 end

--- a/app/dashboards/occupation_standard_dashboard.rb
+++ b/app/dashboards/occupation_standard_dashboard.rb
@@ -28,7 +28,8 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
     url: Field::Url,
     wage_steps: Field::HasMany,
     work_processes: Field::HasMany,
-    redacted_document: Field::ActiveStorage
+    redacted_document: Field::ActiveStorage,
+    public_document: Field::Boolean
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[
@@ -64,6 +65,7 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
 
     data_imports
     redacted_document
+    public_document
     work_processes
     related_instructions
     wage_steps
@@ -90,6 +92,7 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
     rsi_hours_max
     rsi_hours_min
     redacted_document
+    public_document
   ].freeze
 
   COLLECTION_FILTERS = {}.freeze

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -107,7 +107,7 @@ class OccupationStandard < ApplicationRecord
   end
 
   def public_document?
-    standards_import.public_document
+    public_document || standards_import.public_document
   end
 
   def original_file_url

--- a/app/views/standards_imports/new.html.erb
+++ b/app/views/standards_imports/new.html.erb
@@ -47,6 +47,12 @@
           <%= f.label :notes, class: "form-label" %>
           <%= f.text_area :notes, class: "form-field" %>
         </div>
+        <% if current_user&.admin? %>
+          <div class="mb-6">
+            <%= f.label :public_document, class: "form-label" %>
+            <%= f.check_box :public_document, class: "bg-white" %>
+          </div>
+        <% end %>
         <div class="mb-6">
           <%= f.label :files, class: "form-label" %>
           <%= f.file_field :files, multiple: true, class: "form-field bg-white px-6" %>

--- a/db/migrate/20230529180125_add_public_document_to_occupation_standard.rb
+++ b/db/migrate/20230529180125_add_public_document_to_occupation_standard.rb
@@ -1,0 +1,5 @@
+class AddPublicDocumentToOccupationStandard < ActiveRecord::Migration[7.0]
+  def change
+    add_column :occupation_standards, :public_document, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_18_171423) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_29_180125) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_18_171423) do
     t.date "registration_date"
     t.date "latest_update_date"
     t.uuid "industry_id"
+    t.boolean "public_document", default: false, null: false
     t.index ["industry_id"], name: "index_occupation_standards_on_industry_id"
     t.index ["occupation_id"], name: "index_occupation_standards_on_occupation_id"
     t.index ["organization_id"], name: "index_occupation_standards_on_organization_id"

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -456,4 +456,19 @@ RSpec.describe OccupationStandard, type: :model do
       expect(occupation_standard.work_processes_hours_in_human_format).to eq "160"
     end
   end
+
+  describe "#public_document?" do
+    it "returns true if OccupationStandard#public_document flag is true" do
+      occupation_standard = build(:occupation_standard, public_document: true)
+
+      expect(occupation_standard.public_document?).to be true
+    end
+
+    it "trus true if associated standard import is public document regardless of public_document flag" do
+      occupation_standard = build(:occupation_standard, public_document: false)
+      allow_any_instance_of(OccupationStandard).to receive(:public_document?).and_return(true)
+
+      expect(occupation_standard.public_document?).to be true
+    end
+  end
 end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -465,8 +465,8 @@ RSpec.describe OccupationStandard, type: :model do
     end
 
     it "returns true if associated standard import is public document regardless of public_document flag" do
-      occupation_standard = build(:occupation_standard, public_document: false)
-      allow_any_instance_of(OccupationStandard).to receive(:public_document?).and_return(true)
+      occupation_standard = create(:occupation_standard, :with_data_import, public_document: false)
+      allow_any_instance_of(StandardsImport).to receive(:public_document).and_return(true)
 
       expect(occupation_standard.public_document?).to be true
     end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe OccupationStandard, type: :model do
       expect(occupation_standard.public_document?).to be true
     end
 
-    it "trus true if associated standard import is public document regardless of public_document flag" do
+    it "returns true if associated standard import is public document regardless of public_document flag" do
       occupation_standard = build(:occupation_standard, public_document: false)
       allow_any_instance_of(OccupationStandard).to receive(:public_document?).and_return(true)
 

--- a/spec/requests/standards_imports_spec.rb
+++ b/spec/requests/standards_imports_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe "StandardsImports", type: :request do
                 email: "mickey@mouse.com",
                 organization: "Disney",
                 notes: "a" * 500,
-                files: [fixture_file_upload("spec/fixtures/files/pixel1x1.jpg", "image/jpeg")]
+                files: [fixture_file_upload("spec/fixtures/files/pixel1x1.jpg", "image/jpeg")],
+                public_document: true
               }
             }
           }.to change(StandardsImport, :count).by(1)
@@ -33,6 +34,7 @@ RSpec.describe "StandardsImports", type: :request do
           expect(si.organization).to eq "Disney"
           expect(si.notes).to eq "a" * 500
           expect(si.files.count).to eq 1
+          expect(si.public_document?).to be false
 
           expect(response).to redirect_to standards_import_path(si)
         end
@@ -51,7 +53,8 @@ RSpec.describe "StandardsImports", type: :request do
                 email: "mickey@mouse.com",
                 organization: "Disney",
                 notes: "a" * 500,
-                files: [fixture_file_upload("spec/fixtures/files/pixel1x1.jpg", "image/jpeg")]
+                files: [fixture_file_upload("spec/fixtures/files/pixel1x1.jpg", "image/jpeg")],
+                public_document: true
               }
             }
           }.to change(StandardsImport, :count).by(1)
@@ -63,6 +66,7 @@ RSpec.describe "StandardsImports", type: :request do
           expect(si.organization).to eq "Disney"
           expect(si.notes).to eq "a" * 500
           expect(si.files.count).to eq 1
+          expect(si.public_document?).to be true
 
           expect(response).to redirect_to admin_source_files_path
         end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204653712611866/f

Add a checkbox only visible to admins to mark a standard as public from the Upload Apprenticeship Standards view

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/a5546828-9775-4ad1-a872-f3b151e64679)


Also, it adds the same field in occupation standards show and edit view

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/2700750c-f886-498a-9b4d-999969bac988)

