### PR TITLE
Add redraw when scrolling document

### DIFF
--- a/app/javascript/controllers/pdf_editor_controller.js
+++ b/app/javascript/controllers/pdf_editor_controller.js
@@ -60,6 +60,7 @@ export default class extends Controller {
       addons: UIXAddons
     });
 
+
     if (this.fileUrlValue && this.fileNameValue) {
       this.pdfui.openPDFByHttpRangeRequest(
         {
@@ -70,6 +71,7 @@ export default class extends Controller {
         },
         { fileName: this.fileNameValue }
       );
+      window.addEventListener("scroll", this.redrawPdf.bind(this))
     }
   }
 
@@ -116,5 +118,17 @@ export default class extends Controller {
           alert("Oh no, something went wrong!");
         });
       })
+  }
+
+  // Workaround suggested by FoxitSDK team.
+  // This will trigger a redraw on every scroll. It impacts the
+  // performance, but based on users and document length, it's
+  // good enough for now
+  redrawPdf() {
+    this.pdfui.getPDFViewer().then(pdfViewer => pdfViewer.redraw())
+  }
+
+  disconnect() {
+    window.removeEventListener("scroll", this.redrawPdf);
   }
 }


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205355375729695/f

This PR adds a workaround to pages not loading. This will trigger a viewer redender on scroll. It is inefficient, but a workaround nevertheless 
