### PR TITLE
Add safe navigation operator to similar occupation standards query

### DIFF
--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -38,7 +38,7 @@ class SimilarOccupationStandards
               ojt_type: {query: occupation_standard.ojt_type, boost: 0.5}
             }},
             {match: {
-              state: {query: occupation_standard.registration_agency.state&.abbreviation}
+              state: {query: occupation_standard.registration_agency&.state&.abbreviation}
             }},
             more_like_this: more_like_this
           ],


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203289004376689/f

Even with there's a presence validation for registration agencies on occupation standards,  there are some occupation standards with empty registration agencies in production, which can lead to a problem in this query. Adding a safe navigation operator fixes it. 

