### PR TITLE
Add synonym filter to English analyzer

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -60,6 +60,26 @@ class OccupationStandard < ApplicationRecord
             ]
           }
         },
+        filter: {
+          english_stop: {
+            type: "stop",
+            stopwords: "_english_"
+          },
+          english_stemmer: {
+            type: "stemmer",
+            language: "english"
+          },
+          english_possessive_stemmer: {
+            type: "stemmer",
+            language: "possessive_english"
+          },
+          synonym: {
+            type: "synonym",
+            synonyms: [
+              "UX, User experience"
+            ]
+          }
+        },
         analyzer: {
           autocomplete: {
             tokenizer: "autocomplete_tokenizer",
@@ -73,6 +93,16 @@ class OccupationStandard < ApplicationRecord
           },
           onet_prefix: {
             tokenizer: "onet_prefix_tokenizer"
+          },
+          rebuilt_english: {
+            tokenizer: "standard",
+            filter: [
+              "english_possessive_stemmer",
+              "lowercase",
+              "english_stop",
+              "english_stemmer",
+              "synonym"
+            ]
           }
         }
       }
@@ -90,11 +120,11 @@ class OccupationStandard < ApplicationRecord
       indexes :rapids_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
       indexes :state, type: :text, analyzer: :keyword
       indexes :state_id, type: :keyword
-      indexes :title, type: :text, analyzer: :english do
+      indexes :title, type: :text, analyzer: :rebuilt_english do
         indexes :typeahead, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
       end
       indexes :work_process_titles, type: :text, analyzer: :english
-      indexes :related_job_titles, type: :text, analyzer: :english
+      indexes :related_job_titles, type: :text, analyzer: :rebuilt_english
       indexes :created_at, type: :date
     end
   end

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -287,4 +287,23 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
 
     expect(response.records.pluck(:id)).to eq [os1.id, os3.id]
   end
+
+  it "returns results that match synonyms" do
+    os1 = create(:occupation_standard, :with_work_processes, title: "User experience designer")
+    os2 = create(:occupation_standard, :with_work_processes, title: "UX Designer")
+    create(:occupation_standard, :with_work_processes, title: "Mechanic")
+
+    OccupationStandard.import
+    OccupationStandard.__elasticsearch__.refresh_index!
+
+    params = {q: "usER expERience"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to eq [os1.id, os2.id]
+
+    params = {q: "ux design"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to eq [os2.id, os1.id]
+  end
 end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205503615126500/f

This rebuilds the English analyzer to add a synonyms filter. If the list gets long it is recommended to use a file instead, but this file must live on the Elasticsearch server, not the Rails server.
