### PR TITLE
Reduce the boost on work_process_titles when getting similar results

### DIFF
--- a/app/models/similar_occupation_standards.rb
+++ b/app/models/similar_occupation_standards.rb
@@ -40,8 +40,7 @@ class SimilarOccupationStandards
             }},
             {match: {
               work_process_titles: {
-                query: occupation_standard.work_processes.pluck(:title).to_sentence,
-                boost: 5
+                query: occupation_standard.work_processes.pluck(:title).to_sentence
               }
             }},
             {match: {


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1203289004376689/f

We care mostly about title when finding similar programs.
