### PR TITLE
Make typeahead return user to search results

### DIFF
--- a/app/blueprints/occupation_standard_blueprint.rb
+++ b/app/blueprints/occupation_standard_blueprint.rb
@@ -4,6 +4,6 @@ class OccupationStandardBlueprint < Blueprinter::Base
   field :display_for_typeahead, name: :display
 
   field :link do |resource, options|
-    Rails.application.routes.url_helpers.occupation_standard_path(resource)
+    Rails.application.routes.url_helpers.occupation_standards_path
   end
 end

--- a/app/javascript/controllers/typeahead_controller.js
+++ b/app/javascript/controllers/typeahead_controller.js
@@ -29,10 +29,10 @@ export default class extends Controller {
       // autocompleting the input with the suggestion.
       display: (item, event) => {
         if (event) {
-          Turbo.visit(`${item.link}?q=${this.inputTarget.value}`)
+          Turbo.visit(`${item.link}?q=${item.display}`)
         }
 
-        return this.inputTarget.value;
+        return item.display;
       },
       highlight: true
     })

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -252,10 +252,7 @@ class OccupationStandard < ApplicationRecord
   end
 
   def display_for_typeahead
-    output = title.strip
-    output << " (#{onet_code})" if onet_code
-    output << " (#{rapids_code})" if rapids_code
-    output
+    title.strip
   end
 
   def hours_meet_occupation_requirements?

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -486,28 +486,16 @@ RSpec.describe OccupationStandard, type: :model do
   end
 
   describe "#display_for_typeahead" do
-    it "returns title if onet and rapids code missing" do
-      occupation_standard = build(:occupation_standard, title: "Mechanic", onet_code: nil, rapids_code: nil)
+    it "returns title" do
+      occupation_standard = build_stubbed(:occupation_standard, title: "Mechanic")
 
       expect(occupation_standard.display_for_typeahead).to eq "Mechanic"
     end
 
-    it "returns title and onet code if rapids code missing" do
-      occupation_standard = build(:occupation_standard, title: "Mechanic", onet_code: "15-1342", rapids_code: nil)
+    it "returns trimmed title" do
+      occupation_standard = build_stubbed(:occupation_standard, title: " Mechanical Engineer ")
 
-      expect(occupation_standard.display_for_typeahead).to eq "Mechanic (15-1342)"
-    end
-
-    it "returns title and rapids code if onet code missing" do
-      occupation_standard = build(:occupation_standard, title: "Mechanic", onet_code: nil, rapids_code: "9201")
-
-      expect(occupation_standard.display_for_typeahead).to eq "Mechanic (9201)"
-    end
-
-    it "returns title and both codes if present" do
-      occupation_standard = build(:occupation_standard, title: "Mechanic", onet_code: "15-1342", rapids_code: "9201")
-
-      expect(occupation_standard.display_for_typeahead).to eq "Mechanic (15-1342) (9201)"
+      expect(occupation_standard.display_for_typeahead).to eq "Mechanical Engineer"
     end
   end
 

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "OccupationStandard", type: :request do
 
         expect(result["id"]).to eq occupation_standard.id
         expect(result["display"]).to eq occupation_standard.display_for_typeahead
-        expect(result["link"]).to eq occupation_standard_path(occupation_standard)
+        expect(result["link"]).to eq occupation_standards_path
       end
     end
   end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205098181984738

This uses the standard titles and take the user to search results 


https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/dffb677b-9197-4c70-9d71-d03eb4d0e07c


