### PR TITLE
Enable rollbar in staging

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -4,7 +4,7 @@ Rollbar.configure do |config|
 
   config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
 
-  unless Rails.env.production? || Rails.env.staging?
+  if !(Rails.env.production? || Rails.env.staging?)
     config.enabled = false
   end
 

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -4,7 +4,7 @@ Rollbar.configure do |config|
 
   config.access_token = ENV["ROLLBAR_ACCESS_TOKEN"]
 
-  unless Rails.env.production?
+  unless Rails.env.production? || Rails.env.staging?
     config.enabled = false
   end
 


### PR DESCRIPTION
We're having a 500 error when trying to use the forgot my password feature in staging. To debug it, we'd like to see the error reported on rollbar. Having rollbar enabled in staging will also help us find out about issues sooner before deploying the app to prod. 