### PR TITLE
Move some words to acronyms

### DIFF
--- a/app/services/scrape_rapids_code.rb
+++ b/app/services/scrape_rapids_code.rb
@@ -1,4 +1,4 @@
-class ScrapeRapidsCode
+class ScrapeRAPIDSCode
   def call
     xlsx = Roo::Spreadsheet.open("https://www.apprenticeship.gov/sites/default/files/wps/apprenticeship-occupations.xlsx")
     xlsx.sheet(0).parse(headers: true).each_with_index do |row, index|

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,4 +13,7 @@
 # These inflection rules are supported but not enabled by default:
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "API"
+  inflect.acronym "RAPIDS"
+  inflect.acronym "OJT"
+  inflect.acronym "RSI"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,12 +7,9 @@ en:
           competency: "Apprentices progress at their own pace – they demonstrate<br/> competency in skills and knowledge through assessment tests, <br/>but are not required to complete a specific number of hours."
           time: "Apprentices complete a required number of hours<br/> in on-the-job training and related instruction."
         national_standard_type: National Standard Type
-        ojt_type: OJT type
         ojt_hours_max: Max OJT hours
         ojt_hours_min: Min OJT hours
-        onet_code: ONET Code
-        rapids_code: RAPIDS Code
-        registration_agency: Registration Agency
+        onet_code: ONET code
         rsi_hours_max: Max RSI hours
         rsi_hours_min: Min RSI hours
         url: URL

--- a/spec/services/scrape_rapids_code_spec.rb
+++ b/spec/services/scrape_rapids_code_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ScrapeRapidsCode do
+RSpec.describe ScrapeRAPIDSCode do
   describe "#call" do
     it "creates occupation records" do
       stub_responses

--- a/spec/system/admin/occupation_standards/edit_spec.rb
+++ b/spec/system/admin/occupation_standards/edit_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe "admin/occupation_standards/edit" do
 
     expect(page).to have_selector("h1", text: "Edit Mechanic")
     expect(page).to have_field("Title")
-    expect(page).to have_field("ONET Code")
-    expect(page).to have_field("RAPIDS Code")
+    expect(page).to have_field("ONET code")
+    expect(page).to have_field("RAPIDS code")
     expect(page).to have_select("Status")
 
     fill_in "Title", with: "New title"
-    fill_in "ONET Code", with: "2345.67"
-    fill_in "RAPIDS Code", with: "98765"
+    fill_in "ONET code", with: "2345.67"
+    fill_in "RAPIDS code", with: "98765"
     select "In Review", from: "Status"
     click_on "Update"
 

--- a/spec/system/admin/occupation_standards/show_spec.rb
+++ b/spec/system/admin/occupation_standards/show_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "admin/occupation_standards/show" do
     expect(page).to have_selector("h1", text: "Mechanic")
 
     expect(page).to have_selector("dt", text: "Title")
-    expect(page).to have_selector("dt", text: "ONET Code")
-    expect(page).to have_selector("dt", text: "RAPIDS Code")
+    expect(page).to have_selector("dt", text: "ONET code")
+    expect(page).to have_selector("dt", text: "RAPIDS code")
     expect(page).to have_selector("dt", text: "Term months")
     expect(page).to have_selector("dt", text: "URL")
     expect(page).to have_selector("dt", text: "Status")
@@ -40,7 +40,7 @@ RSpec.describe "admin/occupation_standards/show" do
     expect(page).to have_selector("dt", text: "Min OJT hours")
     expect(page).to have_selector("dt", text: "Organization")
     expect(page).to have_selector("dt", text: "Probationary period months")
-    expect(page).to have_selector("dt", text: "Registration Agency")
+    expect(page).to have_selector("dt", text: "Registration agency")
     expect(page).to have_selector("dt", text: "Max RSI hours")
     expect(page).to have_selector("dt", text: "Min RSI hours")
     expect(page).to have_selector("dt", text: "Data imports")
@@ -97,7 +97,7 @@ RSpec.describe "admin/occupation_standards/show" do
     within_grid "Wage steps" do
       expect(page).to have_columnheader("Title")
       expect(page).to have_columnheader("Minimum Hours")
-      expect(page).to have_columnheader("Ojt Percentage")
+      expect(page).to have_columnheader("OJT Percentage")
 
       expect(page).to have_gridcell("WS1")
       expect(page).to have_text "3456"


### PR DESCRIPTION
"RAPIDS" was displaying as "R API D"
on the Administrate index column
header due to "API" being an acronym.
This adds RAPIDS to the acronyms list,
along with a few other additions. Notably,
ONET was **not** added as there is an
Onet model, and this was going to involve
a lot of code changes to rename everything
to ONET.

