### PR TITLE
Do not include occupation standard ID as search term

### DIFF
--- a/app/dashboards/occupation_standard_dashboard.rb
+++ b/app/dashboards/occupation_standard_dashboard.rb
@@ -6,7 +6,7 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     data_imports: Field::HasMany,
     existing_title: Field::String,
-    id: Field::String,
+    id: Field::String.with_options(searchable: false),
     national_standard_type: EnumField,
     occupation: Field::BelongsTo,
     ojt_hours_max: Field::Number,


### PR DESCRIPTION
Since we are often searching on numbers (RAPIDS
or ONET codes), we need to exclude the id field
from the fields to search.

Asana ticket: https://app.asana.com/0/1203289004376659/1204799580445034/f

On production, https://admin.apprenticeshipstandards.org/admin/occupation_standards/d82ce233-6a33-41bb-880f-2ae726920489 was getting returned when searching on "2048" for RAPIDS code, although the only match was in the ID field.
