### PR TITLE
Elasticsearch updates

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -29,9 +29,10 @@ class OccupationStandard < ApplicationRecord
   MAX_SIMILAR_PROGRAMS_TO_DISPLAY = 5
 
   index_name "occupation_standards_#{Rails.env}"
+  number_of_shards = Rails.env.production? ? 2 : 1
   es_settings = {
     index: {
-      number_of_shards: 2,
+      number_of_shards: number_of_shards,
       analysis: {
         tokenizer: {
           autocomplete_tokenizer: {

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -77,7 +77,7 @@ class OccupationStandard < ApplicationRecord
 
   def as_indexed_json(_ = {})
     as_json(
-      only: [:title, :ojt_type, :onet_code, :rapids_code, :national_standard_type],
+      only: [:title, :ojt_type, :onet_code, :rapids_code, :national_standard_type]
     ).merge(
       state: registration_agency&.state&.abbreviation,
       work_process_titles: work_processes.pluck(:title).uniq

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -66,7 +66,7 @@ class OccupationStandard < ApplicationRecord
     mappings dynamic: false do
       indexes :title, type: :text, analyzer: :snowball
       indexes :ojt_type, type: :text
-      indexes :work_process_titles, type: :text
+      indexes :work_process_titles, type: :text, analyzer: :snowball
       indexes :onet_code, type: :text, analyzer: :autocomplete
       indexes :rapids_code, type: :text, analyzer: :autocomplete
       indexes :national_standard_type, type: :text, analyzer: :keyword

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -28,6 +28,7 @@ class OccupationStandard < ApplicationRecord
 
   MAX_SIMILAR_PROGRAMS_TO_DISPLAY = 5
 
+  index_name "occupation_standards_#{Rails.env}"
   es_settings = {
     index: {
       number_of_shards: 2,

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -76,13 +76,10 @@ class OccupationStandard < ApplicationRecord
 
   def as_indexed_json(_ = {})
     as_json(
-      include: {
-        work_processes: {only: [:title, :description]},
-        related_instructions: {only: [:title, :description]}
-      }
+      only: [:title, :ojt_type, :onet_code, :rapids_code, :national_standard_type],
     ).merge(
       state: registration_agency&.state&.abbreviation,
-      work_process_titles: work_processes.pluck(:title)
+      work_process_titles: work_processes.pluck(:title).uniq
     )
   end
 

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -1,19 +1,24 @@
 class SimilarOccupationStandards
-  attr_reader :occupation_standard
+  attr_reader :occupation_standard, :debug
 
   RESULTS_SIZE = 5
   MINIMUM_SCORE = 0.2
 
-  def self.similar_to(occupation_standard)
-    new(occupation_standard).similar_to
+  def self.similar_to(occupation_standard, debug = false)
+    new(occupation_standard, debug).similar_to
   end
 
-  def initialize(occupation_standard)
+  def initialize(occupation_standard, debug = false)
     @occupation_standard = occupation_standard
+    @debug = debug
   end
 
   def similar_to
-    OccupationStandard.__elasticsearch__.search(query).records
+    search = OccupationStandard.__elasticsearch__.search(query)
+    if debug
+      puts search.search.definition[:body][:query].to_json
+    end
+    search.records.to_a
   end
 
   private

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -14,11 +14,11 @@ class SimilarOccupationStandards
   end
 
   def similar_to
-    search = OccupationStandard.__elasticsearch__.search(query)
+    response = OccupationStandard.__elasticsearch__.search(query)
     if debug
-      puts search.search.definition[:body][:query].to_json
+      puts response.search.definition[:body][:query].to_json
     end
-    search.records.to_a
+    response.records.to_a
   end
 
   private

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -19,6 +19,9 @@ class SimilarOccupationStandards
       puts "QUERY"
       puts response.search.definition[:body][:query].to_json
       puts "HITS: #{response.results.total}"
+      response.results.each do |result|
+        puts "#{result._id}: #{result._score}"
+      end
     end
     response.records.to_a
   end

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -16,7 +16,9 @@ class SimilarOccupationStandards
   def similar_to
     response = OccupationStandard.__elasticsearch__.search(query)
     if debug
+      puts "QUERY"
       puts response.search.definition[:body][:query].to_json
+      puts "HITS: #{response.results.total}"
     end
     response.records.to_a
   end

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -9,37 +9,37 @@ RSpec.describe SimilarOccupationStandards, type: :model do
       al_reg_agency = create(:registration_agency, state: al)
 
       os1 = create(:occupation_standard, :time, title: "Childcare worker", registration_agency: wa_reg_agency)
-      wp1a = create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os1)
-      wp1b = create(:work_process, title: "Social and Emotional Development", occupation_standard: os1)
+      create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os1)
+      create(:work_process, title: "Social and Emotional Development", occupation_standard: os1)
 
       # Matches on title, state
       os4 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
-      wp4a = create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
-      wp4b = create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
+      create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
+      create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
 
       # Matches on title, ojt_type
       os6 = create(:occupation_standard, :time, title: "Childcare worker", registration_agency: al_reg_agency)
-      wp6a = create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
-      wp6b = create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
+      create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
+      create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
 
       # Matches on title, state, work process titles
       os2 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
-      wp2a = create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os2)
-      wp2b = create(:work_process, title: "Social and Emotional Development", occupation_standard: os2)
+      create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os2)
+      create(:work_process, title: "Social and Emotional Development", occupation_standard: os2)
 
       # Matches on title, work process titles
       os3 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: al_reg_agency)
-      wp3a = create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os3)
-      wp3b = create(:work_process, title: "Social and Emotional Development", occupation_standard: os3)
+      create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os3)
+      create(:work_process, title: "Social and Emotional Development", occupation_standard: os3)
 
       os5 = create(:occupation_standard, :hybrid, title: "Human Resource Specialist", registration_agency: al_reg_agency)
-      wp5a = create(:work_process, title: "Vehicle Inspection", occupation_standard: os5)
-      wp5b = create(:work_process, title: "Tracking and Management Systems", occupation_standard: os5)
+      create(:work_process, title: "Vehicle Inspection", occupation_standard: os5)
+      create(:work_process, title: "Tracking and Management Systems", occupation_standard: os5)
 
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!
 
-      expect(described_class.similar_to(os1.reload, true)).to eq [os2, os3, os4, os6]
+      expect(described_class.similar_to(os1.reload)).to eq [os2, os3, os4, os6]
     end
 
     it "returns RESULTS_SIZE records" do

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe SimilarOccupationStandards, type: :model do
+  describe ".similar_to", :elasticsearch do
+    it "returns records that are similar to the passed occupation standard" do
+      wa = create(:state, name: "Washington", abbreviation: "WA")
+      al = create(:state, name: "Alabama", abbreviation: "AL")
+      wa_reg_agency = create(:registration_agency, state: wa)
+      al_reg_agency = create(:registration_agency, state: al)
+
+      os1 = create(:occupation_standard, :time, title: "Childcare worker", registration_agency: wa_reg_agency)
+      wp1a = create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os1)
+      wp1b = create(:work_process, title: "Social and Emotional Development", occupation_standard: os1)
+
+      os4 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
+      wp4a = create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
+      wp4b = create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
+
+      os2 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
+      wp2a = create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os2)
+      wp2b = create(:work_process, title: "Social and Emotional Development", occupation_standard: os2)
+
+      os3 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: al_reg_agency)
+      wp3a = create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os3)
+      wp3b = create(:work_process, title: "Social and Emotional Development", occupation_standard: os3)
+
+      os5 = create(:occupation_standard, :hybrid, title: "Human Resource Specialist", registration_agency: al_reg_agency)
+      wp5a = create(:work_process, title: "Vehicle Inspection", occupation_standard: os5)
+      wp5b = create(:work_process, title: "Tracking and Management Systems", occupation_standard: os5)
+
+      OccupationStandard.import
+      OccupationStandard.__elasticsearch__.refresh_index!
+
+      expect(described_class.similar_to(os1.reload)).to eq [os2, os3, os4]
+    end
+  end
+end

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SimilarOccupationStandards, type: :model do
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!
 
-      expect(described_class.similar_to(os1.reload)).to eq [os2, os3, os4]
+      expect(described_class.similar_to(os1.reload, true)).to eq [os2, os3, os4]
     end
   end
 end

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -41,5 +41,16 @@ RSpec.describe SimilarOccupationStandards, type: :model do
 
       expect(described_class.similar_to(os1.reload, true)).to eq [os2, os3, os4, os6]
     end
+
+    it "returns RESULTS_SIZE records" do
+      stub_const("SimilarOccupationStandards::RESULTS_SIZE", 2)
+      os1 = create(:occupation_standard, :time, title: "Childcare worker")
+      create_list(:occupation_standard, 3, title: "Childcare worker")
+
+      OccupationStandard.import
+      OccupationStandard.__elasticsearch__.refresh_index!
+
+      expect(described_class.similar_to(os1.reload).count).to eq 2
+    end
   end
 end

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -12,14 +12,22 @@ RSpec.describe SimilarOccupationStandards, type: :model do
       wp1a = create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os1)
       wp1b = create(:work_process, title: "Social and Emotional Development", occupation_standard: os1)
 
+      # Matches on title, state
       os4 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
       wp4a = create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
       wp4b = create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
 
+      # Matches on title, ojt_type
+      os6 = create(:occupation_standard, :time, title: "Childcare worker", registration_agency: al_reg_agency)
+      wp6a = create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
+      wp6b = create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
+
+      # Matches on title, state, work process titles
       os2 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
       wp2a = create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os2)
       wp2b = create(:work_process, title: "Social and Emotional Development", occupation_standard: os2)
 
+      # Matches on title, work process titles
       os3 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: al_reg_agency)
       wp3a = create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os3)
       wp3b = create(:work_process, title: "Social and Emotional Development", occupation_standard: os3)
@@ -31,7 +39,7 @@ RSpec.describe SimilarOccupationStandards, type: :model do
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!
 
-      expect(described_class.similar_to(os1.reload, true)).to eq [os2, os3, os4]
+      expect(described_class.similar_to(os1.reload, true)).to eq [os2, os3, os4, os6]
     end
   end
 end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203289004376689/f

This is somewhat of a WIP, but is working well enough that I think we could merge this and flip the Flipper flag to use the ES results, and continue iterating.

Changes in this PR:
* Set index name based on environment so we can debug more easily
* Use 1 shard in test, dev environments to ensure consistent scoring results
* Use the `snowball` analyzer for the `work_process_titles` so we don't match on "and" and "or" stopwords
* Do not include as much of the occupation standard record data to be included in ES. Just include the fields we are indexing and matching on for now.
* Add a `debug` flag for the `similar_to` method. This can be cleaned up later.
* Add specs for the `similar_to` method

We weren't entirely sure what the `more_like_this` function was doing, as the specs pass with and without that clause. More work will be done investigating how to use the built-in `more_like_this` feature.

