### PR TITLE
Fix PDF editor not loading pages correctly

### DIFF
--- a/app/javascript/controllers/pdf_editor_controller.js
+++ b/app/javascript/controllers/pdf_editor_controller.js
@@ -70,7 +70,6 @@ export default class extends Controller {
         },
         { fileName: this.fileNameValue }
       );
-      window.addEventListener("scroll", this.redrawPdf.bind(this))
     }
   }
 
@@ -117,17 +116,5 @@ export default class extends Controller {
           alert("Oh no, something went wrong!");
         });
       })
-  }
-
-  // Workaround suggested by FoxitSDK team.
-  // This will trigger a redraw on every scroll. It impacts the
-  // performance, but based on users and document length, it's
-  // good enough for now
-  redrawPdf() {
-    this.pdfui.getPDFViewer().then(pdfViewer => pdfViewer.redraw())
-  }
-
-  disconnect() {
-    window.removeEventListener("scroll", this.redrawPdf);
   }
 }

--- a/app/views/admin/redact_files/new.html.erb
+++ b/app/views/admin/redact_files/new.html.erb
@@ -12,7 +12,7 @@
 
   <div
     id="#pdf-ui"
-    class="h-full"
+    class="absolute w-screen h-screen overflow-hidden"
     data-pdf-editor-target="renderTo">
   </div>
 </div>


### PR DESCRIPTION
* The element was taking all the space available and event scroll was not being propagated correctly. This commit adds the corresponding tailwind classes to the target element and removes the workaround

Asana ticket: https://app.asana.com/0/1203289004376659/1205355375729695/f
