### PR TITLE
Exclude Occupation Standards with No Work Processes

### DIFF
--- a/app/models/industry.rb
+++ b/app/models/industry.rb
@@ -10,9 +10,9 @@ class Industry < ApplicationRecord
   scope :current, -> { where(version: CURRENT_VERSION) }
 
   def self.popular(limit: POPULAR_LIMIT)
-    Industry.left_joins(:occupation_standards)
+    Industry.joins(occupation_standards: :work_processes)
       .group("industries.id")
-      .order("COUNT(occupation_standards.id) DESC")
+      .order(Arel.sql("COUNT(DISTINCT occupation_standards.id) DESC"))
       .limit(limit)
   end
 end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -153,6 +153,8 @@ class OccupationStandard < ApplicationRecord
     end
   end
 
+  scope :with_work_processes, -> { joins(:work_processes).distinct }
+
   class << self
     def industry_count(onet_prefix)
       where("SPLIT_PART(onet_code, '-', 1) = ?", onet_prefix.to_s).count

--- a/app/queries/popular_onet_codes_query.rb
+++ b/app/queries/popular_onet_codes_query.rb
@@ -1,9 +1,11 @@
 class PopularOnetCodesQuery
   LIMIT = 4
   def self.run(limit: LIMIT)
-    OccupationStandard.where.not(onet_code: nil)
+    OccupationStandard
+      .joins(:work_processes)
+      .where.not(onet_code: nil)
       .group(:onet_code)
-      .order("COUNT(onet_code) DESC")
+      .order(Arel.sql("COUNT(DISTINCT occupation_standards.id) DESC"))
       .limit(limit)
       .pluck(:onet_code)
   end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -77,7 +77,7 @@
                 </svg>
               </div>
               <h3 class="text-xl font-bold text-primary-700"><%= industry.name %></h3>
-              <p class="font-bold text-accent-100"><%= industry.occupation_standards.count %> Apprenticeships</p>
+              <p class="font-bold text-accent-100"><%= industry.occupation_standards.with_work_processes.count %> Apprenticeships</p>
             </div>
           <% end %>
         <% end %>

--- a/spec/models/industry_spec.rb
+++ b/spec/models/industry_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Industry, type: :model do
       trucking = create(:industry, name: "Trucking")
       create(:industry, name: "Eletrical")
 
-      create_list(:occupation_standard, 2, industry: tech)
-      create(:occupation_standard, industry: trucking)
+      create_list(:occupation_standard, 2, :with_work_processes, industry: tech)
+      create(:occupation_standard, :with_work_processes, industry: trucking)
 
       popular = described_class.popular(limit: 2)
 

--- a/spec/queries/popular_onet_codes_query_spec.rb
+++ b/spec/queries/popular_onet_codes_query_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PopularOnetCodesQuery do
 
     stub_const("PopularOnetCodesQuery::LIMIT", 4)
 
-    result = described_class.run(limit: 3)
+    result = described_class.run
 
     expect(result).to eq ["33", "22", "11"]
   end

--- a/spec/queries/popular_onet_codes_query_spec.rb
+++ b/spec/queries/popular_onet_codes_query_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 RSpec.describe PopularOnetCodesQuery do
   it "returns the onet codes for popular occupation standards" do
-    create(:occupation_standard, title: "Medical Assistant", onet_code: "11")
-    create_list(:occupation_standard, 2, title: "Pipe Fitter", onet_code: "22")
-    create_list(:occupation_standard, 3, title: "Nurse", onet_code: "33")
+    create(:occupation_standard, :with_work_processes, title: "Medical Assistant", onet_code: "11")
+    create_list(:occupation_standard, 2, title: "HR Specialist", onet_code: "12")
+    create_list(:occupation_standard, 2, :with_work_processes, title: "Pipe Fitter", onet_code: "22")
+    create_list(:occupation_standard, 3, :with_work_processes, title: "Nurse", onet_code: "33")
     create(:occupation_standard, onet_code: nil)
 
     result = described_class.run(limit: 3)

--- a/spec/queries/popular_onet_codes_query_spec.rb
+++ b/spec/queries/popular_onet_codes_query_spec.rb
@@ -3,10 +3,12 @@ require "rails_helper"
 RSpec.describe PopularOnetCodesQuery do
   it "returns the onet codes for popular occupation standards" do
     create(:occupation_standard, :with_work_processes, title: "Medical Assistant", onet_code: "11")
-    create_list(:occupation_standard, 2, title: "HR Specialist", onet_code: "12")
+    create(:occupation_standard, title: "HR Specialist", onet_code: "12")
     create_list(:occupation_standard, 2, :with_work_processes, title: "Pipe Fitter", onet_code: "22")
     create_list(:occupation_standard, 3, :with_work_processes, title: "Nurse", onet_code: "33")
     create(:occupation_standard, onet_code: nil)
+
+    stub_const("PopularOnetCodesQuery::LIMIT", 4) 
 
     result = described_class.run(limit: 3)
 

--- a/spec/queries/popular_onet_codes_query_spec.rb
+++ b/spec/queries/popular_onet_codes_query_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PopularOnetCodesQuery do
     create_list(:occupation_standard, 3, :with_work_processes, title: "Nurse", onet_code: "33")
     create(:occupation_standard, onet_code: nil)
 
-    stub_const("PopularOnetCodesQuery::LIMIT", 4) 
+    stub_const("PopularOnetCodesQuery::LIMIT", 4)
 
     result = described_class.run(limit: 3)
 


### PR DESCRIPTION
Asana ticket: [https://app.asana.com/0/1203289004376659/1205072158398816/f](https://app.asana.com/0/1203289004376659/1205072158398816/f)

The popular occupations and industries on the home page were showing a count of all `occupation_standards` even though we filter out the ones without `work_processes` in search. 

I adjusted the queries to only include those with associated `work_processes`. I also added a `with_work_processes` scope to make sure we count the correct occupations