### PR TITLE
Add ONET tokenizer to match on prefix

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -43,6 +43,11 @@ class OccupationStandard < ApplicationRecord
             min_gram: 2,
             max_gram: 20,
             token_chars: ["letter", "digit", "punctuation"]
+          },
+          onet_prefix_tokenizer: {
+            type: "pattern",
+            pattern: "^(\\d{2})\\D", # capture first two digits of ONET code
+            group: 1
           }
         },
         char_filter: {
@@ -65,6 +70,9 @@ class OccupationStandard < ApplicationRecord
             tokenizer: "standard",
             filter: ["lowercase"],
             char_filter: ["my_char_filter"]
+          },
+          onet_prefix: {
+            tokenizer: "onet_prefix_tokenizer"
           }
         }
       }

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -46,7 +46,7 @@ class OccupationStandard < ApplicationRecord
           },
           onet_prefix_tokenizer: {
             type: "pattern",
-            pattern: "^(\\d{2})\\D", # capture first two digits of ONET code
+            pattern: "^(\\d{2})", # capture first two digits of ONET code
             group: 1
           }
         },

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -84,7 +84,9 @@ class OccupationStandard < ApplicationRecord
       indexes :industry_name, type: :text, analyzer: :english
       indexes :national_standard_type, type: :text, analyzer: :keyword
       indexes :ojt_type, type: :text, analyzer: :keyword
-      indexes :onet_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
+      indexes :onet_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search do
+        indexes :prefix, type: :text, analyzer: :onet_prefix
+      end
       indexes :rapids_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
       indexes :state, type: :text, analyzer: :keyword
       indexes :state_id, type: :keyword


### PR DESCRIPTION
Precursor for Asana ticket: https://app.asana.com/0/1203289004376659/1205503615126496/f

This adds an analyzer that allows matching against the ONET prefix. In a future PR, this analyzer will be used to help return better search results by filtering on the ONET code that matches the first result.

<img width="1156" alt="Screen Shot 2023-09-18 at 2 29 21 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/1d5d76b6-b8f5-43bd-9de6-094b81d95ad8">

<img width="1133" alt="Screen Shot 2023-09-18 at 2 29 55 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/4e692700-2a05-4126-85fc-312a83c31ebd">

<img width="1547" alt="Screen Shot 2023-09-18 at 2 30 46 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/d75ab692-8983-4142-8af8-c60f606a306f">

