### PR TITLE
Remove OJT hours for competency based occupation

### DIFF
--- a/app/models/work_process.rb
+++ b/app/models/work_process.rb
@@ -6,6 +6,8 @@ class WorkProcess < ApplicationRecord
 
   validates :title, presence: true
 
+  delegate :work_processes_hours, to: :occupation_standard, prefix: true, allow_nil: true
+
   def hours
     [maximum_hours, minimum_hours].compact.first
   end

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -16,7 +16,7 @@
                                     <div class="text-3xl font-bold text-yonder-600"><%= work_process.competencies.count %></div>
                                 </div>
                             <% end %>
-                            <% if work_process.hours.present? && work_process.occupation_standard_work_processes_hours.positive?%>
+                            <% if work_process.hours.present? && work_process.occupation_standard_work_processes_hours.positive? %>
                                 <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center">
                                     <div class="text-3xl font-bold text-rust-800"><%= hours_in_human_format(work_process.hours) %></div>
                                 </div>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -16,7 +16,7 @@
                                     <div class="text-3xl font-bold text-yonder-600"><%= work_process.competencies.count %></div>
                                 </div>
                             <% end %>
-                            <% if work_process.hours.present? %>
+                            <% if work_process.occupation_standard_work_processes_hours.positive? && work_process.hours.present? %>
                                 <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center">
                                     <div class="text-3xl font-bold text-rust-800"><%= hours_in_human_format(work_process.hours) %></div>
                                 </div>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -16,7 +16,7 @@
                                     <div class="text-3xl font-bold text-yonder-600"><%= work_process.competencies.count %></div>
                                 </div>
                             <% end %>
-                            <% if work_process.occupation_standard_work_processes_hours.positive? && work_process.hours.present? %>
+                            <% if work_process.hours.present? && work_process.occupation_standard_work_processes_hours.positive?%>
                                 <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center">
                                     <div class="text-3xl font-bold text-rust-800"><%= hours_in_human_format(work_process.hours) %></div>
                                 </div>

--- a/app/views/occupation_standards/show.html.erb
+++ b/app/views/occupation_standards/show.html.erb
@@ -139,7 +139,7 @@
                                       <div class="text-sm font-bold text-yonder-600">Skills</div>
                                   </div>
                               <% end %>
-                              <% if @occupation_standard.work_processes_hours.present? %>
+                              <% if @occupation_standard.work_processes_hours.present? && @occupation_standard.work_processes_hours.positive? %>
                                   <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center">
                                       <div class="text-3xl font-bold text-rust-800">
                                           <%= hours_in_human_format(@occupation_standard.work_processes_hours) %>

--- a/spec/system/occupation_standards/show_spec.rb
+++ b/spec/system/occupation_standards/show_spec.rb
@@ -90,4 +90,13 @@ RSpec.describe "occupation_standards/show" do
 
     expect(page).to have_link "9876", href: occupation_standards_path(q: "9876")
   end
+
+  it "does not show OJT if the occupation standard is competency based" do
+    mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", rapids_code: "9876", ojt_type: :competency)
+    create(:work_process, minimum_hours: 500, occupation_standard: mechanic)
+
+    visit occupation_standard_path(mechanic)
+
+    expect(page).not_to have_content "OJT hours"
+  end
 end


### PR DESCRIPTION
Asana ticket: [https://app.asana.com/0/1203289004376659/1204649515289367/f](https://app.asana.com/0/1203289004376659/1204649515289367/f)

It looks like competency based occupation standards should not have OJT hours. I made it so that these don't show up in the views

![Screenshot 2023-07-19 at 2 49 59 PM](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/58493319/54687d5f-57b3-4a16-b3a0-d8ee94ecbefd)
