### PR TITLE
Remove developer's email address from the daily uploads report mailer

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -24,7 +24,6 @@ class AdminMailer < ApplicationMailer
     if @data_imports.any?
       date = Time.zone.yesterday.to_date
       mail to: "info@workhands.us",
-        cco: "sarah.lima@thoughtbot.com",
         subject: "Daily imported standards report #{date}"
     end
   end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204836206826468/f

I had previously added my own email to this mailer for validation purposes. Remove it now.
