### PR TITLE
Refine Elasticsearch results

### DIFF
--- a/app/controllers/occupation_standards_controller.rb
+++ b/app/controllers/occupation_standards_controller.rb
@@ -4,13 +4,7 @@ class OccupationStandardsController < ApplicationController
 
     if Flipper.enabled?(:use_elasticsearch_for_search)
       if search_term_params[:q].present?
-        es_response_0 = OccupationStandardElasticsearchQuery.new(
-          search_params: search_term_params
-        ).call
-        first_hit = es_response_0.records.first
-        if first_hit && first_hit.onet_code.present?
-          search_term_params[:onet_prefix] = first_hit.onet_code
-        end
+        refine_search_params
       end
 
       es_response = OccupationStandardElasticsearchQuery.new(
@@ -75,6 +69,16 @@ class OccupationStandardsController < ApplicationController
 
   def search_term_params
     @search_term_params ||= SearchTermExtractor.call(occupation_standards_search_params)
+  end
+
+  def refine_search_params
+    resp = OccupationStandardElasticsearchQuery.new(
+      search_params: search_term_params
+    ).call
+    first_hit = resp.records.first
+    if first_hit && first_hit.onet_code.present?
+      search_term_params[:onet_prefix] = first_hit.onet_code
+    end
   end
 
   def standards_scope

--- a/app/controllers/occupation_standards_controller.rb
+++ b/app/controllers/occupation_standards_controller.rb
@@ -3,12 +3,14 @@ class OccupationStandardsController < ApplicationController
     @page_title = "Occupations"
 
     if Flipper.enabled?(:use_elasticsearch_for_search)
-      es_response_0 = OccupationStandardElasticsearchQuery.new(
-        search_params: search_term_params
-      ).call
-      first_hit = es_response_0.records.first
-      if first_hit && first_hit.onet_code.present?
-        search_term_params[:onet_prefix] = first_hit.onet_code
+      if search_term_params[:q].present?
+        es_response_0 = OccupationStandardElasticsearchQuery.new(
+          search_params: search_term_params
+        ).call
+        first_hit = es_response_0.records.first
+        if first_hit && first_hit.onet_code.present?
+          search_term_params[:onet_prefix] = first_hit.onet_code
+        end
       end
 
       es_response = OccupationStandardElasticsearchQuery.new(

--- a/app/controllers/occupation_standards_controller.rb
+++ b/app/controllers/occupation_standards_controller.rb
@@ -3,6 +3,14 @@ class OccupationStandardsController < ApplicationController
     @page_title = "Occupations"
 
     if Flipper.enabled?(:use_elasticsearch_for_search)
+      es_response_0 = OccupationStandardElasticsearchQuery.new(
+        search_params: search_term_params
+      ).call
+      first_hit = es_response_0.records.first
+      if first_hit && first_hit.onet_code.present?
+        search_term_params[:onet_prefix] = first_hit.onet_code
+      end
+
       es_response = OccupationStandardElasticsearchQuery.new(
         search_params: search_term_params,
         offset: offset

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -40,6 +40,11 @@ class OccupationStandardElasticsearchQuery
               term state: search_params[:state].upcase
             end
           end
+          if search_params[:onet_prefix].present?
+            filter do
+              match "onet_code.prefix": search_params[:onet_prefix]
+            end
+          end
           if search_params[:national_standard_type].present?
             must do
               bool do

--- a/config/initializers/elasticsearch/dsl/search/filters/match.rb
+++ b/config/initializers/elasticsearch/dsl/search/filters/match.rb
@@ -1,0 +1,11 @@
+module Elasticsearch
+  module DSL
+    module Search
+      module Filters
+        class Match
+          include BaseComponent
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -143,6 +143,20 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     expect(response.records.pluck(:id)).to contain_exactly(os1.id)
   end
 
+  it "allows filtering occupation standards by onet prefix" do
+    os1 = create(:occupation_standard, :with_work_processes, onet_code: "12.3456")
+    os2 = create(:occupation_standard, :with_work_processes, onet_code: "12-9876")
+    create(:occupation_standard, :with_work_processes, onet_code: "13-3457")
+
+    OccupationStandard.import
+    OccupationStandard.__elasticsearch__.refresh_index!
+
+    params = {onet_prefix: "12-1111"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to contain_exactly(os1.id, os2.id)
+  end
+
   it "allows filtering occupation standards by state id" do
     ca = create(:state)
     wa = create(:state)

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe "OccupationStandard", type: :request do
           expect(response).to be_successful
           Flipper.disable :use_elasticsearch_for_search
         end
-
       end
     end
 

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -36,7 +36,18 @@ RSpec.describe "OccupationStandard", type: :request do
           Flipper.disable :use_elasticsearch_for_search
         end
 
-        it "makes two Elasticsearch queries if search params" do
+        it "makes one Elasticsearch query if search params does not start with letter" do
+          Flipper.enable :use_elasticsearch_for_search
+          create(:occupation_standard, :with_work_processes, :with_data_import)
+
+          expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
+          get occupation_standards_path(q: "15")
+
+          expect(response).to be_successful
+          Flipper.disable :use_elasticsearch_for_search
+        end
+
+        it "makes two Elasticsearch queries if search params start with letter" do
           Flipper.enable :use_elasticsearch_for_search
           create(:occupation_standard, :with_work_processes, :with_data_import)
 

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "OccupationStandard", type: :request do
       context "with ES search" do
         it "makes one Elasticsearch query if no search params" do
           Flipper.enable :use_elasticsearch_for_search
-          create_pair(:occupation_standard, :with_work_processes, :with_data_import)
+          create(:occupation_standard, :with_work_processes, :with_data_import)
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
           get occupation_standards_path
@@ -27,7 +27,7 @@ RSpec.describe "OccupationStandard", type: :request do
 
         it "makes one Elasticsearch query if only filter params" do
           Flipper.enable :use_elasticsearch_for_search
-          create_pair(:occupation_standard, :with_work_processes, :with_data_import)
+          create(:occupation_standard, :with_work_processes, :with_data_import)
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
           get occupation_standards_path(state_id: SecureRandom.uuid)
@@ -38,7 +38,7 @@ RSpec.describe "OccupationStandard", type: :request do
 
         it "makes two Elasticsearch queries if search params" do
           Flipper.enable :use_elasticsearch_for_search
-          create_pair(:occupation_standard, :with_work_processes, :with_data_import)
+          create(:occupation_standard, :with_work_processes, :with_data_import)
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).twice.and_call_original
           get occupation_standards_path(q: "Mechanic")
@@ -46,6 +46,18 @@ RSpec.describe "OccupationStandard", type: :request do
           expect(response).to be_successful
           Flipper.disable :use_elasticsearch_for_search
         end
+
+        it "makes one Elasticsearch query if search param but first hit has no onet code" do
+          Flipper.enable :use_elasticsearch_for_search
+          create(:occupation_standard, :with_work_processes, :with_data_import, onet_code: nil)
+
+          expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
+          get occupation_standards_path(state_id: SecureRandom.uuid)
+
+          expect(response).to be_successful
+          Flipper.disable :use_elasticsearch_for_search
+        end
+
       end
     end
 

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "OccupationStandard", type: :request do
 
         it "makes one Elasticsearch query if search params does not start with letter" do
           Flipper.enable :use_elasticsearch_for_search
-          onet = create(:onet, code: "15-1234.00")
           create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "15-1234.00")
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "occupation_standards/index" do
       Pagy::DEFAULT[:items] = default_items
     end
 
-    it "filters occupations based on search term" do
+    it "filters standards based on search term" do
       dental = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Dental Assistant")
       medical = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Medical Assistant")
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter")
@@ -34,7 +34,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "Pipe Fitter"
     end
 
-    it "filters occupations based on rapids_code search term" do
+    it "filters standards based on rapids_code search term" do
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", rapids_code: "1234")
       pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", rapids_code: "1234CB")
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR", rapids_code: "9876")
@@ -53,7 +53,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters occupations based on onet_code search term" do
+    it "filters standards based on onet_code search term" do
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR", onet_code: "12.34")
@@ -72,7 +72,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters occupations based on onet_code search term and state filter", :js do
+    it "filters standards based on onet_code search term and state filter", :js do
       wa = create(:state, name: "Washington")
       ra = create(:registration_agency, state: wa)
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
@@ -96,7 +96,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters occupations based on onet_code search term and national_standard_type filter", :js do
+    it "filters standards based on onet_code search term and national_standard_type filter", :js do
       mechanic = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :guideline_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -125,7 +125,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters occupations based on onet_code search term and ojt_type filter", :js do
+    it "filters standards based on onet_code search term and ojt_type filter", :js do
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -153,7 +153,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters occupations with state shortcode" do
+    it "filters standards with state shortcode" do
       washington = create(:state, name: "Washington", abbreviation: "WA")
       washington_registration_agency = create(:registration_agency, state: washington)
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: washington_registration_agency)
@@ -174,7 +174,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters occupations with national_standard_type shortcode" do
+    it "filters standards with national_standard_type shortcode" do
       mechanic = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       create(:occupation_standard, :with_work_processes, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :guideline_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -196,7 +196,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters occupations with ojt_type shortcode" do
+    it "filters standards with ojt_type shortcode" do
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       create(:occupation_standard, :with_work_processes, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -395,7 +395,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.disable :use_elasticsearch_for_search
     end
 
-    it "filters occupations based on search term" do
+    it "filters standards based on search term" do
       Flipper.enable :use_elasticsearch_for_search
       dental = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Dental Assistant")
       medical = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Medical Assistant")
@@ -419,7 +419,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.disable :use_elasticsearch_for_search
     end
 
-    it "filters occupations based on rapids_code search term" do
+    it "filters standards based on rapids_code search term" do
       Flipper.enable :use_elasticsearch_for_search
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", rapids_code: "1234")
       pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", rapids_code: "1234CB")
@@ -443,7 +443,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.disable :use_elasticsearch_for_search
     end
 
-    it "filters occupations based on onet_code search term" do
+    it "filters standards based on onet_code search term" do
       Flipper.enable :use_elasticsearch_for_search
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -467,7 +467,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.disable :use_elasticsearch_for_search
     end
 
-    it "filters occupations based on onet_code search term and state filter", :js do
+    it "filters standards based on onet_code search term and state filter", :js do
       Flipper.enable :use_elasticsearch_for_search
       wa = create(:state, name: "Washington")
       ra = create(:registration_agency, state: wa)
@@ -496,7 +496,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.disable :use_elasticsearch_for_search
     end
 
-    it "filters occupations based on onet_code search term and national_standard_type filter", :js do
+    it "filters standards based on onet_code search term and national_standard_type filter", :js do
       Flipper.enable :use_elasticsearch_for_search
       mechanic = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
@@ -530,7 +530,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.disable :use_elasticsearch_for_search
     end
 
-    it "filters occupations based on onet_code search term and ojt_type filter", :js do
+    it "filters standards based on onet_code search term and ojt_type filter", :js do
       Flipper.enable :use_elasticsearch_for_search
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
@@ -563,7 +563,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.disable :use_elasticsearch_for_search
     end
 
-    it "filters occupations with state shortcode" do
+    it "filters standards with state shortcode" do
       Flipper.enable :use_elasticsearch_for_search
       washington = create(:state, name: "Washington", abbreviation: "WA")
       washington_registration_agency = create(:registration_agency, state: washington)
@@ -589,7 +589,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.disable :use_elasticsearch_for_search
     end
 
-    it "filters occupations with national_standard_type shortcode" do
+    it "filters standards with national_standard_type shortcode" do
       Flipper.enable :use_elasticsearch_for_search
       mechanic = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       create(:occupation_standard, :with_work_processes, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
@@ -616,7 +616,7 @@ RSpec.describe "occupation_standards/index" do
       Flipper.disable :use_elasticsearch_for_search
     end
 
-    it "filters occupations with ojt_type shortcode" do
+    it "filters standards with ojt_type shortcode" do
       Flipper.enable :use_elasticsearch_for_search
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       create(:occupation_standard, :with_work_processes, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")


### PR DESCRIPTION
Asana tickets: 
https://app.asana.com/0/1203289004376659/1205503615126496/f
https://app.asana.com/0/1203289004376659/1205444475106625/f

When a user enters a search term, they are often returned results unrelated to their intended search due to related words. For example, searching "software developer" will also return results for "Child Development Teacher" because of the word "developer" in the search. To refine the elasticsearch results, when a user enters a search term, we look up the ONET code of the top hit and do a second search that only returns results matching the ONET prefix. In that way, "Child Development Teacher" would be excluded from a search for "software developer" since they do not share the same ONET code prefix.

**Note**
The Elasticsearch gem does not have a filter for "match", even though it is valid Elasticsearch syntax, so a Filters Match model was added. Ordinarily a match would not likely be in the filter section, since matches can be fuzzy and scoring would be important. However in the case of the `onet_prefix` analyzer, we are using `match` in order to have the onet code in the search term get tokenized identically to the `onet_code.prefix` being stored. We could use the existing "term" filter if we performed our own regex on the onet_code search term, but I prefer to use the tokenizer on both the input and the search term for consistency, just in case we make any other changes to it down the line.