### PR TITLE
Hide accordion for production

### DIFF
--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -119,8 +119,7 @@
                     </div>
                 </div>
             </div>
-            <!-- TODO: hide accordion until results are condensed so there is no duplication -->
-            <% if Rails.env.test? %>
+            <% if Flipper.enabled?(:similar_programs_accordion) %>
               <%= render partial: "similar_results_list", locals: {occupation_standard: occupation_standard} %>
             <% end %>
         </div>

--- a/app/views/occupation_standards/index.html.erb
+++ b/app/views/occupation_standards/index.html.erb
@@ -119,7 +119,10 @@
                     </div>
                 </div>
             </div>
-            <%= render partial: "similar_results_list", locals: {occupation_standard: occupation_standard} %>
+            <!-- TODO: hide accordion until results are condensed so there is no duplication -->
+            <% if Rails.env.test? %>
+              <%= render partial: "similar_results_list", locals: {occupation_standard: occupation_standard} %>
+            <% end %>
         </div>
         <% end %>
         <%== pagy_nav(@pagy) if @pagy.pages > 1 %>

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -392,6 +392,7 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "shows similar results accordion button if they are present" do
+    Flipper.enable :similar_programs_accordion
     create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
     create(:occupation_standard, :with_work_processes, :with_data_import, :program_standard, title: "Mechanic")
 
@@ -401,6 +402,7 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "does not show similar results accordion button if they are not present" do
+    Flipper.enable :similar_programs_accordion
     create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
     create(:occupation_standard, :with_work_processes, :with_data_import, :program_standard, title: "Pipe Fitter")
 
@@ -410,6 +412,7 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "expands similar results accordion when accordion button is clicked", js: true do
+    Flipper.enable :similar_programs_accordion
     create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
     create(:occupation_standard, :with_work_processes, :with_data_import, :program_standard, title: "Mechanic")
 
@@ -421,6 +424,7 @@ RSpec.describe "occupation_standards/index" do
   end
 
   it "closes similar results accordion when accordion button is clicked", js: true do
+    Flipper.enable :similar_programs_accordion
     mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
     create(:occupation_standard, :with_work_processes, :with_data_import, :program_standard, title: "Mechanic")
 


### PR DESCRIPTION
We need to setup the condensing of occupation standards so that similar programs will be grouped. That way the accordion showing similar programs will make sense. Currently it' redundant because the same results inside the accordion are also listed in the page with their own accordions. I hid the accordion unless we are in tests so that the tests could remain. Once we condense the results we can add back the accordion.

Asana ticket: https://app.asana.com/0/1203289004376659/1205072156506456/f
