### PR TITLE
The system should return already-aggregated results from Elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Tools" under the Management section.
 To see all of the records in the `occupation_standards` in the Kibana Dev Tools enter:
 
 ```
-GET occupation_standards/_search
+GET occupation_standards_development/_search
 {
   "query": {
     "match_all": {}

--- a/app/controllers/occupation_standards_controller.rb
+++ b/app/controllers/occupation_standards_controller.rb
@@ -12,7 +12,17 @@ class OccupationStandardsController < ApplicationController
         items: Pagy::DEFAULT[:items],
         page: current_page
       )
-      @occupation_standards = es_response.records.to_a
+      occupation_standards = es_response.records
+
+      @occupation_standards = occupation_standards.map_with_hit do |occupation_standard, result|
+        inner_hits = result.inner_hits["children"]["hits"]["hits"]
+        if inner_hits.any?
+          occupation_standard.inner_hits = InnerHit.from_result(inner_hits)
+        end
+
+        occupation_standard
+      end
+
     else
       @occupation_standards_search = OccupationStandardQuery::Container.new(
         search_term_params: search_term_params

--- a/app/controllers/occupation_standards_controller.rb
+++ b/app/controllers/occupation_standards_controller.rb
@@ -12,17 +12,7 @@ class OccupationStandardsController < ApplicationController
         items: Pagy::DEFAULT[:items],
         page: current_page
       )
-      occupation_standards = es_response.records
-
-      @occupation_standards = occupation_standards.map_with_hit do |occupation_standard, result|
-        inner_hits = result.inner_hits["children"]["hits"]["hits"]
-        if inner_hits.any?
-          occupation_standard.inner_hits = InnerHit.from_result(inner_hits)
-        end
-
-        occupation_standard
-      end
-
+      @occupation_standards = add_inner_hits_from_results(es_response.records)
     else
       @occupation_standards_search = OccupationStandardQuery::Container.new(
         search_term_params: search_term_params
@@ -87,5 +77,16 @@ class OccupationStandardsController < ApplicationController
 
   def offset
     (current_page.to_i - 1) * Pagy::DEFAULT[:items]
+  end
+
+  def add_inner_hits_from_results(occupation_standards)
+    occupation_standards.map_with_hit do |occupation_standard, result|
+      inner_hits = result.inner_hits["children"]["hits"]["hits"]
+      if inner_hits.any?
+        occupation_standard.inner_hits = InnerHit.from_result(inner_hits)
+      end
+
+      occupation_standard
+    end
   end
 end

--- a/app/models/inner_hit.rb
+++ b/app/models/inner_hit.rb
@@ -1,5 +1,5 @@
 class InnerHit
-  attr_accessor :id, :title
+  attr_reader :id, :title
 
   def self.from_result(inner_hits)
     inner_hits.map do |hit|
@@ -10,7 +10,7 @@ class InnerHit
     end
   end
 
-  def initialize(id: , title:)
+  def initialize(id:, title:)
     @id = id
     @title = title
   end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -99,7 +99,8 @@ class OccupationStandard < ApplicationRecord
       state: state_abbreviation,
       state_id: state_id,
       work_process_titles: work_processes.pluck(:title).uniq,
-      related_job_titles: related_job_titles
+      related_job_titles: related_job_titles,
+      headline: headline
     )
   end
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -224,7 +224,7 @@ class OccupationStandard < ApplicationRecord
     end
 
     [
-      state&.id,
+      state&.abbreviation,
       ojt_type,
       title.parameterize,
       work_processes_hours.to_s,

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -217,16 +217,18 @@ class OccupationStandard < ApplicationRecord
   def headline
     associations = if time_based?
       work_processes
-    else
+    elsif competency_based?
       work_processes.flat_map(&:competencies)
+    else
+      work_processes.flat_map(&:competencies) + work_processes
     end
 
     [
       state&.id,
       ojt_type,
       title.parameterize,
-      associations.map(&:title).map(&:parameterize),
-      work_processes_hours.to_s
+      work_processes_hours.to_s,
+      associations.map(&:title).map(&:parameterize)
     ].flatten.compact.join("-")
   end
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -227,7 +227,7 @@ class OccupationStandard < ApplicationRecord
       title.parameterize,
       associations.map(&:title).map(&:parameterize),
       work_processes_hours.to_s
-    ].flatten.compact.map(&:downcase).join("-")
+    ].flatten.compact.join("-")
   end
 
   def competencies_count

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -224,7 +224,7 @@ class OccupationStandard < ApplicationRecord
     [
       state&.id,
       ojt_type,
-      title,
+      title.parameterize,
       associations.map(&:title).map(&:parameterize),
       work_processes_hours.to_s
     ].flatten.compact.map(&:downcase).join("-")

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -86,6 +86,7 @@ class OccupationStandard < ApplicationRecord
       indexes :work_process_titles, type: :text, analyzer: :english
       indexes :related_job_titles, type: :text, analyzer: :english
       indexes :created_at, type: :date
+      indexes :headline, type: :keyword
     end
   end
 
@@ -211,6 +212,22 @@ class OccupationStandard < ApplicationRecord
 
   def original_file_url
     standards_import.url
+  end
+
+  def headline
+    associations = if time_based?
+      work_processes
+    else
+      work_processes.flat_map(&:competencies)
+    end
+
+    [
+      state&.id,
+      ojt_type,
+      title,
+      associations.map(&:title).map(&:parameterize),
+      work_processes_hours.to_s
+    ].flatten.compact.map(&:downcase).join("-")
   end
 
   def competencies_count

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -19,6 +19,10 @@ class OccupationStandardElasticsearchQuery
       end
       collapse :headline do
         inner_hits :children
+        sort do
+          by :_score, order: :desc
+          by :created_at, order: :desc
+        end
       end
       query do
         bool do

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -17,6 +17,9 @@ class OccupationStandardElasticsearchQuery
         by :_score, order: :desc
         by :created_at, order: :desc
       end
+      collapse :headline do
+        inner_hits :children
+      end
       query do
         bool do
           must match_all: {}

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -140,8 +140,12 @@ class OccupationStandardElasticsearchQuery
       puts response.search.definition[:body].to_json
       puts "HITS: #{response.results.total}"
       response.results.each do |result|
-        #        puts result.inspect
-        puts "#{result._id}: #{result._score}"
+        puts "PARENT: #{result._id}: #{result._score}"
+        result.inner_hits.children.each do |child|
+          child[1].hits.each do |hit|
+            puts "\tCHILD ID: #{hit._id}: #{hit._score}"
+          end
+        end
       end
     end
   end

--- a/app/views/occupation_standards/_similar_results_list.html.erb
+++ b/app/views/occupation_standards/_similar_results_list.html.erb
@@ -1,4 +1,4 @@
-<% similar_results = occupation_standard.similar_programs %>
+<% similar_results = occupation_standard.duplicates %>
 
 <% if similar_results.any? %>
   <div data-controller="accordion">
@@ -16,7 +16,7 @@
       <% similar_results.each do |result| %>
         <div class="bg-white border-2 border-gray-200 items-center py-2 px-4 w-full">
           <div class="flex items-center space-x-2">
-            <h3 class="text-primary-700 text-base font-bold"><%= link_to occupation_standard.title, occupation_standard %></h3>
+            <h3 class="text-primary-700 text-base font-bold"><%= link_to result.title, occupation_standard_path(result.id) %></h3>
             <p class="text-primary-600 text-xs font-normal"><%= occupation_standard.ojt_type&.capitalize %></p>
             <svg class="fill-goldenrod-800" width="4" height="5" viewBox="0 0 4 5" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M1.875 4.375C1.53125 4.375 1.21733 4.29119 0.933239 4.12358C0.649148 3.95313 0.421875 3.72585 0.25142 3.44176C0.0838069 3.15767 0 2.84375 0 2.5C0 2.15341 0.0838069 1.83949 0.25142 1.55824C0.421875 1.27415 0.649148 1.0483 0.933239 0.880682C1.21733 0.710227 1.53125 0.625 1.875 0.625C2.22159 0.625 2.53551 0.710227 2.81676 0.880682C3.10085 1.0483 3.3267 1.27415 3.49432 1.55824C3.66477 1.83949 3.75 2.15341 3.75 2.5C3.75 2.84375 3.66477 3.15767 3.49432 3.44176C3.3267 3.72585 3.10085 3.95313 2.81676 4.12358C2.53551 4.29119 2.22159 4.375 1.875 4.375Z" />

--- a/lib/tasks/deployment/20230920204336_rebuild_occupation_standards_to_add_headline.rake
+++ b/lib/tasks/deployment/20230920204336_rebuild_occupation_standards_to_add_headline.rake
@@ -1,5 +1,5 @@
 namespace :after_party do
-  desc 'Deployment task: rebuild_occupation_standards_to_add_headline'
+  desc "Deployment task: rebuild_occupation_standards_to_add_headline"
   task rebuild_occupation_standards_to_add_headline: :environment do
     puts "Running deploy task 'rebuild_occupation_standards_to_add_headline'"
 

--- a/lib/tasks/deployment/20230920204336_rebuild_occupation_standards_to_add_headline.rake
+++ b/lib/tasks/deployment/20230920204336_rebuild_occupation_standards_to_add_headline.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc 'Deployment task: rebuild_occupation_standards_to_add_headline'
+  task rebuild_occupation_standards_to_add_headline: :environment do
+    puts "Running deploy task 'rebuild_occupation_standards_to_add_headline'"
+
+    OccupationStandard.__elasticsearch__.create_index!(force: true)
+    OccupationStandard.import
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/factories/inner_hit.rb
+++ b/spec/factories/inner_hit.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :inner_hit do
+    sequence(:id)
+    sequence(:title) { |n| "Inner hit #{n}" }
+
+    initialize_with { new(**attributes) }
+  end
+end

--- a/spec/factories/inner_hit.rb
+++ b/spec/factories/inner_hit.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:id)
     sequence(:title) { |n| "Inner hit #{n}" }
 
+    skip_create
     initialize_with { new(**attributes) }
   end
 end

--- a/spec/models/inner_hit_spec.rb
+++ b/spec/models/inner_hit_spec.rb
@@ -18,18 +18,24 @@ RSpec.describe InnerHit, type: :model do
         {
           "_id" => 1,
           "_source" => {
-            title: "First record"
+            "title" => "First record"
           }
         },
         {
           "_id" => 2,
           "_source" => {
-            title: "Second record"
+            "title" => "Second record"
           }
         }
       ]
 
-      expect(InnerHit.from_result(inner_hits).count).to eq 2
+      inner_hits_results = InnerHit.from_result(inner_hits)
+
+      expect(inner_hits_results.count).to eq 2
+      expect(inner_hits_results.first.id).to eq 1
+      expect(inner_hits_results.first.title).to eq "First record"
+      expect(inner_hits_results.second.id).to eq 2
+      expect(inner_hits_results.second.title).to eq "Second record"
     end
   end
 end

--- a/spec/models/inner_hit_spec.rb
+++ b/spec/models/inner_hit_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe InnerHit, type: :model do
+  it "has a valid factory" do
+    inner_hit = build(:inner_hit)
+
+    expect(inner_hit.id).to be_present
+    expect(inner_hit.title).to be_present
+  end
+
+  describe ".from_result" do
+    it "returns empty array if inner_hits is empty" do
+      expect(InnerHit.from_result([])).to be_empty
+    end
+
+    it "returns an array of InnerHit if inner_hits provided" do
+      inner_hits = [
+        {
+          "_id" => 1,
+          "_source" => {
+            title: "First record"
+          }
+        },
+        {
+          "_id" => 2,
+          "_source" => {
+            title: "Second record"
+          }
+        }
+      ]
+
+      expect(InnerHit.from_result(inner_hits).count).to eq 2
+    end
+  end
+end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -645,24 +645,24 @@ RSpec.describe OccupationStandard, type: :model do
         it "concatenates state, type, title, work process titles, work process hours" do
           state = create(:state)
           agency = create(:registration_agency, state: state)
-          occupation_standard = create(:occupation_standard, :time, registration_agency: agency, title: "Mechanic")
+          occupation_standard = create(:occupation_standard, :time, registration_agency: agency, title: "Pipe Fitter")
           create(:work_process, occupation_standard: occupation_standard, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
           create(:work_process, occupation_standard: occupation_standard, sort_order: 1, title: "The quick brown", maximum_hours: 200)
           create(:work_process, occupation_standard: occupation_standard, sort_order: 3, title: "the lazy dog", maximum_hours: 400)
 
-          expect(occupation_standard.headline).to eq "#{state.id}-time-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+          expect(occupation_standard.headline).to eq "#{state.id}-time-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
         end
       end
 
       context "when state does not exist" do
         it "concatenates type, title, work process titles, work process hours" do
           agency = create(:registration_agency, state: nil)
-          occupation_standard = create(:occupation_standard, :time, registration_agency: agency, title: "Mechanic")
+          occupation_standard = create(:occupation_standard, :time, registration_agency: agency, title: "Pipe Fitter")
           create(:work_process, occupation_standard: occupation_standard, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
           create(:work_process, occupation_standard: occupation_standard, sort_order: 1, title: "The quick brown", maximum_hours: 200)
           create(:work_process, occupation_standard: occupation_standard, sort_order: 3, title: "the lazy dog", maximum_hours: 400)
 
-          expect(occupation_standard.headline).to eq "time-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+          expect(occupation_standard.headline).to eq "time-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
         end
       end
     end
@@ -672,7 +672,7 @@ RSpec.describe OccupationStandard, type: :model do
         it "concatenates state, type, title, skill names" do
           state = create(:state)
           agency = create(:registration_agency, state: state)
-          occupation_standard = create(:occupation_standard, :competency, registration_agency: agency, title: "Mechanic")
+          occupation_standard = create(:occupation_standard, :competency, registration_agency: agency, title: "Pipe Fitter")
           wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2)
           wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1)
           create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
@@ -680,14 +680,14 @@ RSpec.describe OccupationStandard, type: :model do
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "#{state.id}-competency-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-0"
+          expect(occupation_standard.headline).to eq "#{state.id}-competency-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-0"
         end
       end
 
       context "when state does not exist" do
         it "concatenates type, title, skill names" do
           agency = create(:registration_agency, state: nil)
-          occupation_standard = create(:occupation_standard, :competency, registration_agency: agency, title: "Mechanic")
+          occupation_standard = create(:occupation_standard, :competency, registration_agency: agency, title: "Pipe Fitter")
           wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2)
           wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1)
           create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
@@ -695,7 +695,7 @@ RSpec.describe OccupationStandard, type: :model do
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "competency-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-0"
+          expect(occupation_standard.headline).to eq "competency-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-0"
         end
       end
     end
@@ -705,7 +705,7 @@ RSpec.describe OccupationStandard, type: :model do
         it "concatenates state, type, title, skill names, work process hours" do
           state = create(:state)
           agency = create(:registration_agency, state: state)
-          occupation_standard = create(:occupation_standard, :hybrid, registration_agency: agency, title: "Mechanic")
+          occupation_standard = create(:occupation_standard, :hybrid, registration_agency: agency, title: "Pipe Fitter")
           wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2, maximum_hours: 200)
           wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1, maximum_hours: 500)
           create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
@@ -713,14 +713,14 @@ RSpec.describe OccupationStandard, type: :model do
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "#{state.id}-hybrid-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+          expect(occupation_standard.headline).to eq "#{state.id}-hybrid-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
         end
       end
 
       context "when state does not exist" do
         it "concatenates type, title, skill names, work process hours" do
           agency = create(:registration_agency, state: nil)
-          occupation_standard = create(:occupation_standard, :hybrid, registration_agency: agency, title: "Mechanic")
+          occupation_standard = create(:occupation_standard, :hybrid, registration_agency: agency, title: "Pipe Fitter")
           wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2, maximum_hours: 200)
           wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1, maximum_hours: 500)
           create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
@@ -728,7 +728,7 @@ RSpec.describe OccupationStandard, type: :model do
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "hybrid-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+          expect(occupation_standard.headline).to eq "hybrid-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
         end
       end
     end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -638,4 +638,99 @@ RSpec.describe OccupationStandard, type: :model do
       expect(os.related_job_titles).to contain_exactly("Engineer", "Developer")
     end
   end
+
+  describe "#headline" do
+    context "when time-based standard" do
+      context "when state exists" do
+        it "concatenates state, type, title, work process titles, work process hours" do
+          state = create(:state)
+          agency = create(:registration_agency, state: state)
+          occupation_standard = create(:occupation_standard, :time, registration_agency: agency, title: "Mechanic")
+          create(:work_process, occupation_standard: occupation_standard, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
+          create(:work_process, occupation_standard: occupation_standard, sort_order: 1, title: "The quick brown", maximum_hours: 200)
+          create(:work_process, occupation_standard: occupation_standard, sort_order: 3, title: "the lazy dog", maximum_hours: 400)
+
+          expect(occupation_standard.headline).to eq "#{state.id}-time-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+        end
+      end
+
+      context "when state does not exist" do
+        it "concatenates type, title, work process titles, work process hours" do
+          agency = create(:registration_agency, state: nil)
+          occupation_standard = create(:occupation_standard, :time, registration_agency: agency, title: "Mechanic")
+          create(:work_process, occupation_standard: occupation_standard, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
+          create(:work_process, occupation_standard: occupation_standard, sort_order: 1, title: "The quick brown", maximum_hours: 200)
+          create(:work_process, occupation_standard: occupation_standard, sort_order: 3, title: "the lazy dog", maximum_hours: 400)
+
+          expect(occupation_standard.headline).to eq "time-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+        end
+      end
+    end
+
+    context "when competency-based standard" do
+      context "when state exists" do
+        it "concatenates state, type, title, skill names" do
+          state = create(:state)
+          agency = create(:registration_agency, state: state)
+          occupation_standard = create(:occupation_standard, :competency, registration_agency: agency, title: "Mechanic")
+          wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2)
+          wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1)
+          create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
+          create(:competency, work_process: wp1, sort_order: 2, title: "the lazy dog")
+          create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
+          create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
+
+          expect(occupation_standard.headline).to eq "#{state.id}-competency-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-0"
+        end
+      end
+
+      context "when state does not exist" do
+        it "concatenates type, title, skill names" do
+          agency = create(:registration_agency, state: nil)
+          occupation_standard = create(:occupation_standard, :competency, registration_agency: agency, title: "Mechanic")
+          wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2)
+          wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1)
+          create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
+          create(:competency, work_process: wp1, sort_order: 2, title: "the lazy dog")
+          create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
+          create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
+
+          expect(occupation_standard.headline).to eq "competency-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-0"
+        end
+      end
+    end
+
+    context "when hybrid standard" do
+      context "when state exists" do
+        it "concatenates state, type, title, skill names, work process hours" do
+          state = create(:state)
+          agency = create(:registration_agency, state: state)
+          occupation_standard = create(:occupation_standard, :hybrid, registration_agency: agency, title: "Mechanic")
+          wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2, maximum_hours: 200)
+          wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1, maximum_hours: 500)
+          create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
+          create(:competency, work_process: wp1, sort_order: 2, title: "the lazy dog")
+          create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
+          create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
+
+          expect(occupation_standard.headline).to eq "#{state.id}-hybrid-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+        end
+      end
+
+      context "when state does not exist" do
+        it "concatenates type, title, skill names, work process hours" do
+          agency = create(:registration_agency, state: nil)
+          occupation_standard = create(:occupation_standard, :hybrid, registration_agency: agency, title: "Mechanic")
+          wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2, maximum_hours: 200)
+          wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1, maximum_hours: 500)
+          create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
+          create(:competency, work_process: wp1, sort_order: 2, title: "the lazy dog")
+          create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
+          create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
+
+          expect(occupation_standard.headline).to eq "hybrid-mechanic-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+        end
+      end
+    end
+  end
 end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -650,7 +650,7 @@ RSpec.describe OccupationStandard, type: :model do
           create(:work_process, occupation_standard: occupation_standard, sort_order: 1, title: "The quick brown", maximum_hours: 200)
           create(:work_process, occupation_standard: occupation_standard, sort_order: 3, title: "the lazy dog", maximum_hours: 400)
 
-          expect(occupation_standard.headline).to eq "#{state.id}-time-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          expect(occupation_standard.headline).to eq "#{state.abbreviation}-time-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog"
         end
       end
 
@@ -680,7 +680,7 @@ RSpec.describe OccupationStandard, type: :model do
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "#{state.id}-competency-pipe-fitter-0-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          expect(occupation_standard.headline).to eq "#{state.abbreviation}-competency-pipe-fitter-0-the-quick-brown-fox-jumps-over-the-lazy-dog"
         end
       end
 
@@ -713,7 +713,7 @@ RSpec.describe OccupationStandard, type: :model do
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "#{state.id}-hybrid-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog-wp2-wp1"
+          expect(occupation_standard.headline).to eq "#{state.abbreviation}-hybrid-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog-wp2-wp1"
         end
       end
 

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -642,7 +642,7 @@ RSpec.describe OccupationStandard, type: :model do
   describe "#headline" do
     context "when time-based standard" do
       context "when state exists" do
-        it "concatenates state, type, title, work process titles, work process hours" do
+        it "concatenates state, type, title, work process hours, work process titles" do
           state = create(:state)
           agency = create(:registration_agency, state: state)
           occupation_standard = create(:occupation_standard, :time, registration_agency: agency, title: "Pipe Fitter")
@@ -650,19 +650,19 @@ RSpec.describe OccupationStandard, type: :model do
           create(:work_process, occupation_standard: occupation_standard, sort_order: 1, title: "The quick brown", maximum_hours: 200)
           create(:work_process, occupation_standard: occupation_standard, sort_order: 3, title: "the lazy dog", maximum_hours: 400)
 
-          expect(occupation_standard.headline).to eq "#{state.id}-time-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+          expect(occupation_standard.headline).to eq "#{state.id}-time-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog"
         end
       end
 
       context "when state does not exist" do
-        it "concatenates type, title, work process titles, work process hours" do
+        it "concatenates type, title, work process hours, work process titles" do
           agency = create(:registration_agency, state: nil)
           occupation_standard = create(:occupation_standard, :time, registration_agency: agency, title: "Pipe Fitter")
           create(:work_process, occupation_standard: occupation_standard, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
           create(:work_process, occupation_standard: occupation_standard, sort_order: 1, title: "The quick brown", maximum_hours: 200)
           create(:work_process, occupation_standard: occupation_standard, sort_order: 3, title: "the lazy dog", maximum_hours: 400)
 
-          expect(occupation_standard.headline).to eq "time-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+          expect(occupation_standard.headline).to eq "time-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog"
         end
       end
     end
@@ -680,7 +680,7 @@ RSpec.describe OccupationStandard, type: :model do
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "#{state.id}-competency-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-0"
+          expect(occupation_standard.headline).to eq "#{state.id}-competency-pipe-fitter-0-the-quick-brown-fox-jumps-over-the-lazy-dog"
         end
       end
 
@@ -695,40 +695,40 @@ RSpec.describe OccupationStandard, type: :model do
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "competency-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-0"
+          expect(occupation_standard.headline).to eq "competency-pipe-fitter-0-the-quick-brown-fox-jumps-over-the-lazy-dog"
         end
       end
     end
 
     context "when hybrid standard" do
       context "when state exists" do
-        it "concatenates state, type, title, skill names, work process hours" do
+        it "concatenates state, type, title, work process hours, skill names, work process titles" do
           state = create(:state)
           agency = create(:registration_agency, state: state)
           occupation_standard = create(:occupation_standard, :hybrid, registration_agency: agency, title: "Pipe Fitter")
-          wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2, maximum_hours: 200)
-          wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1, maximum_hours: 500)
+          wp1 = create(:work_process, title: "wp1", occupation_standard: occupation_standard, sort_order: 2, maximum_hours: 200)
+          wp2 = create(:work_process, title: "wp2", occupation_standard: occupation_standard, sort_order: 1, maximum_hours: 500)
           create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
           create(:competency, work_process: wp1, sort_order: 2, title: "the lazy dog")
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "#{state.id}-hybrid-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+          expect(occupation_standard.headline).to eq "#{state.id}-hybrid-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog-wp2-wp1"
         end
       end
 
       context "when state does not exist" do
-        it "concatenates type, title, skill names, work process hours" do
+        it "concatenates type, title, work process hours, skill names, work process titles" do
           agency = create(:registration_agency, state: nil)
           occupation_standard = create(:occupation_standard, :hybrid, registration_agency: agency, title: "Pipe Fitter")
-          wp1 = create(:work_process, occupation_standard: occupation_standard, sort_order: 2, maximum_hours: 200)
-          wp2 = create(:work_process, occupation_standard: occupation_standard, sort_order: 1, maximum_hours: 500)
+          wp1 = create(:work_process, title: "wp1", occupation_standard: occupation_standard, sort_order: 2, maximum_hours: 200)
+          wp2 = create(:work_process, title: "wp2", occupation_standard: occupation_standard, sort_order: 1, maximum_hours: 500)
           create(:competency, work_process: wp1, sort_order: 1, title: "jumps over")
           create(:competency, work_process: wp1, sort_order: 2, title: "the lazy dog")
           create(:competency, work_process: wp2, sort_order: 2, title: "brown fox")
           create(:competency, work_process: wp2, sort_order: 1, title: "The quick")
 
-          expect(occupation_standard.headline).to eq "hybrid-pipe-fitter-the-quick-brown-fox-jumps-over-the-lazy-dog-700"
+          expect(occupation_standard.headline).to eq "hybrid-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog-wp2-wp1"
         end
       end
     end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -412,8 +412,8 @@ RSpec.describe OccupationStandard, type: :model do
         stub_feature_flag(:similar_programs_elasticsearch, true)
 
         occupation_standard = create(:occupation_standard)
-        duplicate_inner_hit = build(:inner_hit, id: "1", title: "Duplicate")
-        occupation_standard_inner_hit = build(:inner_hit, id: occupation_standard.id, title: occupation_standard.title)
+        duplicate_inner_hit = create(:inner_hit, id: "1", title: "Duplicate")
+        occupation_standard_inner_hit = create(:inner_hit, id: occupation_standard.id, title: occupation_standard.title)
         duplicates = [duplicate_inner_hit, occupation_standard_inner_hit]
 
         occupation_standard.inner_hits = duplicates
@@ -425,7 +425,7 @@ RSpec.describe OccupationStandard, type: :model do
         stub_feature_flag(:similar_programs_elasticsearch, true)
 
         occupation_standard = create(:occupation_standard)
-        occupation_standard_inner_hit = build(:inner_hit, id: occupation_standard.id, title: occupation_standard.title)
+        occupation_standard_inner_hit = create(:inner_hit, id: occupation_standard.id, title: occupation_standard.title)
         duplicates = [occupation_standard_inner_hit]
 
         occupation_standard.inner_hits = duplicates

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe OccupationStandard, type: :model do
 
   describe "#duplicates" do
     context "with the similar_programs_elasticsearch flag enabled" do
-      it "returns from OccupationStandard#inner_hits" do
+      it "returns from OccupationStandard#inner_hits excluding self" do
         stub_feature_flag(:similar_programs_elasticsearch, true)
 
         occupation_standard = create(:occupation_standard)
@@ -419,18 +419,6 @@ RSpec.describe OccupationStandard, type: :model do
         occupation_standard.inner_hits = duplicates
 
         expect(occupation_standard.duplicates).to match_array [duplicate_inner_hit]
-      end
-
-      it "excludes self" do
-        stub_feature_flag(:similar_programs_elasticsearch, true)
-
-        occupation_standard = create(:occupation_standard)
-        occupation_standard_inner_hit = create(:inner_hit, id: occupation_standard.id, title: occupation_standard.title)
-        duplicates = [occupation_standard_inner_hit]
-
-        occupation_standard.inner_hits = duplicates
-
-        expect(occupation_standard.duplicates).to be_empty
       end
     end
 

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     create(:work_process, occupation_standard: os1, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
     create(:work_process, occupation_standard: os1, sort_order: 1, title: "The quick brown", maximum_hours: 200)
 
-    onet = create(:onet, code: "1234.56", related_job_titles: ["pipe"])
+    create(:onet, code: "1234.56", related_job_titles: ["pipe"])
     os2 = create(:occupation_standard, :time, onet_code: "1234.56", registration_agency: agency, title: "Pipe Fitter")
     create(:work_process, occupation_standard: os2, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
     create(:work_process, occupation_standard: os2, sort_order: 1, title: "The quick brown", maximum_hours: 200)

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -296,7 +296,8 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     create(:work_process, occupation_standard: os1, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
     create(:work_process, occupation_standard: os1, sort_order: 1, title: "The quick brown", maximum_hours: 200)
 
-    os2 = create(:occupation_standard, :time, registration_agency: agency, title: "Pipe Fitter")
+    onet = create(:onet, code: "1234.56", related_job_titles: ["pipe"])
+    os2 = create(:occupation_standard, :time, onet_code: "1234.56", registration_agency: agency, title: "Pipe Fitter")
     create(:work_process, occupation_standard: os2, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
     create(:work_process, occupation_standard: os2, sort_order: 1, title: "The quick brown", maximum_hours: 200)
 
@@ -313,6 +314,9 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     params = {q: "pipe"}
     response = described_class.new(search_params: params).call
 
-    expect(response.records.pluck(:id)).to eq [os3.id, os2.id]
+    expect(response.records.pluck(:id)).to eq [os2.id, os3.id]
+    expect(response.results[0].inner_hits.children.first[1].hits[0]._id).to eq os2.id
+    expect(response.results[0].inner_hits.children.first[1].hits[1]._id).to eq os1.id
+    expect(response.results[1].inner_hits.children.first[1].hits[0]._id).to eq os3.id
   end
 end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205005445681275/f

This PR:
* Update OccupationStandardElasticsearchQuery class to retrieve collapse results
* Add InnerHit PORO model to wrap inner_hits values from query mentioned above 
* Add OccupationStandard#inner_hits accessor to store processed results from ES
* Add OccupationStandard#duplicates method to populate similar_results partial 
* Updates partial to use #duplicates instead of #similar_results

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/f2931273-40e2-492f-98a0-60e78322a658)
