### PR TITLE
Make editor zoom to 100% by default

### DIFF
--- a/app/javascript/controllers/pdf_editor_controller.js
+++ b/app/javascript/controllers/pdf_editor_controller.js
@@ -69,7 +69,10 @@ export default class extends Controller {
           },
         },
         { fileName: this.fileNameValue }
-      );
+      ).then(() => {
+        this.pdfui.getPDFViewer().then(viewer => viewer.zoomTo(1))
+      });
+
     }
   }
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205398237601073/f

Call [zoomTo](https://developers.foxit.com/resources/pdf-sdk-web/api_reference/class_p_d_f_viewer.html#adcaa51399f31e7616379f0c1d46cac74) after document is loaded to make the zoom 100% 
