### PR TITLE
Rename classes

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,6 @@ if Rails.env.development?
     password: "passwordpassword"
   )
 
-  ScrapeRapidsCode.new.call
+  ScrapeRAPIDSCode.new.call
   ScrapeOnetCodes.new.call
 end

--- a/lib/tasks/occupation.rake
+++ b/lib/tasks/occupation.rake
@@ -5,7 +5,7 @@ namespace :occupation do
   task rapids_codes_scraper: :environment do
     if Date.current.wday.eql?(0) || ENV["FORCE"] == "true"
       puts "Importing RAPIDS codes"
-      ScrapeRapidsCode.new.call
+      ScrapeRAPIDSCode.new.call
     else
       puts "Not Sunday, skipping"
       puts "Use FORCE=true to force this task"


### PR DESCRIPTION
Asana ticket:

We added RAPIDS as an inflection in a4f4dc39, but we did not update the name of the class in some parts of the code, raising an error while trying to run the seeds locally and in [production](https://app.rollbar.com/a/apprenticeship-standards-dot-o/fix/item/apprenticeship-standards-dot-o/170)
