### PR TITLE
Remove Homebrew Elasticsearch setup

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,0 @@
-tap "elastic/tap"
-brew "elastic/tap/elasticsearch-full"

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ command.
 The promotion can also be done through the Heroku Dashboard on the [Pipelines page](https://dashboard.heroku.com/pipelines/3657e91f-455e-4fa7-9da7-f6ddc1beb854).
 
 ## Elasticsearch setup
-We are currently using Elasticsearch version 7.17.4. This can be installed with
-[Homebrew](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/brew.html).
+We are currently using Elasticsearch version 7.17.4. See the [Elasticsearch
+documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/install-elasticsearch.html)
+for installation options. The Homebrew installation may no longer work due to
+licensing issues.
 
 ### Populate Elasticsearch
 Once the app is running with the `bin/dev` command, set up the index for the
@@ -99,9 +101,7 @@ through the Rails console:
 ### Kibana setup
 If you are working on any tasks related to Elasticsearch, then it may be helpful
 to set up
-[Kibana](https://www.elastic.co/guide/en/kibana/7.17/introduction.html). This
-can also be installed with
-[Homebrew](https://www.elastic.co/guide/en/kibana/7.17/brew.html).
+[Kibana](https://www.elastic.co/guide/en/kibana/7.17/introduction.html).
 
 To start Kibana, make sure that elasticsearch is already running, then run
 `kibana` in the terminal. Kibana will be available at http://localhost:5601. To

--- a/bin/setup
+++ b/bin/setup
@@ -13,10 +13,10 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  if system "command -v brew > /dev/null"
-    puts "== Installing system dependencies with Homebrew =="
-    system! "brew bundle"
-  end
+  # if system "command -v brew > /dev/null"
+  #   puts "== Installing system dependencies with Homebrew =="
+  #   system! "brew bundle"
+  # end
 
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"


### PR DESCRIPTION
It no longer seems possible to install Elasticsearch 7 through Homebrew due to an incompatible license. This PR removes the Brewfile from the setup.
