### PR TITLE
Handle registration agency display for National agency

### DIFF
--- a/app/models/registration_agency.rb
+++ b/app/models/registration_agency.rb
@@ -7,6 +7,7 @@ class RegistrationAgency < ApplicationRecord
   enum agency_type: [:oa, :saa]
 
   def to_s
-    "#{state.name} (#{agency_type.upcase})"
+    state_name = state&.name || "National"
+    "#{state_name} (#{agency_type.upcase})"
   end
 end

--- a/spec/system/admin/occupation_standards/edit_spec.rb
+++ b/spec/system/admin/occupation_standards/edit_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "admin/occupation_standards/edit" do
   it "allows admin user to edit occupation_standard", :admin do
+    create(:registration_agency, state: nil) # National registration agency
     data_import = create(:data_import)
     occupation_standard = data_import.occupation_standard
     admin = create(:admin)


### PR DESCRIPTION
We recently added a registration agency with no
associated state to represent a national
registration agency (#277). However, this was
causing the edit occupation standard page to break,
due to the lack of a state association. This will
now display "National (OA)" for the national agency
in the select options.