### PR TITLE
Use flipper flags to return similar programs conditionally

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -166,11 +166,11 @@ class OccupationStandard < ApplicationRecord
   end
 
   def similar_programs
-    OccupationStandard.where(
-      "title ILIKE ?", "%#{self.class.sanitize_sql_like(title).split.join("%")}%"
-    ).where.not(
-      id: id
-    ).limit(MAX_SIMILAR_PROGRAMS_TO_DISPLAY)
+    if Flipper.enabled?(:similar_programs_elasticsearch)
+      SimilarOccupationStandards.similar_to(self)
+    else
+      similar_programs_deprecated
+    end
   end
 
   def ojt_type_display
@@ -187,5 +187,13 @@ class OccupationStandard < ApplicationRecord
 
   def national?
     national_standard_type.present?
+  end
+
+  def similar_programs_deprecated
+    OccupationStandard.where(
+      "title ILIKE ?", "%#{self.class.sanitize_sql_like(title).split.join("%")}%"
+    ).where.not(
+      id: id
+    ).limit(MAX_SIMILAR_PROGRAMS_TO_DISPLAY)
   end
 end

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -1,0 +1,13 @@
+class SimilarOccupationStandards
+  def self.similar_to(occupation_standard)
+    new(occupation_standard).top_five
+  end
+
+  def initialize(occupation_standard)
+    @occupation_standard = occupation_standard
+  end
+
+  def top_five
+    OccupationStandard.search()
+  end
+end

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -8,6 +8,6 @@ class SimilarOccupationStandards
   end
 
   def top_five
-    OccupationStandard.search()
+    OccupationStandard.search
   end
 end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -385,21 +385,21 @@ RSpec.describe OccupationStandard, type: :model do
         similar_program1 = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
         similar_program2 = create(:occupation_standard, title: "human resource specialist")
         create(:occupation_standard, title: "Mechanic")
-  
+
         expect(occupation_standard.similar_programs.pluck(:id)).to match_array [similar_program1.id, similar_program2.id]
       end
-  
+
       it "returns up to MAX_SIMILAR_PROGRAMS_TO_DISPLAY occupations" do
         stub_const("OccupationStandard::MAX_SIMILAR_PROGRAMS_TO_DISPLAY", 1)
         occupation_standard = create(:occupation_standard, title: "Human Resource Specialist")
         create_list(:occupation_standard, 2, title: "Human Resource Specialist")
-  
+
         expect(occupation_standard.similar_programs.count).to eq OccupationStandard::MAX_SIMILAR_PROGRAMS_TO_DISPLAY
       end
-  
+
       it "excludes itself" do
         occupation_standard = create(:occupation_standard, title: "Human Resource Specialist")
-  
+
         expect(occupation_standard.similar_programs).to be_empty
       end
     end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe OccupationStandard, type: :model do
 
   describe "#similar_programs" do
     context "with the similar_programs_elasticsearch flag enabled" do
-      it "returns from SimilarOccupationStandards.top_five" do
+      it "returns from SimilarOccupationStandards.similar_to" do
         stub_feature_flag(:similar_programs_elasticsearch, true)
 
         allow(SimilarOccupationStandards).to receive(:similar_to).and_return([])

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -1,0 +1,5 @@
+require "./spec/support/helpers/stub_feature_flags"
+
+RSpec.configure do |config|
+  config.include Helpers::StubFeatureFlags
+end

--- a/spec/support/helpers/stub_feature_flags.rb
+++ b/spec/support/helpers/stub_feature_flags.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Helpers
+  module StubFeatureFlags
+    # Enable/disable flipper for a specific feature for any actors
+    # stub_feature_flag(:staff_directory, true)
+    def stub_feature_flag(feature_name, value)
+      allow(Flipper).to receive(:enabled?).with(feature_name, anything).and_return(value)
+      allow(Flipper).to receive(:enabled?).with(feature_name).and_return(value)
+    end
+  end
+end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203289004376689/f


In the sprit of keeping PRs short and easy to review, in this one, we're only introducing the usage of a flipper flag to conditionally return the results of the deprecated similar programs, or to call the new SimilarOccupationStandards class. 

In the next PR, I'll work on expanding/implementing the `SimilarOccupationStandards` class.