### PR TITLE
Boost national occupation framework standards in search

### DIFF
--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -85,6 +85,9 @@ class OccupationStandardElasticsearchQuery
               end
             end
           end
+          should do
+            term national_standard_type: "occupational_framework"
+          end
         end
       end
     end

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -19,6 +19,7 @@ class OccupationStandardElasticsearchQuery
       end
       query do
         bool do
+          must match_all: {}
           if search_params[:state_id].present?
             filter do
               term state_id: search_params[:state_id]

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -1,16 +1,17 @@
 require "rails_helper"
 
 RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
-  it "retrieves all records if params empty" do
+  it "retrieves all records if params empty, giving priority to national occupational framework standards" do
     os1 = create(:occupation_standard)
-    os2 = create(:occupation_standard)
+    os2 = create(:occupation_standard, :occupational_framework)
+    os3 = create(:occupation_standard)
 
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!
 
     response = described_class.new(search_params: {}).call
 
-    expect(response.records.pluck(:id)).to eq [os2.id, os1.id]
+    expect(response.records.pluck(:id)).to eq [os2.id, os3.id, os1.id]
   end
 
   it "limits size" do

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -204,4 +204,17 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
 
     expect(response.records.pluck(:id)).to eq [occupation_standard.id]
   end
+
+  it "boosts national occupation framework standards" do
+    os1 = create(:occupation_standard, :occupational_framework, title: "Mechanic")
+    os2 = create(:occupation_standard, :program_standard, title: "Mechanic")
+
+    OccupationStandard.import
+    OccupationStandard.__elasticsearch__.refresh_index!
+
+    params = {q: "Mechanic"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to eq [os1.id, os2.id]
+  end
 end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205288992536746/f

This adds a `should` statement for national occupation frameworks to the Elasticsearch search query, giving national occupational framework standards a higher score relevancy. This also adds the `match_all` statement so that queries with no other search parameters will still return all records, not just those that are of type national occupational framework.