### PR TITLE
Add Occupations controller

### DIFF
--- a/app/blueprints/occupation_blueprint.rb
+++ b/app/blueprints/occupation_blueprint.rb
@@ -1,0 +1,9 @@
+class OccupationBlueprint < Blueprinter::Base
+  identifier :id
+
+  field :display_for_typeahead, name: :display
+
+  field :link do |resource, options|
+    Rails.application.routes.url_helpers.occupations_path
+  end
+end

--- a/app/controllers/occupations_controller.rb
+++ b/app/controllers/occupations_controller.rb
@@ -6,5 +6,4 @@ class OccupationsController < ApplicationController
     occupations = es_response.records.to_a
     render json: OccupationBlueprint.render(occupations)
   end
-
 end

--- a/app/controllers/occupations_controller.rb
+++ b/app/controllers/occupations_controller.rb
@@ -1,0 +1,10 @@
+class OccupationsController < ApplicationController
+  def index
+    es_response = OccupationElasticsearchQuery.new(
+      search_params: params.permit(:q).to_h
+    ).call
+    occupations = es_response.records.to_a
+    render json: OccupationBlueprint.render(occupations)
+  end
+
+end

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -41,12 +41,16 @@ class Occupation < ApplicationRecord
   settings(es_settings) do
     mappings dynamic: false do
       indexes :title, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
+      indexes :rapids_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
+      indexes :onet_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
     end
   end
 
   def as_indexed_json(_ = {})
     as_json(
-      only: [:title]
+      only: [:title, :rapids_code, :onet_code]
+    ).merge(
+      onet_code: onet_code
     )
   end
 

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -48,7 +48,7 @@ class Occupation < ApplicationRecord
 
   def as_indexed_json(_ = {})
     as_json(
-      only: [:title, :rapids_code, :onet_code]
+      only: [:title, :rapids_code]
     ).merge(
       onet_code: onet_code
     )

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -50,6 +50,10 @@ class Occupation < ApplicationRecord
     )
   end
 
+  def display_for_typeahead
+    title.strip
+  end
+
   def to_s
     "#{title} (#{rapids_code})"
   end

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -14,13 +14,33 @@ class Occupation < ApplicationRecord
   number_of_shards = Rails.env.production? ? 2 : 1
   es_settings = {
     index: {
-      number_of_shards: number_of_shards
+      number_of_shards: number_of_shards,
+      analysis: {
+        tokenizer: {
+          autocomplete_tokenizer: {
+            type: "edge_ngram",
+            min_gram: 2,
+            max_gram: 20,
+            token_chars: ["letter", "digit", "punctuation"]
+          }
+        },
+        analyzer: {
+          autocomplete: {
+            tokenizer: "autocomplete_tokenizer",
+            filter: ["lowercase"]
+          },
+          autocomplete_search: {
+            tokenizer: "standard",
+            filter: ["lowercase"]
+          }
+        }
+      }
     }
   }
 
   settings(es_settings) do
     mappings dynamic: false do
-      indexes :title, type: :text, analyzer: :english
+      indexes :title, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
     end
   end
 

--- a/app/queries/occupation_elasticsearch_query.rb
+++ b/app/queries/occupation_elasticsearch_query.rb
@@ -1,0 +1,58 @@
+require "elasticsearch/dsl"
+
+class OccupationElasticsearchQuery
+  include Elasticsearch::DSL
+
+  attr_reader :search_params, :offset, :debug
+
+  def initialize(search_params:, offset: 0, debug: false)
+    @search_params = search_params
+    @offset = offset
+    @debug = debug
+  end
+
+  def call
+    definition = search do
+      sort do
+        by :_score, order: :desc
+        by :created_at, order: :desc
+      end
+      query do
+        bool do
+          must match_all: {}
+          if search_params[:q].present?
+            q = search_params[:q]
+            must do
+              match "title.typeahead": {
+                query: q
+              }
+            end
+          end
+        end
+      end
+    end
+    # Size and From must be passed here rather than defined in the query in
+    # order for Pagy to work correctly.
+    response = OccupationStandard.__elasticsearch__.search(
+      definition,
+      from: offset,
+      size: Pagy::DEFAULT[:items]
+    )
+    debug_query(response)
+    response
+  end
+
+  private
+
+  def debug_query(response)
+    if debug
+      puts "BODY"
+      puts response.search.definition[:body].to_json
+      puts "HITS: #{response.results.total}"
+      response.results.each do |result|
+        #        puts result.inspect
+        puts "#{result._id}: #{result._score}"
+      end
+    end
+  end
+end

--- a/app/queries/occupation_elasticsearch_query.rb
+++ b/app/queries/occupation_elasticsearch_query.rb
@@ -13,17 +13,13 @@ class OccupationElasticsearchQuery
 
   def call
     definition = search do
-      sort do
-        by :_score, order: :desc
-        by :created_at, order: :desc
-      end
       query do
         bool do
           must match_all: {}
           if search_params[:q].present?
             q = search_params[:q]
             must do
-              match "title.typeahead": {
+              match title: {
                 query: q
               }
             end
@@ -31,12 +27,9 @@ class OccupationElasticsearchQuery
         end
       end
     end
-    # Size and From must be passed here rather than defined in the query in
-    # order for Pagy to work correctly.
-    response = OccupationStandard.__elasticsearch__.search(
+    response = Occupation.__elasticsearch__.search(
       definition,
-      from: offset,
-      size: Pagy::DEFAULT[:items]
+      from: offset
     )
     debug_query(response)
     response

--- a/app/queries/occupation_elasticsearch_query.rb
+++ b/app/queries/occupation_elasticsearch_query.rb
@@ -17,10 +17,26 @@ class OccupationElasticsearchQuery
         bool do
           must match_all: {}
           if search_params[:q].present?
+            q = search_params[:q]
             must do
-              match title: {
-                query: search_params[:q]
-              }
+              bool do
+                should do
+                  match title: {
+                    query: q
+                  }
+                end
+                should do
+                  match rapids_code: {
+                    query: q
+                  }
+                end
+                should do
+                  match onet_code: {
+                    query: q
+                  }
+                end
+                minimum_should_match 1
+              end
             end
           end
         end

--- a/app/queries/occupation_elasticsearch_query.rb
+++ b/app/queries/occupation_elasticsearch_query.rb
@@ -17,10 +17,9 @@ class OccupationElasticsearchQuery
         bool do
           must match_all: {}
           if search_params[:q].present?
-            q = search_params[:q]
             must do
               match title: {
-                query: q
+                query: search_params[:q]
               }
             end
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
 
   resources :standards_imports, only: [:new, :create, :show]
   resources :occupation_standards, only: [:index, :show]
-  resources :occupations, only: [:index], defaults: { format: :json }
+  resources :occupations, only: [:index], defaults: {format: :json}
   resources :industries, only: [:index]
   resources :states, only: [:index]
   get "home", as: :home_page, to: "pages#home"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
 
   resources :standards_imports, only: [:new, :create, :show]
   resources :occupation_standards, only: [:index, :show]
+  resources :occupations, only: [:index], defaults: { format: :json }
   resources :industries, only: [:index]
   resources :states, only: [:index]
   get "home", as: :home_page, to: "pages#home"

--- a/lib/tasks/deployment/20230920180858_reindex_occupations.rake
+++ b/lib/tasks/deployment/20230920180858_reindex_occupations.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc "Deployment task: reindex_occupations"
+  task reindex_occupations: :environment do
+    puts "Running deploy task 'reindex_occupations'"
+
+    Occupation.__elasticsearch__.create_index!(force: true)
+    Occupation.import
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/queries/occupation_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_elasticsearch_query_spec.rb
@@ -45,15 +45,15 @@ RSpec.describe OccupationElasticsearchQuery, :elasticsearch do
     onet3 = create(:onet, code: "11.2345")
 
     o1 = create(:occupation, onet: onet1)
-    create(:occupation, onet: onet2)
+    o2 = create(:occupation, onet: onet2)
     create(:occupation, onet: onet3)
 
     Occupation.import
     Occupation.__elasticsearch__.refresh_index!
 
-    params = {q: "12.3456"}
+    params = {q: "12.345"}
     response = described_class.new(search_params: params).call
 
-    expect(response.records.pluck(:id)).to contain_exactly(o1.id)
+    expect(response.records.pluck(:id)).to contain_exactly(o1.id, o2.id)
   end
 end

--- a/spec/queries/occupation_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_elasticsearch_query_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe OccupationElasticsearchQuery, :elasticsearch do
+  it "allows typeahead searching of occupation by title" do
+    o1 = create(:occupation, title: "Software Developer")
+    o2 = create(:occupation, title: "Software Engineer")
+    create(:occupation, title: "Microsoft Specialist")
+
+    Occupation.import
+    Occupation.__elasticsearch__.refresh_index!
+
+    params = {q: "soft"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to contain_exactly(o1.id, o2.id)
+
+    params = {q: "develop"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to contain_exactly(o1.id)
+  end
+end

--- a/spec/queries/occupation_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_elasticsearch_query_spec.rb
@@ -19,4 +19,41 @@ RSpec.describe OccupationElasticsearchQuery, :elasticsearch do
 
     expect(response.records.pluck(:id)).to contain_exactly(o1.id)
   end
+
+  it "allows typeahead searching of occupations by rapids code" do
+    o1 = create(:occupation, rapids_code: "1234")
+    o2 = create(:occupation, rapids_code: "1234cB")
+    create(:occupation, rapids_code: "123")
+
+    Occupation.import
+    Occupation.__elasticsearch__.refresh_index!
+
+    params = {q: "1234"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to contain_exactly(o1.id, o2.id)
+
+    params = {q: "1234Cb"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to contain_exactly(o2.id)
+  end
+
+  it "allows typeahead searching of occupations by onet code" do
+    onet1 = create(:onet, code: "12.3456")
+    onet2 = create(:onet, code: "12.3457")
+    onet3 = create(:onet, code: "11.2345")
+
+    o1 = create(:occupation, onet: onet1)
+    create(:occupation, onet: onet2)
+    create(:occupation, onet: onet3)
+
+    Occupation.import
+    Occupation.__elasticsearch__.refresh_index!
+
+    params = {q: "12.3456"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to contain_exactly(o1.id)
+  end
 end

--- a/spec/requests/occupations_spec.rb
+++ b/spec/requests/occupations_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "Occupation", type: :request do
 
       Occupation.import
       Occupation.__elasticsearch__.refresh_index!
-      
+
       get occupations_path, params: {format: "json", q: "Mech"}
-      
+
       expect(response_json[0][:display]).to eq "Mechanic"
       expect(response_json[0][:link]).to eq "/occupations"
-      
+
       expect(response).to be_successful
       expect(response.content_type).to eq "application/json; charset=utf-8"
     end

--- a/spec/requests/occupations_spec.rb
+++ b/spec/requests/occupations_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe "Occupation", type: :request do
   describe "GET /index.json", :elasticsearch do
     it "returns a json response" do
-      create(:occupation, title: "Mechanic")
+      onet = create(:onet, code: "12-3456")
+      create(:occupation, title: "Mechanic", rapids_code: "5678CB", onet: onet)
 
       Occupation.import
       Occupation.__elasticsearch__.refresh_index!
@@ -15,6 +16,16 @@ RSpec.describe "Occupation", type: :request do
 
       expect(response).to be_successful
       expect(response.content_type).to eq "application/json; charset=utf-8"
+
+      get occupations_path, params: {format: "json", q: "12-34"}
+
+      expect(response_json[0][:display]).to eq "Mechanic"
+      expect(response_json[0][:link]).to eq "/occupations"
+
+      get occupations_path, params: {format: "json", q: "567"}
+
+      expect(response_json[0][:display]).to eq "Mechanic"
+      expect(response_json[0][:link]).to eq "/occupations"
     end
   end
 end

--- a/spec/requests/occupations_spec.rb
+++ b/spec/requests/occupations_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "Occupation", type: :request do
+  describe "GET /index.json", :elasticsearch do
+    it "returns a json response" do
+      create(:occupation, title: "Mechanic")
+
+      Occupation.import
+      Occupation.__elasticsearch__.refresh_index!
+      
+      get occupations_path, params: {format: "json", q: "Mech"}
+      
+      expect(response_json[0][:display]).to eq "Mechanic"
+      expect(response_json[0][:link]).to eq "/occupations"
+      
+      expect(response).to be_successful
+      expect(response.content_type).to eq "application/json; charset=utf-8"
+    end
+  end
+end


### PR DESCRIPTION
Asana ticket: [https://app.asana.com/0/1203289004376659/1205503615126504/f](https://app.asana.com/0/1203289004376659/1205503615126504/f)

This adds an Occupations controller in preparation for using occupations in the typeahead results.
