### PR TITLE
Use Flipper instead of env var for enabling reCAPTCHA

### DIFF
--- a/app/controllers/concerns/spammable.rb
+++ b/app/controllers/concerns/spammable.rb
@@ -33,6 +33,6 @@ module Spammable
   end
 
   def skip_recaptcha?
-    current_user&.admin? || ENV.fetch("ENABLE_RECAPTCHA", "false") == "false"
+    current_user&.admin? || !Flipper.enabled?(:recaptcha)
   end
 end

--- a/spec/requests/standards_imports_spec.rb
+++ b/spec/requests/standards_imports_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "StandardsImports", type: :request do
     context "with valid parameters and decent Google recaptcha score" do
       context "when guest" do
         it "creates new standards import record, redirects to show page, and notifies admin" do
+          Flipper.enable :recaptcha
           stub_recaptcha_high_score
 
           expect_any_instance_of(StandardsImport).to receive(:notify_admin)
@@ -39,11 +40,13 @@ RSpec.describe "StandardsImports", type: :request do
           expect(si.public_document?).to be false
 
           expect(response).to redirect_to standards_import_path(si)
+          Flipper.disable :recaptcha
         end
       end
 
       context "when admin", :admin do
         it "creates new standards import record, redirects to source files page, and does not notify admin" do
+          Flipper.enable :recaptcha
           admin = create(:admin)
 
           sign_in admin
@@ -71,6 +74,7 @@ RSpec.describe "StandardsImports", type: :request do
           expect(si.public_document?).to be true
 
           expect(response).to redirect_to admin_source_files_path
+          Flipper.disable :recaptcha
         end
       end
     end
@@ -78,6 +82,7 @@ RSpec.describe "StandardsImports", type: :request do
     context "with valid parameters and poor Google recaptcha score" do
       context "when guest" do
         it "does not create new standards import record" do
+          Flipper.enable :recaptcha
           stub_recaptcha_low_score
 
           expect_any_instance_of(StandardsImport).to_not receive(:notify_admin)
@@ -95,6 +100,7 @@ RSpec.describe "StandardsImports", type: :request do
           }.to_not change(StandardsImport, :count)
 
           expect(response).to redirect_to guest_root_path
+          Flipper.disable :recaptcha
         end
       end
     end
@@ -102,6 +108,7 @@ RSpec.describe "StandardsImports", type: :request do
     context "with valid parameters and unsuccessful recaptcha score" do
       context "when guest" do
         it "does not create new standards import record and reports error" do
+          Flipper.enable :recaptcha
           stub_recaptcha_failure
 
           expect_any_instance_of(StandardsImport).to_not receive(:notify_admin)
@@ -120,12 +127,14 @@ RSpec.describe "StandardsImports", type: :request do
           }.to_not change(StandardsImport, :count)
 
           expect(response).to redirect_to guest_root_path
+          Flipper.disable :recaptcha
         end
       end
     end
 
     context "with invalid parameters" do
       it "does not create new standards import record and renders new" do
+        Flipper.enable :recaptcha
         stub_recaptcha_high_score
 
         allow_any_instance_of(StandardsImport).to receive(:save).and_return(false)
@@ -141,6 +150,7 @@ RSpec.describe "StandardsImports", type: :request do
         }.to_not change(StandardsImport, :count)
 
         expect(response).to have_http_status(:ok)
+        Flipper.disable :recaptcha
       end
     end
   end

--- a/spec/support/helpers/webmock_helpers.rb
+++ b/spec/support/helpers/webmock_helpers.rb
@@ -3,7 +3,6 @@
 module Helpers
   module WebmockHelpers
     def stub_recaptcha_high_score
-      stub_const "ENV", ENV.to_h.merge("ENABLE_RECAPTCHA" => "true")
       stub_request(:post, /google.*recaptcha/)
         .to_return(status: 200, body: {
           success: true,
@@ -15,7 +14,6 @@ module Helpers
     end
 
     def stub_recaptcha_low_score
-      stub_const "ENV", ENV.to_h.merge("ENABLE_RECAPTCHA" => "true")
       stub_request(:post, /google.*recaptcha/)
         .to_return(status: 200, body: {
           success: true,
@@ -27,7 +25,6 @@ module Helpers
     end
 
     def stub_recaptcha_failure
-      stub_const "ENV", ENV.to_h.merge("ENABLE_RECAPTCHA" => "true")
       stub_request(:post, /google.*recaptcha/)
         .to_return(status: 200, body: {
           success: false,


### PR DESCRIPTION
In order to have consistency with how we are using feature flags, this uses Flipper to set the flag for enabling/disabling reCAPTCHA instead of an environment variable.
