### PR TITLE
Fix occupational frameworks count

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -141,7 +141,7 @@ class OccupationStandard < ApplicationRecord
   scope :by_national_standard_type, ->(standard_types) do
     if standard_types.present?
       types = [standard_types].flatten
-      occupational_framework = types.delete("occupational_framework")
+      occupational_framework = types.delete("occupational_framework") || types.delete(:occupational_framework)
 
       query = where(national_standard_type: types)
       if occupational_framework

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -147,6 +147,15 @@ RSpec.describe OccupationStandard, type: :model do
       expect(described_class.by_national_standard_type(%w[program_standard occupational_framework])).to contain_exactly(os1, os2)
     end
 
+    it "if only occupational_framework passed as symbol, returns Urban Institute standards only" do
+      org = create(:organization, title: "Urban Institute")
+      os1 = create(:occupation_standard, :occupational_framework, organization: org)
+      create(:occupation_standard, :occupational_framework)
+      create(:occupation_standard, :program_standard)
+
+      expect(described_class.by_national_standard_type(:occupational_framework)).to contain_exactly(os1)
+    end
+
     it "returns all records if empty string provided" do
       standards = create_pair(:occupation_standard, :program_standard)
 


### PR DESCRIPTION
Asana ticket: 

This allows  `OccupationStandard.by_national_standard_type` to receive a single value as a symbol and work as expected. Previously it only worked with the value as string, since it is the format we search from the query form checkbox

This is how is called from home.html.erb, which display an incorrect result:

```
 <p class="font-bold text-accent-100">
   <%= OccupationStandard.by_national_standard_type(:occupational_framework).count %> Apprenticeships
 </p>
```