### PR TITLE
Daily email update of imported standards

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -17,4 +17,12 @@ class AdminMailer < ApplicationMailer
     mail to: "patrick@workhands.us",
       subject: "New ApprenticeshipStandards Contact Request"
   end
+
+  def daily_uploads_report
+    @data_imports = DataImport.recent_uploads
+    date = Time.zone.yesterday.to_date
+
+    mail to: "info@workhands.us",
+      subject: "Daily imported standards report #{date}"
+  end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -20,9 +20,11 @@ class AdminMailer < ApplicationMailer
 
   def daily_uploads_report
     @data_imports = DataImport.recent_uploads
-    date = Time.zone.yesterday.to_date
 
-    mail to: "info@workhands.us",
-      subject: "Daily imported standards report #{date}"
+    if @data_imports.any?
+      date = Time.zone.yesterday.to_date
+      mail to: "info@workhands.us",
+        subject: "Daily imported standards report #{date}"
+    end
   end
 end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -21,6 +21,12 @@ class DataImport < ApplicationRecord
     text/csv
   ]
 
+  class << self
+    def recent_uploads(start_time: Time.zone.yesterday.beginning_of_day, end_time: Time.zone.yesterday.end_of_day)
+      where("created_at BETWEEN ? AND ?", start_time, end_time)
+    end
+  end
+
   def related_occupation_standard(title)
     OccupationStandard
       .joins(data_imports: :source_file)

--- a/app/views/admin_mailer/daily_uploads_report.html.erb
+++ b/app/views/admin_mailer/daily_uploads_report.html.erb
@@ -1,22 +1,35 @@
 <div>
   <% @data_imports.each do |data_import| %>
-    <p>
-      <%= link_to "Public occupation standard view", occupation_standard_url(data_import.occupation_standard) %>
-    </p>
-    <p>
-      Competencies count: <%= data_import.occupation_standard.competencies_count %>
-    </p>
-    <p>
-      OJT hours: <%= data_import.occupation_standard.ojt_hours_min %>-<%= data_import.occupation_standard.ojt_hours_max %>
-    </p>
-    <p>
-      RSI hours: <%= data_import.occupation_standard.rsi_hours_min %>-<%= data_import.occupation_standard.rsi_hours_max %>
-    </p>
-    <p>
-      <%= link_to "Admin Data Import", admin_data_import_url(data_import) %>
-    </p>
-    <p>
-      <%= link_to "Admin Source File", admin_source_file_url(data_import.source_file) %>
-    </p>
+    <div>
+      <p>
+        <%= link_to "#{data_import.occupation_standard.title} (Public link)", occupation_standard_url(data_import.occupation_standard) %>
+      </p>
+      <p>
+        <%= link_to "#{data_import.occupation_standard.title} (Admin link)", admin_occupation_standard_url(data_import.occupation_standard) %>
+      </p>
+      <p>
+        Competencies count: <%= data_import.occupation_standard.competencies_count %>
+      </p>
+      <p>
+        OJT hours min: <%= data_import.occupation_standard.ojt_hours_min %>
+      </p>
+      <p>
+        OJT hours max: <%= data_import.occupation_standard.ojt_hours_max %>
+      </p>
+      <p>
+        RSI hours min: <%= data_import.occupation_standard.rsi_hours_min %>
+      </p>
+      <p>
+        RSI hours max: <%= data_import.occupation_standard.rsi_hours_max %>
+      </p>
+      <p>
+        <%= link_to "Admin Data Import", admin_data_import_url(data_import) %>
+      </p>
+      <p>
+        <%= link_to "Admin Source File", admin_source_file_url(data_import.source_file) %>
+      </p>
+    </div>
+    <br>
+    <br>
   <% end %>
 </div>

--- a/app/views/admin_mailer/daily_uploads_report.html.erb
+++ b/app/views/admin_mailer/daily_uploads_report.html.erb
@@ -1,35 +1,17 @@
 <div>
   <% @data_imports.each do |data_import| %>
     <div>
-      <p>
-        <%= link_to "#{data_import.occupation_standard.title} (Public link)", occupation_standard_url(data_import.occupation_standard, host: ENV.fetch("PUBLIC_DOMAIN", Rails.application.config.action_mailer.default_url_options[:host])) %>
-      </p>
-      <p>
-        <%= link_to "#{data_import.occupation_standard.title} (Admin link)", admin_occupation_standard_url(data_import.occupation_standard) %>
-      </p>
-      <p>
-        Competencies count: <%= data_import.occupation_standard.competencies_count %>
-      </p>
-      <p>
-        OJT hours min: <%= data_import.occupation_standard.ojt_hours_min %>
-      </p>
-      <p>
-        OJT hours max: <%= data_import.occupation_standard.ojt_hours_max %>
-      </p>
-      <p>
-        RSI hours min: <%= data_import.occupation_standard.rsi_hours_min %>
-      </p>
-      <p>
-        RSI hours max: <%= data_import.occupation_standard.rsi_hours_max %>
-      </p>
-      <p>
-        <%= link_to "Admin Data Import", admin_data_import_url(data_import) %>
-      </p>
-      <p>
-        <%= link_to "Admin Source File", admin_source_file_url(data_import.source_file) %>
+      <%= link_to "#{data_import.occupation_standard.title} (Public link)", occupation_standard_url(data_import.occupation_standard, host: ENV.fetch("PUBLIC_DOMAIN", Rails.application.config.action_mailer.default_url_options[:host])) %><br>
+      <%= link_to "#{data_import.occupation_standard.title} (Admin link)", admin_occupation_standard_url(data_import.occupation_standard) %><br>
+      Competencies count: <%= data_import.occupation_standard.competencies_count %><br>
+      OJT hours min: <%= data_import.occupation_standard.ojt_hours_min %><br>
+      OJT hours max: <%= data_import.occupation_standard.ojt_hours_max %><br>
+      RSI hours min: <%= data_import.occupation_standard.rsi_hours_min %><br>
+      RSI hours max: <%= data_import.occupation_standard.rsi_hours_max %><br>
+      <%= link_to "Admin Data Import", admin_data_import_url(data_import) %><br>
+      <%= link_to "Admin Source File", admin_source_file_url(data_import.source_file) %>
       </p>
     </div>
-    <br>
     <br>
   <% end %>
 </div>

--- a/app/views/admin_mailer/daily_uploads_report.html.erb
+++ b/app/views/admin_mailer/daily_uploads_report.html.erb
@@ -2,7 +2,7 @@
   <% @data_imports.each do |data_import| %>
     <div>
       <p>
-        <%= link_to "#{data_import.occupation_standard.title} (Public link)", occupation_standard_url(data_import.occupation_standard) %>
+        <%= link_to "#{data_import.occupation_standard.title} (Public link)", occupation_standard_url(data_import.occupation_standard, host: ENV.fetch("PUBLIC_DOMAIN", Rails.application.config.action_mailer.default_url_options[:host])) %>
       </p>
       <p>
         <%= link_to "#{data_import.occupation_standard.title} (Admin link)", admin_occupation_standard_url(data_import.occupation_standard) %>

--- a/app/views/admin_mailer/daily_uploads_report.html.erb
+++ b/app/views/admin_mailer/daily_uploads_report.html.erb
@@ -1,0 +1,22 @@
+<div>
+  <% @data_imports.each do |data_import| %>
+    <p>
+      <%= link_to "Public occupation standard view", occupation_standard_url(data_import.occupation_standard) %>
+    </p>
+    <p>
+      Competencies count: <%= data_import.occupation_standard.competencies_count %>
+    </p>
+    <p>
+      OJT hours: <%= data_import.occupation_standard.ojt_hours_min %>-<%= data_import.occupation_standard.ojt_hours_max %>
+    </p>
+    <p>
+      RSI hours: <%= data_import.occupation_standard.rsi_hours_min %>-<%= data_import.occupation_standard.rsi_hours_max %>
+    </p>
+    <p>
+      <%= link_to "Admin Data Import", admin_data_import_url(data_import) %>
+    </p>
+    <p>
+      <%= link_to "Admin Source File", admin_source_file_url(data_import.source_file) %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/admin_mailer/daily_uploads_report.text.erb
+++ b/app/views/admin_mailer/daily_uploads_report.text.erb
@@ -1,0 +1,8 @@
+<% @data_imports.each do |data_import| %>
+  Public occupation standard view: <%= occupation_standard_url(data_import.occupation_standard) %>
+  Competencies count: <%= data_import.occupation_standard.competencies_count %>
+  OJT hours: <%= data_import.occupation_standard.ojt_hours_min %>-<%= data_import.occupation_standard.ojt_hours_max %>
+  RSI hours: <%= data_import.occupation_standard.rsi_hours_min %>-<%= data_import.occupation_standard.rsi_hours_max %>
+  Link to Admin Data Import: <%= admin_data_import_url(data_import) %>
+  Link to Admin Source File: <%= admin_source_file_url(data_import.source_file) %>
+<% end %>

--- a/app/views/admin_mailer/daily_uploads_report.text.erb
+++ b/app/views/admin_mailer/daily_uploads_report.text.erb
@@ -1,5 +1,5 @@
 <% @data_imports.each do |data_import| %>
-  <%= "#{data_import.occupation_standard.title} (Public link)" %>: <%= occupation_standard_url(data_import.occupation_standard) %>
+  <%= "#{data_import.occupation_standard.title} (Public link)" %>: <%= occupation_standard_url(data_import.occupation_standard, host: ENV.fetch("PUBLIC_DOMAIN", Rails.application.config.action_mailer.default_url_options[:host])) %>
   <%= "#{data_import.occupation_standard.title} (Admin link)" %>: <%= admin_occupation_standard_url(data_import.occupation_standard) %>
   Competencies count: <%= data_import.occupation_standard.competencies_count %>
   OJT hours min: <%= data_import.occupation_standard.ojt_hours_min %>

--- a/app/views/admin_mailer/daily_uploads_report.text.erb
+++ b/app/views/admin_mailer/daily_uploads_report.text.erb
@@ -1,8 +1,13 @@
 <% @data_imports.each do |data_import| %>
-  Public occupation standard view: <%= occupation_standard_url(data_import.occupation_standard) %>
+  <%= "#{data_import.occupation_standard.title} (Public link)" %>: <%= occupation_standard_url(data_import.occupation_standard) %>
+  <%= "#{data_import.occupation_standard.title} (Admin link)" %>: <%= admin_occupation_standard_url(data_import.occupation_standard) %>
   Competencies count: <%= data_import.occupation_standard.competencies_count %>
-  OJT hours: <%= data_import.occupation_standard.ojt_hours_min %>-<%= data_import.occupation_standard.ojt_hours_max %>
-  RSI hours: <%= data_import.occupation_standard.rsi_hours_min %>-<%= data_import.occupation_standard.rsi_hours_max %>
+  OJT hours min: <%= data_import.occupation_standard.ojt_hours_min %>
+  OJT hours max: <%= data_import.occupation_standard.ojt_hours_max %>
+  RSI hours min: <%= data_import.occupation_standard.rsi_hours_min %>
+  RSI hours max: <%= data_import.occupation_standard.rsi_hours_max %>
   Link to Admin Data Import: <%= admin_data_import_url(data_import) %>
   Link to Admin Source File: <%= admin_source_file_url(data_import.source_file) %>
+
+
 <% end %>

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -1,0 +1,5 @@
+namespace :data_import do
+  task daily_report: :environment do
+    AdminMailer.daily_uploads_report.deliver_now
+  end
+end

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe AdminMailer, type: :mailer do
         expect(mail.from).to eq(["no-reply@apprenticeshipstandards.org"])
 
         mail.body.parts.each do |part|
-          expect(part.body.encoded).to match /Mechanic \(Public link\)/
-          expect(part.body.encoded).to match /Mechanic \(Admin link\)/
+          expect(part.body.encoded).to match(/Mechanic \(Public link\)/)
+          expect(part.body.encoded).to match(/Mechanic \(Admin link\)/)
           expect(part.body.encoded).to match occupation_standard_url(occupation_standard)
           expect(part.body.encoded).to match admin_occupation_standard_url(occupation_standard)
           expect(part.body.encoded).to match "Admin Data Import"

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe AdminMailer, type: :mailer do
         data_import = create(:data_import, created_at: Time.zone.local(2023, 6, 14))
         source_file = data_import.source_file
         occupation_standard = data_import.occupation_standard
-        occupation_standard.update!(ojt_hours_min: 100, ojt_hours_max: 200, rsi_hours_min: 500, rsi_hours_max: 600)
+        occupation_standard.update!(ojt_hours_min: 100, ojt_hours_max: 200, rsi_hours_min: 500, rsi_hours_max: 600, title: "Mechanic")
         allow_any_instance_of(OccupationStandard).to receive(:competencies_count).and_return(123)
 
         mail = described_class.daily_uploads_report
@@ -57,15 +57,19 @@ RSpec.describe AdminMailer, type: :mailer do
         expect(mail.from).to eq(["no-reply@apprenticeshipstandards.org"])
 
         mail.body.parts.each do |part|
-          expect(part.body.encoded).to match "Public occupation standard view"
+          expect(part.body.encoded).to match /Mechanic \(Public link\)/
+          expect(part.body.encoded).to match /Mechanic \(Admin link\)/
           expect(part.body.encoded).to match occupation_standard_url(occupation_standard)
+          expect(part.body.encoded).to match admin_occupation_standard_url(occupation_standard)
           expect(part.body.encoded).to match "Admin Data Import"
           expect(part.body.encoded).to match admin_data_import_url(data_import)
           expect(part.body.encoded).to match "Admin Source File"
           expect(part.body.encoded).to match admin_source_file_url(source_file)
           expect(part.body.encoded).to match "Competencies count: 123"
-          expect(part.body.encoded).to match "OJT hours: 100-200"
-          expect(part.body.encoded).to match "RSI hours: 500-600"
+          expect(part.body.encoded).to match "OJT hours min: 100"
+          expect(part.body.encoded).to match "OJT hours max: 200"
+          expect(part.body.encoded).to match "RSI hours min: 500"
+          expect(part.body.encoded).to match "RSI hours max: 600"
         end
       end
     end

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AdminMailer, type: :mailer do
       si = build(:standards_import, name: "Mickey", email: "mickey@mouse.com", organization: "Disney")
       allow(si).to receive(:file_count).and_return(10)
 
-      mail = AdminMailer.new_standards_import(si)
+      mail = described_class.new_standards_import(si)
 
       expect(mail.subject).to eq("New standards import uploaded")
       expect(mail.to).to eq(["patrick@workhands.us"])
@@ -25,7 +25,7 @@ RSpec.describe AdminMailer, type: :mailer do
     it "renders the header and body correctly" do
       contact = create(:contact_request, name: "Mickey", email: "mickey@mouse.com", organization: "Disney", message: "Some message")
 
-      mail = AdminMailer.new_contact_request(contact)
+      mail = described_class.new_contact_request(contact)
 
       expect(mail.subject).to eq("New ApprenticeshipStandards Contact Request")
       expect(mail.to).to eq(["patrick@workhands.us"])
@@ -50,7 +50,7 @@ RSpec.describe AdminMailer, type: :mailer do
         occupation_standard.update!(ojt_hours_min: 100, ojt_hours_max: 200, rsi_hours_min: 500, rsi_hours_max: 600)
         allow_any_instance_of(OccupationStandard).to receive(:competencies_count).and_return(123)
 
-        mail = AdminMailer.daily_uploads_report
+        mail = described_class.daily_uploads_report
 
         expect(mail.subject).to eq("Daily imported standards report 2023-06-14")
         expect(mail.to).to eq(["info@workhands.us"])
@@ -68,6 +68,12 @@ RSpec.describe AdminMailer, type: :mailer do
           expect(part.body.encoded).to match "RSI hours: 500-600"
         end
       end
+    end
+
+    it "does not send mail if no imports" do
+      expect {
+        described_class.daily_uploads_report.deliver_now
+      }.not_to change(ActionMailer::Base.deliveries, :count)
     end
   end
 end

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe AdminMailer, type: :mailer do
-  describe "new_standards_import" do
+  describe "#new_standards_import" do
     it "renders the header and body correctly" do
       si = build(:standards_import, name: "Mickey", email: "mickey@mouse.com", organization: "Disney")
       allow(si).to receive(:file_count).and_return(10)
@@ -21,7 +21,7 @@ RSpec.describe AdminMailer, type: :mailer do
     end
   end
 
-  describe "new_contact_request" do
+  describe "#new_contact_request" do
     it "renders the header and body correctly" do
       contact = create(:contact_request, name: "Mickey", email: "mickey@mouse.com", organization: "Disney", message: "Some message")
 
@@ -36,7 +36,37 @@ RSpec.describe AdminMailer, type: :mailer do
         expect(part.body.encoded).to match contact.email
         expect(part.body.encoded).to match contact.organization
         expect(part.body.encoded).to match contact.message
-        expect(part.body.encoded).to match admin_contact_request_path(contact)
+        expect(part.body.encoded).to match admin_contact_request_url(contact)
+      end
+    end
+  end
+
+  describe "#daily_uploads_report" do
+    it "renders the header and body correctly" do
+      travel_to(Time.zone.local(2023, 6, 15)) do
+        data_import = create(:data_import, created_at: Time.zone.local(2023, 6, 14))
+        source_file = data_import.source_file
+        occupation_standard = data_import.occupation_standard
+        occupation_standard.update!(ojt_hours_min: 100, ojt_hours_max: 200, rsi_hours_min: 500, rsi_hours_max: 600)
+        allow_any_instance_of(OccupationStandard).to receive(:competencies_count).and_return(123)
+
+        mail = AdminMailer.daily_uploads_report
+
+        expect(mail.subject).to eq("Daily imported standards report 2023-06-14")
+        expect(mail.to).to eq(["info@workhands.us"])
+        expect(mail.from).to eq(["no-reply@apprenticeshipstandards.org"])
+
+        mail.body.parts.each do |part|
+          expect(part.body.encoded).to match "Public occupation standard view"
+          expect(part.body.encoded).to match occupation_standard_url(occupation_standard)
+          expect(part.body.encoded).to match "Admin Data Import"
+          expect(part.body.encoded).to match admin_data_import_url(data_import)
+          expect(part.body.encoded).to match "Admin Source File"
+          expect(part.body.encoded).to match admin_source_file_url(source_file)
+          expect(part.body.encoded).to match "Competencies count: 123"
+          expect(part.body.encoded).to match "OJT hours: 100-200"
+          expect(part.body.encoded).to match "RSI hours: 500-600"
+        end
       end
     end
   end

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -13,6 +13,32 @@ RSpec.describe DataImport, type: :model do
     expect(data_import).to_not be_valid
   end
 
+  describe ".recent_uploads" do
+    it "returns records created the day before by default" do
+      travel_to(Time.zone.local(2023, 6, 15)) do
+        recent_records = [
+          create(:data_import, created_at: Time.zone.local(2023, 6, 14)),
+          create(:data_import, created_at: Time.zone.local(2023, 6, 14, 23, 59, 59))
+        ]
+        create(:data_import, created_at: Time.zone.local(2023, 6, 13, 23, 59, 59))
+
+        expect(described_class.recent_uploads).to match_array recent_records
+      end
+    end
+
+    it "returns records within the passed start and end time" do
+      recent_records = [
+        create(:data_import, created_at: Time.zone.local(2022, 6, 14)),
+        create(:data_import, created_at: Time.zone.local(2022, 6, 14, 22, 59, 59))
+      ]
+      create(:data_import, created_at: Time.zone.local(2022, 6, 14, 23, 59, 59))
+
+      start_time = Time.zone.local(2022, 6, 14)
+      end_time = Time.zone.local(2022, 6, 14, 23)
+      expect(described_class.recent_uploads(start_time: start_time, end_time: end_time)).to match_array recent_records
+    end
+  end
+
   describe "#file_mime_type" do
     it "is valid with accepted content-type" do
       file = Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "occupation-standards-template.xlsx"), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,7 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Warden::Test::Helpers


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204836206826468/f

This adds a rake task that will be added to the Heroku scheduler to run a report of the previous day's data imports.

<img width="440" alt="Screen Shot 2023-06-15 at 4 07 30 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/c48a946b-14f2-4cb6-8090-6b03ef9a582f">

<img width="1150" alt="Screen Shot 2023-06-15 at 4 07 37 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/e13718c0-8a87-4f10-b06d-3fb5f17cc659">


