### PR TITLE
Revert falling back to asset pipeline in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.assets.css_compressor = nil
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1204541721010818/f

Turn off the fallback to the assets pipeline in production.

I tried this out in staging and didn't see any asset errors. Unfortunately we didn't record the exact details of the issues last time.
