### PR TITLE
Remove stop word from work process title since sometimes matching

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -65,9 +65,9 @@ class OccupationStandard < ApplicationRecord
 
   settings(es_settings) do
     mappings dynamic: false do
-      indexes :title, type: :text, analyzer: :snowball
+      indexes :title, type: :text, analyzer: :english
       indexes :ojt_type, type: :text
-      indexes :work_process_titles, type: :text, analyzer: :snowball
+      indexes :work_process_titles, type: :text, analyzer: :english
       indexes :onet_code, type: :text, analyzer: :autocomplete
       indexes :rapids_code, type: :text, analyzer: :autocomplete
       indexes :national_standard_type, type: :text, analyzer: :keyword

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -20,7 +20,6 @@ class SimilarOccupationStandards
       puts response.search.definition[:body][:query].to_json
       puts "HITS: #{response.results.total}"
       response.results.each do |result|
-        pp result
         puts "#{result._id}: #{result._score}"
       end
     end
@@ -60,11 +59,6 @@ class SimilarOccupationStandards
               }
             }
           ]
-        }
-      },
-      "highlight": {
-        "fields": {
-          "*": {}
         }
       }
     }

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -52,6 +52,7 @@ class SimilarOccupationStandards
               state: {query: occupation_standard.registration_agency&.state&.abbreviation}
             }}
           ],
+          minimum_should_match: 1,
           must_not: [
             {
               term: {

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -20,6 +20,7 @@ class SimilarOccupationStandards
       puts response.search.definition[:body][:query].to_json
       puts "HITS: #{response.results.total}"
       response.results.each do |result|
+        pp result
         puts "#{result._id}: #{result._score}"
       end
     end

--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -61,6 +61,11 @@ class SimilarOccupationStandards
             }
           ]
         }
+      },
+      "highlight": {
+        "fields": {
+          "*": {}
+        }
       }
     }
   end

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SimilarOccupationStandards, type: :model do
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!
 
-      expect(described_class.similar_to(os1.reload)).to eq [os2, os3, os4, os6]
+      expect(described_class.similar_to(os1.reload)).to match_array [os2, os3, os4, os6]
     end
 
     it "returns RESULTS_SIZE records" do

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -11,42 +11,35 @@ RSpec.describe SimilarOccupationStandards, type: :model do
       os1 = create(:occupation_standard, :time, title: "Childcare worker", registration_agency: wa_reg_agency)
       create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os1)
       create(:work_process, title: "Social and Emotional Development", occupation_standard: os1)
-      puts "os1: #{os1.id}"
 
       # Matches on title, state
       os4 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
       create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
       create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
-      puts "os4: #{os4.id}"
 
       # Matches on title, ojt_type
       os6 = create(:occupation_standard, :time, title: "Childcare worker", registration_agency: al_reg_agency)
       create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
       create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
-      puts "os6: #{os6.id}"
 
       # Matches on title, state, work process titles
       os2 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
       create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os2)
       create(:work_process, title: "Social and Emotional Development", occupation_standard: os2)
-      puts "os2: #{os2.id}"
 
       # Matches on title, work process titles
       os3 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: al_reg_agency)
       create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os3)
       create(:work_process, title: "Social and Emotional Development", occupation_standard: os3)
-      puts "os3: #{os3.id}"
 
       os5 = create(:occupation_standard, :hybrid, title: "Human Resource Specialist", registration_agency: al_reg_agency)
       create(:work_process, title: "Vehicle Inspection", occupation_standard: os5)
       create(:work_process, title: "Tracking Management Systems", occupation_standard: os5)
-      puts "os5: #{os5.id}"
 
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!
 
-      expect(described_class.similar_to(os1.reload, true)).to match_array [os2, os3, os4, os6]
-      expect(described_class.similar_to(os1.reload)).to_not include(os5)
+      expect(described_class.similar_to(os1.reload)).to eq [os2, os3, os4, os6]
     end
 
     it "returns RESULTS_SIZE records" do

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SimilarOccupationStandards, type: :model do
 
       os5 = create(:occupation_standard, :hybrid, title: "Human Resource Specialist", registration_agency: al_reg_agency)
       create(:work_process, title: "Vehicle Inspection", occupation_standard: os5)
-      create(:work_process, title: "Tracking and Management Systems", occupation_standard: os5)
+      create(:work_process, title: "Tracking Management Systems", occupation_standard: os5)
       puts "os5: #{os5.id}"
 
       OccupationStandard.import

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -11,30 +11,36 @@ RSpec.describe SimilarOccupationStandards, type: :model do
       os1 = create(:occupation_standard, :time, title: "Childcare worker", registration_agency: wa_reg_agency)
       create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os1)
       create(:work_process, title: "Social and Emotional Development", occupation_standard: os1)
+      puts "os1: #{os1.id}"
 
       # Matches on title, state
       os4 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
       create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
       create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
+      puts "os4: #{os4.id}"
 
       # Matches on title, ojt_type
       os6 = create(:occupation_standard, :time, title: "Childcare worker", registration_agency: al_reg_agency)
       create(:work_process, title: "Vehicle Inspection", occupation_standard: os4)
       create(:work_process, title: "Tracking and Management Systems", occupation_standard: os4)
+      puts "os6: #{os6.id}"
 
       # Matches on title, state, work process titles
       os2 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: wa_reg_agency)
       create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os2)
       create(:work_process, title: "Social and Emotional Development", occupation_standard: os2)
+      puts "os2: #{os2.id}"
 
       # Matches on title, work process titles
       os3 = create(:occupation_standard, :hybrid, title: "Childcare worker", registration_agency: al_reg_agency)
       create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os3)
       create(:work_process, title: "Social and Emotional Development", occupation_standard: os3)
+      puts "os3: #{os3.id}"
 
       os5 = create(:occupation_standard, :hybrid, title: "Human Resource Specialist", registration_agency: al_reg_agency)
       create(:work_process, title: "Vehicle Inspection", occupation_standard: os5)
       create(:work_process, title: "Tracking and Management Systems", occupation_standard: os5)
+      puts "os5: #{os5.id}"
 
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe SimilarOccupationStandards, type: :model do
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!
 
-      expect(described_class.similar_to(os1.reload)).to match_array [os2, os3, os4, os6]
+      expect(described_class.similar_to(os1.reload, true)).to match_array [os2, os3, os4, os6]
+      expect(described_class.similar_to(os1.reload)).to_not include(os5)
     end
 
     it "returns RESULTS_SIZE records" do


### PR DESCRIPTION
On CI we are not getting consistent scoring back
and it is resulting in a flaky test.

I added highlighting while debugging, and it seems that the "and" stop word is occasionally matching for some reason. I just ended up taking out the "and" in the work process title as a workaround. Don't love it, but seems to be working fine on production.

Other changes:
* The snowball analyzer seems to have been removed (but still seemed to work, so unsure), but I replaced the snowball analyzer with the english analyzer anyway as that [seemed to be the appropriate change](https://stackoverflow.com/a/41867221/1753903).
* Added `minimum_must_match` equal to 1 for the items in the should clause
