### PR TITLE
Remove more_like_this in Elasticsearch query for similar_to method

### DIFF
--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -49,8 +49,7 @@ class SimilarOccupationStandards
             }},
             {match: {
               state: {query: occupation_standard.registration_agency&.state&.abbreviation}
-            }},
-            more_like_this: more_like_this
+            }}
           ],
           must_not: [
             {
@@ -61,19 +60,6 @@ class SimilarOccupationStandards
           ]
         }
       }
-    }
-  end
-
-  def more_like_this
-    {
-      like: [
-        {
-          _index: OccupationStandard.index_name,
-          _id: occupation_standard.id
-        }
-      ],
-      min_term_freq: 1,
-      analyzer: "snowball"
     }
   end
 end


### PR DESCRIPTION
The built-in `more_like_this` feature in Elasticsearch seems better suited to finding documents related to some simple text, or a group of input documents.

Per the [Alternative](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-mlt-query.html#_alternative) section in the Elasticsearch
documentation, a more complex boolean query can
be used to achieve the same functionality of
`more_like_this`, with more control:

"To take more control over the construction of a query for similar documents it is worth considering writing custom client code to assemble selected terms from an example document into a Boolean query with the desired settings."

We already have such a boolean query established, so this removes the unnecessary additional call to the `more_like_this` function.

Asana ticket: https://app.asana.com/0/1203289004376659/1203289004376689/f
