### PR TITLE
Remove webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,5 @@ group :test do
   gem "capybara"
   gem "capybara_accessible_selectors", git: "https://github.com/citizensadvice/capybara_accessible_selectors", tag: "v0.10.0"
   gem "selenium-webdriver"
-  gem "webdrivers"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,10 +472,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -549,7 +545,6 @@ DEPENDENCIES
   tzinfo-data
   watir (~> 7.2)
   web-console
-  webdrivers
   webmock
 
 RUBY VERSION

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,8 +10,6 @@ require "capybara/rails"
 require "webmock/rspec"
 require "pundit/rspec"
 
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
The webdrivers gem is no longer necessary as Selenium Manager now handles its own installations of the Chrome Driver.

https://github.com/rails/rails/pull/48847
