### PR TITLE
Declare route outside of subdomain constraint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,12 +28,6 @@ Rails.application.routes.draw do
       end
     end
 
-    # SEO-friendly routes for Occupation Standards
-    get ":state_abbreviation/occupation_standards",
-      to: "occupation_standards#index",
-      as: :occupation_standards_by_state,
-      constraints: {state_abbreviation: /[a-zA-Z]{2}/}
-
     namespace :admin do
       resources :data_imports, except: [:index]
       resources :users do
@@ -67,6 +61,13 @@ Rails.application.routes.draw do
   get "terms", as: :terms_page, to: "pages#terms"
   get "contact", as: :contact_page, to: "contact_requests#new"
   resources :contact_requests, only: [:create]
+
+
+  # SEO-friendly routes for Occupation Standards
+  get ":state_abbreviation/occupation_standards",
+    to: "occupation_standards#index",
+    as: :occupation_standards_by_state,
+    constraints: {state_abbreviation: /[a-zA-Z]{2}/}
 
   namespace :api do
     namespace :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,6 @@ Rails.application.routes.draw do
   get "contact", as: :contact_page, to: "contact_requests#new"
   resources :contact_requests, only: [:create]
 
-
   # SEO-friendly routes for Occupation Standards
   get ":state_abbreviation/occupation_standards",
     to: "occupation_standards#index",


### PR DESCRIPTION
Asana ticket:

Routes such /:state_abbreviation/occupation_standards should be available only outside the admin subdomain
