### PR TITLE
The typeahead on the staging site is narrower than the container its in

### DIFF
--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -9,7 +9,7 @@
   <div class="flex px-4 pt-4">
     <%= f.search_field :q,
           value: params[:q],
-          class: "text-gray-900 bg-gray-50",
+          class: "text-gray-900 bg-gray-50 w-full",
           placeholder: "Search by occupation name, O*NET, or industry",
           autocomplete: :off,
           data: {


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205288992536738/f

Fix PR fixes a CSS issue with the typeahead that showed a "jump" when readjusting the input size

Fixed behaviour:


https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/5ad6a19e-3684-4ca8-95d4-e8e57d8f2c68


