### PR TITLE
Add correct navbar to pages

### DIFF
--- a/app/views/occupation_standards/_header.html.erb
+++ b/app/views/occupation_standards/_header.html.erb
@@ -6,7 +6,6 @@
     <!-- <h1 class="page-title" mb-3 text-3xl font-bold leading-none tracking-tight text-gray-100 md:text-4xl xl:text-5xl">Page Title</h1> -->
 
     <! -- If Occupation Standards Page -->
-  <% unless current_page?(terms_page_path) %>
     <div class="mb-8 lg:mb-16">
       <div class="items-center sm:mb-6 lg:mb-0">
         <div class="mx-auto max-w-2xl rounded bg-seafoam-100">
@@ -14,6 +13,5 @@
         </div>
       </div>
     </div>
-  <% end %>
   </div>
 </section>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,4 +1,6 @@
-<%= render partial: "occupation_standards/header" %>
+<section aria-labelledby="page-title" class="occ-hero bg-no-repeat bg-cover bg-center bg-gray-700">
+  <%= render partial: "layouts/nav" %>
+</section>
 
 <section aria-label="main content" role="main" class="bg-seafoam-50">
   <div class="mx-auto max-w-screen-xl py-8 px-4 sm:py-16 lg:px-6">

--- a/app/views/pages/definitions.html.erb
+++ b/app/views/pages/definitions.html.erb
@@ -1,4 +1,6 @@
-<%= render partial: "occupation_standards/header" %>
+<section aria-labelledby="page-title" class="occ-hero bg-no-repeat bg-cover bg-center bg-gray-700">
+  <%= render partial: "layouts/nav" %>
+</section>
 
 <section aria-label="main content" role="main" class="bg-seafoam-50">
   <div class="mx-auto max-w-screen-xl py-8 px-4 sm:py-16 lg:px-6">

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,4 +1,6 @@
-<%= render partial: "occupation_standards/header" %>
+<section aria-labelledby="page-title" class="occ-hero bg-no-repeat bg-cover bg-center bg-gray-700">
+  <%= render partial: "layouts/nav" %>
+</section>
 
 <section aria-label="main content" role="main" class="bg-seafoam-50">
   <div class="mx-auto max-w-screen-xl py-8 px-4 sm:py-16 lg:px-6">


### PR DESCRIPTION
Asana ticket: [https://app.asana.com/0/1203289004376659/1204607522639589/f](https://app.asana.com/0/1203289004376659/1204607522639589/f)

I realized I was using the wrong header, so I replaced all of them with the correct one so the search form doesn't show up on these pages. This way we don't need the conditional for the occupation_standard header