### PR TITLE
Add more searching capabilities for Admin occupation standards

### DIFF
--- a/app/controllers/admin/occupation_standards_controller.rb
+++ b/app/controllers/admin/occupation_standards_controller.rb
@@ -22,17 +22,18 @@ module Administrate
       super
         .split(" OR ")
         .push("LOWER(states.name) LIKE ?")
+        .push("LOWER(occupations.title) LIKE ?")
         .join(" OR ")
     end
 
     def query_values
       values = super
       term = values.first
-      values + [term]
+      values + [term, term]
     end
 
     def search_results(resources)
-      super.joins(registration_agency: :state)
+      super.left_joins(registration_agency: :state).left_joins(:occupation)
     end
   end
 end

--- a/app/controllers/admin/occupation_standards_controller.rb
+++ b/app/controllers/admin/occupation_standards_controller.rb
@@ -3,5 +3,36 @@ module Admin
     def scoped_resource
       OccupationStandard.includes(occupation: :onet, registration_agency: :state)
     end
+
+    def filter_resources(resources, search_term:)
+      Administrate::OccupationStandardSearch.new(
+        resources,
+        dashboard,
+        search_term
+      ).run
+    end
+  end
+end
+
+module Administrate
+  class OccupationStandardSearch < Search
+    private
+
+    def query_template
+      super
+        .split(" OR ")
+        .push("LOWER(states.name) LIKE ?")
+        .join(" OR ")
+    end
+
+    def query_values
+      values = super
+      term = values.first
+      values + [term]
+    end
+
+    def search_results(resources)
+      super.joins(registration_agency: :state)
+    end
   end
 end

--- a/app/controllers/admin/occupation_standards_controller.rb
+++ b/app/controllers/admin/occupation_standards_controller.rb
@@ -23,13 +23,14 @@ module Administrate
         .split(" OR ")
         .push("LOWER(states.name) LIKE ?")
         .push("LOWER(occupations.title) LIKE ?")
+        .push("occupations.rapids_code LIKE ?")
         .join(" OR ")
     end
 
     def query_values
       values = super
       term = values.first
-      values + [term, term]
+      values + [term, term, term]
     end
 
     def search_results(resources)

--- a/app/dashboards/occupation_standard_dashboard.rb
+++ b/app/dashboards/occupation_standard_dashboard.rb
@@ -36,6 +36,7 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
     occupation
     registration_agency
     onet_code
+    rapids_code
     status
   ].freeze
 

--- a/spec/factories/registration_agencies.rb
+++ b/spec/factories/registration_agencies.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :registration_agency do
+    traits_for_enum :agency_type, RegistrationAgency.agency_types
+
     state
     agency_type { :oa }
   end

--- a/spec/system/admin/occupation_standards/index_spec.rb
+++ b/spec/system/admin/occupation_standards/index_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "admin/occupation_standards/index", :admin do
+  it "can search by agency" do
+    alabama = create(:state, name: "Alabama", abbreviation: "AL")
+    reg_agency = create(:registration_agency, :saa, state: alabama)
+    os = create(:occupation_standard, registration_agency: reg_agency)
+    admin = create(:admin)
+
+    login_as admin
+    visit admin_occupation_standards_path(search: "alabama")
+
+    expect(page).to have_text("Alabama (SAA)")
+  end
+end

--- a/spec/system/admin/occupation_standards/index_spec.rb
+++ b/spec/system/admin/occupation_standards/index_spec.rb
@@ -44,4 +44,30 @@ RSpec.describe "admin/occupation_standards/index", :admin do
     expect(page).to have_text("COPPERSMITH")
     expect(page).to_not have_text("Mechanic")
   end
+
+  it "will search both occupation and occupation standard for RAPIS code" do
+    coppersmith = create(:occupation, title: "COPPERSMITH", rapids_code: "1234")
+    create(:occupation_standard, occupation: coppersmith, title: "os 1", rapids_code: "4567")
+
+    mechanic = create(:occupation, title: "Mechanic", rapids_code: "9876")
+    create(:occupation_standard, occupation: mechanic, title: "os 2", rapids_code: "1234")
+
+    medical_asst = create(:occupation, title: "Medical Assistant", rapids_code: "1111")
+    create(:occupation_standard, occupation: medical_asst, title: "os 3", rapids_code: "1111")
+
+    admin = create(:admin)
+
+    login_as admin
+    visit admin_occupation_standards_path
+
+    expect(page).to have_text("COPPERSMITH")
+    expect(page).to have_text("Mechanic")
+    expect(page).to have_text("Medical Assistant")
+
+    visit admin_occupation_standards_path(search: "1234")
+
+    expect(page).to have_text("COPPERSMITH")
+    expect(page).to have_text("Mechanic")
+    expect(page).to_not have_text("Medical Assistant")
+  end
 end

--- a/spec/system/admin/occupation_standards/index_spec.rb
+++ b/spec/system/admin/occupation_standards/index_spec.rb
@@ -2,14 +2,46 @@ require "rails_helper"
 
 RSpec.describe "admin/occupation_standards/index", :admin do
   it "can search by agency" do
-    alabama = create(:state, name: "Alabama", abbreviation: "AL")
-    reg_agency = create(:registration_agency, :saa, state: alabama)
-    os = create(:occupation_standard, registration_agency: reg_agency)
+    alabama = create(:state, name: "Alabama")
+    al_reg_agency = create(:registration_agency, :saa, state: alabama)
+    create(:occupation_standard, registration_agency: al_reg_agency)
+
+    california = State.find_by(name: "California") || create(:state, name: "California")
+    ca_reg_agency = create(:registration_agency, :oa, state: california)
+    create(:occupation_standard, registration_agency: ca_reg_agency)
+
     admin = create(:admin)
 
     login_as admin
+    visit admin_occupation_standards_path
+
+    expect(page).to have_text("Alabama (SAA)")
+    expect(page).to have_text("California (OA)")
+
     visit admin_occupation_standards_path(search: "alabama")
 
     expect(page).to have_text("Alabama (SAA)")
+    expect(page).to_not have_text("California (OA)")
+  end
+
+  it "can search by occupation" do
+    coppersmith = create(:occupation, title: "COPPERSMITH")
+    create(:occupation_standard, occupation: coppersmith, title: "os 1")
+
+    mechanic = create(:occupation, title: "Mechanic")
+    create(:occupation_standard, occupation: mechanic, title: "os 2")
+
+    admin = create(:admin)
+
+    login_as admin
+    visit admin_occupation_standards_path
+
+    expect(page).to have_text("COPPERSMITH")
+    expect(page).to have_text("Mechanic")
+
+    visit admin_occupation_standards_path(search: "copper")
+
+    expect(page).to have_text("COPPERSMITH")
+    expect(page).to_not have_text("Mechanic")
   end
 end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204799580445034/f

This allows an admin to use the search feature to search on occupation title, occupation rapids code, agency name.
