### PR TITLE
Fix javascript error on google analytics script. 

### DIFF
--- a/app/javascript/google_analytics.js
+++ b/app/javascript/google_analytics.js
@@ -1,7 +1,8 @@
 document.addEventListener('turbo:load', function(event) {
   if (typeof gtag === 'function') {
     gtag('config', 'G-EJH1K3YRJK', {
-      'page_location': event.data.url
+      'page_title': document.title,
+      'page_path': location.href.replace(location.origin, ""),
     })
   }
 })


### PR DESCRIPTION
We have a javascript error showing up on the console in production:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'url')
```

This happens because the turbo:load does not pass the same data in the same way as turbolinks:load did. After the load event has fired, the title and location should be available via document and location, so we don't need to attempt to get them via the event itself.

I can verify that the error goes away on the console, but I'm not sure how to verify that the analytics are reported correctly, so I'll ask @jenlu33's help.

Reference: https://github.com/turbolinks/turbolinks/issues/73#issuecomment-812484452

Asana ticket: https://app.asana.com/0/1203289004376659/1204541884043963/f


