### PR TITLE
Add service to query Onet Web Services API for related job titles

### DIFF
--- a/app/services/onet_web_service.rb
+++ b/app/services/onet_web_service.rb
@@ -1,0 +1,22 @@
+class OnetWebService
+  attr_reader :onet, :base_url
+
+  def initialize(onet)
+    @onet = onet
+    @base_url = "https://services.onetcenter.org/ws/online/occupations/#{onet.code}"
+  end
+
+  def call
+    uri = URI.parse(base_url)
+
+    headers = {Authorization: "Bearer #{ENV.fetch("ONET_WEB_SERVICES_API_TOKEN")}"}
+    response = Net::HTTP.get(uri, headers)
+    data = JSON.parse(response)
+
+    related_job_titles = data.dig("sample_of_reported_job_titles", "title")
+
+    unless related_job_titles.nil?
+      onet.update!(related_job_titles: related_job_titles)
+    end
+  end
+end

--- a/app/services/onet_web_service.rb
+++ b/app/services/onet_web_service.rb
@@ -12,7 +12,7 @@ class OnetWebService
     request["Accept"] = "application/json"
     request.basic_auth(ENV["ONET_WEB_SERVICES_USERNAME"], ENV["ONET_WEB_SERVICES_PASSWORD"])
 
-    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) {|http|
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http|
       http.request(request)
     }
 

--- a/app/services/onet_web_service.rb
+++ b/app/services/onet_web_service.rb
@@ -8,10 +8,15 @@ class OnetWebService
 
   def call
     uri = URI.parse(base_url)
+    request = Net::HTTP::Get.new(uri.request_uri)
+    request["Accept"] = "application/json"
+    request.basic_auth(ENV["ONET_WEB_SERVICES_USERNAME"], ENV["ONET_WEB_SERVICES_PASSWORD"])
 
-    headers = {Authorization: "Bearer #{ENV.fetch("ONET_WEB_SERVICES_API_TOKEN")}"}
-    response = Net::HTTP.get(uri, headers)
-    data = JSON.parse(response)
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) {|http|
+      http.request(request)
+    }
+
+    data = JSON.parse(response.body)
 
     related_job_titles = data.dig("sample_of_reported_job_titles", "title")
 

--- a/app/services/scrape_onet_codes.rb
+++ b/app/services/scrape_onet_codes.rb
@@ -4,6 +4,7 @@ class ScrapeOnetCodes
     CSV.parse(file, headers: true) do |row|
       onet = Onet.find_or_initialize_by(name: row["Occupation"])
       onet.update!(code: row["Code"])
+      OnetWebService.new(onet).call
     end
   end
 end

--- a/lib/tasks/deployment/20230830205916_populate_related_job_titles.rake
+++ b/lib/tasks/deployment/20230830205916_populate_related_job_titles.rake
@@ -1,5 +1,5 @@
 namespace :after_party do
-  desc 'Deployment task: populate_related_job_titles'
+  desc "Deployment task: populate_related_job_titles"
   task populate_related_job_titles: :environment do
     puts "Running deploy task 'populate_related_job_titles'"
 

--- a/lib/tasks/deployment/20230830205916_populate_related_job_titles.rake
+++ b/lib/tasks/deployment/20230830205916_populate_related_job_titles.rake
@@ -1,0 +1,15 @@
+namespace :after_party do
+  desc 'Deployment task: populate_related_job_titles'
+  task populate_related_job_titles: :environment do
+    puts "Running deploy task 'populate_related_job_titles'"
+
+    Onet.find_each do |onet|
+      OnetWebService.new(onet).call
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20230830212843_reindex_occupation_standards_after_related_job_titles_addition.rake
+++ b/lib/tasks/deployment/20230830212843_reindex_occupation_standards_after_related_job_titles_addition.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc "Deployment task: reindex_occupation_standards_after_related_job_titles_addition"
+  task reindex_occupation_standards_after_related_job_titles_addition: :environment do
+    puts "Running deploy task 'reindex_occupation_standards_after_related_job_titles_addition'"
+
+    OccupationStandard.__elasticsearch__.create_index!(force: true)
+    OccupationStandard.import
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/fixtures/files/onet_web_service_response.json
+++ b/spec/fixtures/files/onet_web_service_response.json
@@ -1,0 +1,72 @@
+{
+   "code" : "17-2051.00",
+   "title" : "Civil Engineers",
+   "tags" : {
+      "bright_outlook" : false,
+      "green" : false
+   },
+   "description" : "Perform engineering duties in planning, designing, and overseeing construction and maintenance of building structures and facilities, such as roads, railroads, airports, bridges, harbors, channels, dams, irrigation projects, pipelines, power plants, and water and sewage systems.",
+   "sample_of_reported_job_titles" : {
+      "title" : [
+         "City Engineer",
+         "Civil Engineer"
+      ]
+   },
+   "also_see" : {
+      "occupation" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.01/",
+            "code" : "17-2051.01",
+            "title" : "Transportation Engineers",
+            "tags" : {
+               "bright_outlook" : false,
+               "green" : false
+            }
+         },
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.02/",
+            "code" : "17-2051.02",
+            "title" : "Water/Wastewater Engineers",
+            "tags" : {
+               "bright_outlook" : false,
+               "green" : false
+            }
+         }
+      ]
+   },
+   "updated" : {
+      "partial" : false,
+      "year" : 2023,
+      "resource_updated" : [
+         {
+            "title" : "Abilities",
+            "source" : "Analyst",
+            "year" : 2021
+         }
+      ]
+   },
+   "summary_resources" : {
+      "resource" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.00/summary/tasks",
+            "title" : "Tasks"
+         }
+      ]
+   },
+   "details_resources" : {
+      "resource" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.00/details/tasks",
+            "title" : "Tasks"
+         }
+      ]
+   },
+   "custom_resources" : {
+      "resource" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.00/custom/work_activities_outline",
+            "title" : "Work Activities Outline"
+         }
+      ]
+   }
+}

--- a/spec/fixtures/files/onet_web_service_response_empty_field.json
+++ b/spec/fixtures/files/onet_web_service_response_empty_field.json
@@ -1,0 +1,70 @@
+{
+   "code" : "17-2051.00",
+   "title" : "Civil Engineers",
+   "tags" : {
+      "bright_outlook" : false,
+      "green" : false
+   },
+   "description" : "Perform engineering duties in planning, designing, and overseeing construction and maintenance of building structures and facilities, such as roads, railroads, airports, bridges, harbors, channels, dams, irrigation projects, pipelines, power plants, and water and sewage systems.",
+   "sample_of_reported_job_titles" : {
+      "title" : [
+      ]
+   },
+   "also_see" : {
+      "occupation" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.01/",
+            "code" : "17-2051.01",
+            "title" : "Transportation Engineers",
+            "tags" : {
+               "bright_outlook" : false,
+               "green" : false
+            }
+         },
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.02/",
+            "code" : "17-2051.02",
+            "title" : "Water/Wastewater Engineers",
+            "tags" : {
+               "bright_outlook" : false,
+               "green" : false
+            }
+         }
+      ]
+   },
+   "updated" : {
+      "partial" : false,
+      "year" : 2023,
+      "resource_updated" : [
+         {
+            "title" : "Abilities",
+            "source" : "Analyst",
+            "year" : 2021
+         }
+      ]
+   },
+   "summary_resources" : {
+      "resource" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.00/summary/tasks",
+            "title" : "Tasks"
+         }
+      ]
+   },
+   "details_resources" : {
+      "resource" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.00/details/tasks",
+            "title" : "Tasks"
+         }
+      ]
+   },
+   "custom_resources" : {
+      "resource" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.00/custom/work_activities_outline",
+            "title" : "Work Activities Outline"
+         }
+      ]
+   }
+}

--- a/spec/fixtures/files/onet_web_service_response_missing_field.json
+++ b/spec/fixtures/files/onet_web_service_response_missing_field.json
@@ -1,0 +1,66 @@
+{
+   "code" : "17-2051.00",
+   "title" : "Civil Engineers",
+   "tags" : {
+      "bright_outlook" : false,
+      "green" : false
+   },
+   "description" : "Perform engineering duties in planning, designing, and overseeing construction and maintenance of building structures and facilities, such as roads, railroads, airports, bridges, harbors, channels, dams, irrigation projects, pipelines, power plants, and water and sewage systems.",
+   "also_see" : {
+      "occupation" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.01/",
+            "code" : "17-2051.01",
+            "title" : "Transportation Engineers",
+            "tags" : {
+               "bright_outlook" : false,
+               "green" : false
+            }
+         },
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.02/",
+            "code" : "17-2051.02",
+            "title" : "Water/Wastewater Engineers",
+            "tags" : {
+               "bright_outlook" : false,
+               "green" : false
+            }
+         }
+      ]
+   },
+   "updated" : {
+      "partial" : false,
+      "year" : 2023,
+      "resource_updated" : [
+         {
+            "title" : "Abilities",
+            "source" : "Analyst",
+            "year" : 2021
+         }
+      ]
+   },
+   "summary_resources" : {
+      "resource" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.00/summary/tasks",
+            "title" : "Tasks"
+         }
+      ]
+   },
+   "details_resources" : {
+      "resource" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.00/details/tasks",
+            "title" : "Tasks"
+         }
+      ]
+   },
+   "custom_resources" : {
+      "resource" : [
+         {
+            "href" : "https://services.onetcenter.org/ws/online/occupations/17-2051.00/custom/work_activities_outline",
+            "title" : "Work Activities Outline"
+         }
+      ]
+   }
+}

--- a/spec/services/onet_web_service_spec.rb
+++ b/spec/services/onet_web_service_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe OnetWebService do
+  describe "#call" do
+    it "updates related_job_titles field on onet record" do
+      stub_responses
+      onet = create(:onet, code: "17-2051.00", related_job_titles: [])
+      service = described_class.new(onet)
+      service.call
+
+      expect(onet.related_job_titles).to contain_exactly("City Engineer", "Civil Engineer")
+    end
+
+    it "sets related_job_titles to empty if field is empty" do
+      stub_responses_empty_field
+      onet = create(:onet, code: "17-2051.00", related_job_titles: ["Engineer"])
+      service = described_class.new(onet)
+      service.call
+
+      expect(onet.related_job_titles).to be_empty
+    end
+
+    it "does not update related_job_titles if field is missing" do
+      stub_responses_missing_field
+      onet = create(:onet, code: "17-2051.00", related_job_titles: ["Engineer"])
+      service = described_class.new(onet)
+      service.call
+
+      expect(onet.related_job_titles).to eq ["Engineer"]
+    end
+  end
+
+  def stub_responses
+    stub_const "ENV", ENV.to_h.merge("ONET_WEB_SERVICES_API_TOKEN" => "abc123")
+    json_file = file_fixture("onet_web_service_response.json")
+    stub_request(:get, /services.onetcenter.org/)
+      .with(headers: {Authorization: "Bearer abc123"})
+      .to_return(
+        {status: 200, body: json_file.read, headers: {}}
+      )
+  end
+
+  def stub_responses_empty_field
+    stub_const "ENV", ENV.to_h.merge("ONET_WEB_SERVICES_API_TOKEN" => "abc123")
+    json_file = file_fixture("onet_web_service_response_empty_field.json")
+    stub_request(:get, /services.onetcenter.org/)
+      .with(headers: {Authorization: "Bearer abc123"})
+      .to_return(
+        {status: 200, body: json_file.read, headers: {}}
+      )
+  end
+
+  def stub_responses_missing_field
+    stub_const "ENV", ENV.to_h.merge("ONET_WEB_SERVICES_API_TOKEN" => "abc123")
+    json_file = file_fixture("onet_web_service_response_missing_field.json")
+    stub_request(:get, /services.onetcenter.org/)
+      .with(headers: {Authorization: "Bearer abc123"})
+      .to_return(
+        {status: 200, body: json_file.read, headers: {}}
+      )
+  end
+end

--- a/spec/services/onet_web_service_spec.rb
+++ b/spec/services/onet_web_service_spec.rb
@@ -31,30 +31,27 @@ RSpec.describe OnetWebService do
   end
 
   def stub_responses
-    stub_const "ENV", ENV.to_h.merge("ONET_WEB_SERVICES_API_TOKEN" => "abc123")
+    stub_const "ENV", ENV.to_h.merge("ONET_WEB_SERVICES_USERNAME" => "username", "ONET_WEB_SERVICES_PASSWORD" => "secret")
     json_file = file_fixture("onet_web_service_response.json")
     stub_request(:get, /services.onetcenter.org/)
-      .with(headers: {Authorization: "Bearer abc123"})
       .to_return(
         {status: 200, body: json_file.read, headers: {}}
       )
   end
 
   def stub_responses_empty_field
-    stub_const "ENV", ENV.to_h.merge("ONET_WEB_SERVICES_API_TOKEN" => "abc123")
+    stub_const "ENV", ENV.to_h.merge("ONET_WEB_SERVICES_USERNAME" => "username", "ONET_WEB_SERVICES_PASSWORD" => "secret")
     json_file = file_fixture("onet_web_service_response_empty_field.json")
     stub_request(:get, /services.onetcenter.org/)
-      .with(headers: {Authorization: "Bearer abc123"})
       .to_return(
         {status: 200, body: json_file.read, headers: {}}
       )
   end
 
   def stub_responses_missing_field
-    stub_const "ENV", ENV.to_h.merge("ONET_WEB_SERVICES_API_TOKEN" => "abc123")
+    stub_const "ENV", ENV.to_h.merge("ONET_WEB_SERVICES_USERNAME" => "username", "ONET_WEB_SERVICES_PASSWORD" => "secret")
     json_file = file_fixture("onet_web_service_response_missing_field.json")
     stub_request(:get, /services.onetcenter.org/)
-      .with(headers: {Authorization: "Bearer abc123"})
       .to_return(
         {status: 200, body: json_file.read, headers: {}}
       )

--- a/spec/services/scrape_onet_codes_spec.rb
+++ b/spec/services/scrape_onet_codes_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe ScrapeOnetCodes do
       stub_responses
       onet = create(:onet, name: "Actuaries", code: "1234.56")
 
+      service = instance_double("OnetWebService", call: nil)
+      expect(OnetWebService).to receive(:new).and_return(service).thrice
+      expect(service).to receive(:call).thrice
+
       expect {
         described_class.new.call
       }.to change(Onet, :count).by(2)


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205360607082020/f

This adds a new service that queries the [Onet Web Services API](https://services.onetcenter.org/reference/online/occupation#overview) for related job titles. When the ONET scraper is run, it will also query this API for the related job titles. We also added an After Party task so existing ONET code records can be updated.