### PR TITLE
Accessibility fixes

### DIFF
--- a/app/views/occupation_standards/_header.html.erb
+++ b/app/views/occupation_standards/_header.html.erb
@@ -1,4 +1,4 @@
-<section aria-labelledby="page-title" class="occ-hero bg-no-repeat bg-cover bg-center bg-gray-700">
+<section aria-label="search" class="occ-hero bg-no-repeat bg-cover bg-center bg-gray-700">
   <%= render partial: "layouts/nav" %>
   <div class="max-w-screen-xl px-4 pt-8 pb-16 mx-auto lg:py-16">
 

--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -41,9 +41,9 @@
                 <div>
                     <div class="inline">
                         <% if occupation_standard.ojt_type %>
-                            <button data-tooltip-target="<%= occupation_standard.ojt_type %>-occupation-standard" type="button" class="mr-2 mb-2 rounded-lg border-2 border-primary-700 px-2 py-1 text-center text-sm font-bold text-primary-700 hover:bg-primary-800 hover:text-white focus:outline-none focus:ring-4 focus:ring-primary-300"><%= ojt_type_display(occupation_standard) %></button>
+                            <button data-tooltip-target="<%= occupation_standard.ojt_type %>-<%= occupation_standard.id %>-occupation-standard" type="button" class="mr-2 mb-2 rounded-lg border-2 border-primary-700 px-2 py-1 text-center text-sm font-bold text-primary-700 hover:bg-primary-800 hover:text-white focus:outline-none focus:ring-4 focus:ring-primary-300"><%= ojt_type_display(occupation_standard) %></button>
 
-                            <div id="<%= occupation_standard.ojt_type %>-occupation-standard" role="tooltip" class="tooltip invisible absolute z-10 inline-block rounded-lg bg-primary-800 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm">
+                            <div id="<%= occupation_standard.ojt_type %>-<%= occupation_standard.id %>-occupation-standard" role="tooltip" class="tooltip invisible absolute z-10 inline-block rounded-lg bg-primary-800 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm">
                                 <%= t("activerecord.attributes.occupation_standard.definitions.#{occupation_standard.ojt_type}").html_safe %>
                                 <div class="tooltip-arrow" data-popper-arrow></div>
                             </div>

--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -11,7 +11,7 @@
                     Home
                 </a>
             </li>
-            <li aria-current="page">
+            <li aria-current="occupations standards index">
                 <div class="flex items-center">
                     <svg aria-hidden="true" class="w-6 h-6 text-gray-50" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
                         <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path>
@@ -23,7 +23,7 @@
     </div>
 </nav>
 
-<section aria-labelledby="occupation-title" class="bg-seafoam-50">
+<section aria-label="search results" class="bg-seafoam-50">
     <div class="mx-auto max-w-screen-xl py-10 px-4 sm:py-16 lg:px-6">
         <% if @search_term.present? %>
             <div class="mb-8 flex lg:mb-8">
@@ -49,8 +49,8 @@
                             </div>
                         <% end %>
                     </div>
-                    <h3 id="occupation-title" class="occupation-title text-2xl font-bold"><%= link_to occupation_standard.title, occupation_standard %></h3>
-                    <p class="mb-1 font-bold text-seafoam-900"><%= sponsor_name(occupation_standard) %></p>
+                    <h1 class="occupation-title text-2xl font-bold"><%= link_to occupation_standard.title, occupation_standard %></h1>
+                    <h2 class="mb-1 font-bold text-seafoam-900"><%= sponsor_name(occupation_standard) %></h2>
                     <div class="text-primary-700 text-xs mb-4">
                         <% if occupation_standard.latest_update_date %>
                             <span class="mr-4">Updated <%= occupation_standard.latest_update_date.year %> </span>

--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -49,7 +49,7 @@
                             </div>
                         <% end %>
                     </div>
-                    <h3 class="occupation-title text-2xl font-bold"><%= link_to occupation_standard.title, occupation_standard %></h3>
+                    <h3 id="occupation-title" class="occupation-title text-2xl font-bold"><%= link_to occupation_standard.title, occupation_standard %></h3>
                     <p class="mb-1 font-bold text-seafoam-900"><%= sponsor_name(occupation_standard) %></p>
                     <div class="text-primary-700 text-xs mb-4">
                         <% if occupation_standard.latest_update_date %>


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204974668381977/f

I made some edits to fix accessibility issues on the following pages
https://www.apprenticeshipstandards.org/occupation_standards
https://www.apprenticeshipstandards.org/occupation_standards/national_standards
What I did:

- Fixed broken aria-labeledby attributes. They were missing a matching element that would contain the aria information so I changed them to use an aria-label instead.
- Changed the hierarchy of h tags so they would be in level order, providing navigational guidance to users

Note: There were contrast issues that I didn't fix because they are for a disabled element and a hidden label, respectively.

Here are pictures of what the pages look like now.
<img width="1678" alt="Screenshot 2023-07-11 at 11 32 21 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/99890957/51b2785e-3d55-4b37-bfa1-e5f315010037">
<img width="1678" alt="Screenshot 2023-07-11 at 11 42 41 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/99890957/982b8025-3dda-47bd-b0a8-a122053d0316">


