### PR TITLE
Add related job titles to Elasticsearch search query

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -96,6 +96,7 @@ class OccupationStandard < ApplicationRecord
       indexes :state_id, type: :keyword
       indexes :title, type: :text, analyzer: :english_stop_with_ngrams
       indexes :work_process_titles, type: :text, analyzer: :english
+      indexes :related_job_titles, type: :text, analyzer: :english_stop_with_ngrams
       indexes :created_at, type: :date
     end
   end
@@ -108,7 +109,8 @@ class OccupationStandard < ApplicationRecord
       national_standard_type: national_standard_type_with_adjustment,
       state: state_abbreviation,
       state_id: state_id,
-      work_process_titles: work_processes.pluck(:title).uniq
+      work_process_titles: work_processes.pluck(:title).uniq,
+      related_job_titles: related_job_titles
     )
   end
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -206,6 +206,11 @@ class OccupationStandard < ApplicationRecord
     end
   end
 
+  def related_job_titles
+    onet = Onet.find_by(code: onet_code)
+    onet&.related_job_titles || []
+  end
+
   def source_file
     data_import.source_file
   end

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -64,7 +64,8 @@ class OccupationStandardElasticsearchQuery
               bool do
                 should do
                   wildcard title: {
-                    value: "*#{q.downcase}*"
+                    value: "*#{q.downcase}*",
+                    boost: 1.5
                   }
                 end
                 should do
@@ -80,6 +81,11 @@ class OccupationStandardElasticsearchQuery
                 should do
                   match industry_name: {
                     query: q
+                  }
+                end
+                should do
+                  wildcard related_job_titles: {
+                    value: "*#{q.downcase}*"
                   }
                 end
                 minimum_should_match 1

--- a/db/migrate/20230830191114_add_related_job_titles_to_onets.rb
+++ b/db/migrate/20230830191114_add_related_job_titles_to_onets.rb
@@ -1,0 +1,5 @@
+class AddRelatedJobTitlesToOnets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :onets, :related_job_titles, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_193911) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_30_191114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -178,6 +178,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_193911) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "related_job_titles", default: [], array: true
     t.index ["code"], name: "unique_code", unique: true
   end
 

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -607,4 +607,26 @@ RSpec.describe OccupationStandard, type: :model do
       expect(occupation_standard.national_standard_type_with_adjustment).to be_nil
     end
   end
+
+  describe "#related_job_titles" do
+    it "returns an empty array if no onet_code" do
+      os = build(:occupation_standard, onet_code: nil)
+
+      expect(os.related_job_titles).to be_empty
+    end
+
+    it "returns an empty array if onet_code but onet has no related_job titles" do
+      onet = build_stubbed(:onet, code: "1234.56", related_job_titles: [])
+      os = build(:occupation_standard, onet_code: "1234.56")
+
+      expect(os.related_job_titles).to be_empty
+    end
+
+    it "returns onet related_jobs titles if has onet_code" do
+      onet = create(:onet, code: "1234.56", related_job_titles: ["Engineer", "Developer"])
+      os = build(:occupation_standard, onet_code: "1234.56")
+
+      expect(os.related_job_titles).to contain_exactly("Engineer", "Developer")
+    end
+  end
 end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -616,14 +616,14 @@ RSpec.describe OccupationStandard, type: :model do
     end
 
     it "returns an empty array if onet_code but onet has no related_job titles" do
-      onet = build_stubbed(:onet, code: "1234.56", related_job_titles: [])
+      build_stubbed(:onet, code: "1234.56", related_job_titles: [])
       os = build(:occupation_standard, onet_code: "1234.56")
 
       expect(os.related_job_titles).to be_empty
     end
 
     it "returns onet related_jobs titles if has onet_code" do
-      onet = create(:onet, code: "1234.56", related_job_titles: ["Engineer", "Developer"])
+      create(:onet, code: "1234.56", related_job_titles: ["Engineer", "Developer"])
       os = build(:occupation_standard, onet_code: "1234.56")
 
       expect(os.related_job_titles).to contain_exactly("Engineer", "Developer")

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -218,4 +218,19 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
 
     expect(response.records.pluck(:id)).to eq [os1.id, os2.id]
   end
+
+  it "returns results that match on related_job_titles" do
+    onet = create(:onet, code: "1234.56", related_job_titles: ["Some other tax job", "Auditor"])
+    os1 = create(:occupation_standard, title: "Auditor")
+    os2 = create(:occupation_standard, title: "Pipe Fitter")
+    os3 = create(:occupation_standard, title: "Tax Specialist", onet_code: "1234.56")
+
+    OccupationStandard.import
+    OccupationStandard.__elasticsearch__.refresh_index!
+
+    params = {q: "Audit"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to eq [os1.id, os3.id]
+  end
 end

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -220,9 +220,9 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
   end
 
   it "returns results that match on related_job_titles" do
-    onet = create(:onet, code: "1234.56", related_job_titles: ["Some other tax job", "Auditor"])
+    create(:onet, code: "1234.56", related_job_titles: ["Some other tax job", "Auditor"])
     os1 = create(:occupation_standard, title: "Auditor")
-    os2 = create(:occupation_standard, title: "Pipe Fitter")
+    _os2 = create(:occupation_standard, title: "Pipe Fitter")
     os3 = create(:occupation_standard, title: "Tax Specialist", onet_code: "1234.56")
 
     OccupationStandard.import


### PR DESCRIPTION
Asana tickets: 
https://app.asana.com/0/1203289004376659/1205360607082017/f
https://app.asana.com/0/1203289004376659/1205288992536758/f

This adds a new field, `related_job_titles` to the the onets table. These titles are stored in Elasticsearch, and are also queried as possible matches to an entered search term.
