### PR TITLE
Search occupation standards by industry name

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -106,6 +106,13 @@ class OccupationStandard < ApplicationRecord
     end
   end
 
+  scope :by_industry_name, ->(name) do
+    if name.present?
+      ids = joins(:industry).where("industries.name ILIKE ?", "%#{sanitize_sql_like(name).split.join("%")}%").pluck(:id)
+      where(id: ids)
+    end
+  end
+
   class << self
     def industry_count(onet_prefix)
       where("SPLIT_PART(onet_code, '-', 1) = ?", onet_prefix.to_s).count

--- a/app/queries/occupation_standard_query.rb
+++ b/app/queries/occupation_standard_query.rb
@@ -15,14 +15,14 @@ class OccupationStandardQuery
       .by_state_abbreviation(search_term_params[:state_abbreviation])
       .by_national_standard_type(search_term_params[:national_standard_type]&.keys)
       .by_ojt_type(search_term_params[:ojt_type]&.keys)
-      .and(
-        occupation_standards.by_title(search_term_params[:q])
-        .or(
-          occupation_standards.by_rapids_code(search_term_params[:q])
-        )
-        .or(
-          occupation_standards.by_onet_code(search_term_params[:q])
-        )
+      .where(
+        "title ILIKE :q OR rapids_code ILIKE :q OR onet_code ILIKE :q OR
+        occupation_standards.id IN (
+          SELECT occupation_standards.id FROM occupation_standards
+          JOIN industries ON occupation_standards.industry_id = industries.id
+          WHERE industries.name ILIKE :q
+        )",
+        q: "%#{search_term_params[:q]}%"
       )
   end
 end

--- a/app/queries/occupation_standard_query.rb
+++ b/app/queries/occupation_standard_query.rb
@@ -15,14 +15,17 @@ class OccupationStandardQuery
       .by_state_abbreviation(search_term_params[:state_abbreviation])
       .by_national_standard_type(search_term_params[:national_standard_type]&.keys)
       .by_ojt_type(search_term_params[:ojt_type]&.keys)
-      .where(
-        "title ILIKE :q OR rapids_code ILIKE :q OR onet_code ILIKE :q OR
-        occupation_standards.id IN (
-          SELECT occupation_standards.id FROM occupation_standards
-          JOIN industries ON occupation_standards.industry_id = industries.id
-          WHERE industries.name ILIKE :q
-        )",
-        q: "%#{search_term_params[:q]}%"
+      .and(
+        occupation_standards.by_title(search_term_params[:q])
+        .or(
+          occupation_standards.by_rapids_code(search_term_params[:q])
+        )
+        .or(
+          occupation_standards.by_onet_code(search_term_params[:q])
+        )
+        .or(
+          occupation_standards.by_industry_name(search_term_params[:q])
+        )
       )
   end
 end

--- a/app/views/industries/index.html.erb
+++ b/app/views/industries/index.html.erb
@@ -35,7 +35,7 @@
                 </div>
                     <div class="break-inside-avoid-column px-4 flex-grow">
                     <% names.each do |name, id, prefix| %>
-                       <%= link_to occupation_standards_path(q: "#{prefix}-"), class: "hover:font-bold" do %>
+                       <%= link_to occupation_standards_path(q: name), class: "hover:font-bold" do %>
                             <span class="mb-2 block"><%= name %></span>
                         <% end %>
                     <% end %>

--- a/spec/queries/occupation_standard_query_spec.rb
+++ b/spec/queries/occupation_standard_query_spec.rb
@@ -140,4 +140,20 @@ RSpec.describe OccupationStandardQuery do
 
     expect(occupation_standard_search.pluck(:id)).to contain_exactly(os1.id)
   end
+
+  it "allows searching by industry name" do
+    industry1 = create(:industry, name: "Healthcare Support Occupations")
+    industry2 = create(:industry, name: "Repair Occupations")
+
+    occupation_standard = create(:occupation_standard, industry: industry1)
+    create(:occupation_standard, industry: industry2)
+
+    params = {q: "Healthcare Support Occupations"}
+
+    occupation_standard_search = OccupationStandardQuery.run(
+      OccupationStandard.all, params
+    )
+
+    expect(occupation_standard_search.pluck(:id)).to eq [occupation_standard.id]
+  end
 end

--- a/spec/queries/occupation_standard_query_spec.rb
+++ b/spec/queries/occupation_standard_query_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe OccupationStandardQuery do
     occupation_standard = create(:occupation_standard, industry: industry1)
     create(:occupation_standard, industry: industry2)
 
-    params = {q: "Healthcare Support Occupations"}
+    params = {q: "healthcare support"}
 
     occupation_standard_search = OccupationStandardQuery.run(
       OccupationStandard.all, params

--- a/spec/system/industries/index_spec.rb
+++ b/spec/system/industries/index_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "industries/index" do
 
     visit industries_path
 
-    expect(page).to have_link "Health", href: occupation_standards_path(q: "39-")
-    expect(page).to have_link "Business", href: occupation_standards_path(q: "41-")
+    expect(page).to have_link "Health", href: occupation_standards_path(q: "Health")
+    expect(page).to have_link "Business", href: occupation_standards_path(q: "Business")
   end
 end


### PR DESCRIPTION
Asana ticket: [https://app.asana.com/0/1203289004376659/1204799581648899/f](https://app.asana.com/0/1203289004376659/1204799581648899/f)

I changed OccupationStandardQuery quite a bit to use raw SQL because I could not find a way to be able to search the industry name while still using `:q` as the search parameter without doing so. Let me know if there is a better way to do this!

![Screenshot 2023-06-30 at 1 32 20 PM](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/58493319/2230dd56-15c2-496e-a628-3ca62f72c5fe)
