### PR TITLE
Add a search analyzer to be used with the autocomplete searches

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -63,6 +63,7 @@ class OccupationStandard < ApplicationRecord
           },
           autocomplete_search: {
             tokenizer: "standard",
+            filter: ["lowercase"],
             char_filter: ["my_char_filter"]
           }
         }
@@ -80,7 +81,7 @@ class OccupationStandard < ApplicationRecord
       indexes :state, type: :text, analyzer: :keyword
       indexes :state_id, type: :keyword
       indexes :title, type: :text, analyzer: :english do
-        indexes :typeahead, type: :text, analyzer: :autocomplete
+        indexes :typeahead, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
       end
       indexes :work_process_titles, type: :text, analyzer: :english
       indexes :related_job_titles, type: :text, analyzer: :english

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -60,6 +60,10 @@ class OccupationStandard < ApplicationRecord
             tokenizer: "autocomplete_tokenizer",
             filter: ["lowercase"],
             char_filter: ["my_char_filter"]
+          },
+          autocomplete_search: {
+            tokenizer: "standard",
+            char_filter: ["my_char_filter"]
           }
         }
       }
@@ -71,8 +75,8 @@ class OccupationStandard < ApplicationRecord
       indexes :industry_name, type: :text, analyzer: :english
       indexes :national_standard_type, type: :text, analyzer: :keyword
       indexes :ojt_type, type: :text, analyzer: :keyword
-      indexes :onet_code, type: :text, analyzer: :autocomplete
-      indexes :rapids_code, type: :text, analyzer: :autocomplete
+      indexes :onet_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
+      indexes :rapids_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
       indexes :state, type: :text, analyzer: :keyword
       indexes :state_id, type: :keyword
       indexes :title, type: :text, analyzer: :english do

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -92,13 +92,13 @@ class OccupationStandardElasticsearchQuery
                   }
                 end
                 should do
-                  wildcard rapids_code: {
-                    value: "*#{standardize_autocomplete_terms(q)}*"
+                  match rapids_code: {
+                    query: q
                   }
                 end
                 should do
-                  wildcard onet_code: {
-                    value: "*#{standardize_autocomplete_terms(q)}*"
+                  match onet_code: {
+                    query: q
                   }
                 end
                 minimum_should_match 1
@@ -123,10 +123,6 @@ class OccupationStandardElasticsearchQuery
   end
 
   private
-
-  def standardize_autocomplete_terms(q)
-    q.gsub(/\.|-|,/, "").downcase
-  end
 
   def debug_query(response)
     if debug

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
 
   it "allows searching occupation standards by onet code" do
     os1 = create(:occupation_standard, onet_code: "12.3456")
-    os2 = create(:occupation_standard, onet_code: "12.34567")
-    create(:occupation_standard, title: "HR", onet_code: "12.3")
+    os2 = create(:occupation_standard, onet_code: "12.3457")
+    create(:occupation_standard, title: "HR", onet_code: "11.2345")
 
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     os3 = create(:occupation_standard, title: "Operator of Drones")
     os4 = create(:occupation_standard, title: "Drone Extraordinaire")
     create(:occupation_standard, title: "Mechanic")
+    create(:occupation_standard, title: "Amortization Calculator")
 
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!
@@ -100,11 +101,17 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     record_ids = response.records.pluck(:id)
     expect(record_ids.first).to eq os3.id
     expect(record_ids).to contain_exactly(os1.id, os2.id, os3.id, os4.id)
+
+    params = {q: "amaz"}
+    response = described_class.new(search_params: params).call
+
+    record_ids = response.records.pluck(:id)
+    expect(record_ids).to contain_exactly(os1.id)
   end
 
   it "allows searching occupation standards by rapids code" do
     os1 = create(:occupation_standard, rapids_code: "1234")
-    os2 = create(:occupation_standard, rapids_code: "1234CB")
+    os2 = create(:occupation_standard, rapids_code: "1234cB")
     create(:occupation_standard, title: "HR", rapids_code: "123")
 
     OccupationStandard.import
@@ -114,6 +121,11 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     response = described_class.new(search_params: params).call
 
     expect(response.records.pluck(:id)).to contain_exactly(os1.id, os2.id)
+
+    params = {q: "1234Cb"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to contain_exactly(os2.id)
   end
 
   it "allows searching occupation standards by onet code" do

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -114,16 +114,11 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     response = described_class.new(search_params: params).call
 
     expect(response.records.pluck(:id)).to contain_exactly(os1.id, os2.id)
-
-    params = {q: "34CB"}
-    response = described_class.new(search_params: params).call
-
-    expect(response.records.pluck(:id)).to contain_exactly(os2.id)
   end
 
   it "allows searching occupation standards by onet code" do
     os1 = create(:occupation_standard, onet_code: "12.3456")
-    os2 = create(:occupation_standard, onet_code: "12.3457")
+    create(:occupation_standard, onet_code: "12.3457")
     create(:occupation_standard, title: "HR", onet_code: "11.2345")
 
     OccupationStandard.import
@@ -132,7 +127,7 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     params = {q: "12.3456"}
     response = described_class.new(search_params: params).call
 
-    expect(response.records.pluck(:id)).to contain_exactly(os1.id, os2.id)
+    expect(response.records.pluck(:id)).to contain_exactly(os1.id)
   end
 
   it "allows filtering occupation standards by state id" do

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -719,6 +719,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.enable :use_elasticsearch_for_search
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
       pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter")
+      pippen_apple_collector = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pippen Apple Collector")
 
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!
@@ -731,6 +732,7 @@ RSpec.describe "occupation_standards/index" do
 
       expect(page).to have_selector "div", class: "tt-suggestion", text: mechanic.display_for_typeahead
       expect(page).to_not have_selector "div", class: "tt-suggestion", text: pipe_fitter.display_for_typeahead
+      expect(page).to_not have_selector "div", class: "tt-suggestion", text: pippen_apple_collector.display_for_typeahead
 
       visit occupation_standards_path
 
@@ -738,6 +740,15 @@ RSpec.describe "occupation_standards/index" do
 
       expect(page).to_not have_selector "div", class: "tt-suggestion", text: mechanic.display_for_typeahead
       expect(page).to have_selector "div", class: "tt-suggestion", text: pipe_fitter.display_for_typeahead
+      expect(page).to_not have_selector "div", class: "tt-suggestion", text: pippen_apple_collector.display_for_typeahead
+
+      visit occupation_standards_path
+
+      fill_in "q", with: "PIPE"
+
+      expect(page).to_not have_selector "div", class: "tt-suggestion", text: mechanic.display_for_typeahead
+      expect(page).to have_selector "div", class: "tt-suggestion", text: pipe_fitter.display_for_typeahead
+      expect(page).to_not have_selector "div", class: "tt-suggestion", text: pippen_apple_collector.display_for_typeahead
       Flipper.disable :use_elasticsearch_for_search
     end
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205398471115381/f

The autocomplete analyzer at index time breaks up the term into edge ngrams from 3-20. We had been also using the autocomplete analyzer at search time, but this was causing problems as a search term of "tree" would return "tree trimmer" but would also return "truck driver". Per the [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/analysis-edgengram-tokenizer.html#_example_configuration_7), we should be using a separate analyzer to use at search time:

> Usually we recommend using the same analyzer at index time and at search time. In the case of the edge_ngram tokenizer, the advice is different. It only makes sense to use the edge_ngram tokenizer at index time, to ensure that partial words are available for matching in the index. At search time, just search for the terms the user has typed in, for instance: Quick Fo

We created a new search analyzer to be used with the autocomplete indexing analyzer that uses the standard tokenizer with a lowercase filter that does not overmatch results.

Example  before change:

<img width="719" alt="Screen Shot 2023-09-07 at 11 57 17 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/44564556-251a-4dd1-9e63-4ef6b148021e">

Example after change:

<img width="733" alt="Screen Shot 2023-09-07 at 11 58 15 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/49121022-7afc-4e93-a333-4fbcdbacd0da">
<img width="721" alt="Screen Shot 2023-09-07 at 11 58 20 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/b87db8ea-0de9-4103-a4be-113a2aae60ca">



