### PR TITLE
Use occupation titles for typeahead search

### DIFF
--- a/app/blueprints/occupation_blueprint.rb
+++ b/app/blueprints/occupation_blueprint.rb
@@ -3,7 +3,10 @@ class OccupationBlueprint < Blueprinter::Base
 
   field :display_for_typeahead, name: :display
 
+  # The link field is the occupation_standards path since that is
+  # the path we want to use in the search. Occupations are just
+  # used for the initial typeahead search.
   field :link do |resource, options|
-    Rails.application.routes.url_helpers.occupations_path
+    Rails.application.routes.url_helpers.occupation_standards_path
   end
 end

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with url: search_form_url, method: :get, data: {
       controller: "search typeahead",
-      typeahead_src_value: occupation_standards_path(format: :json, q: "QUERY"),
+      typeahead_src_value: occupations_path(format: :json, q: "QUERY"),
       typeahead_wildcard_value: "QUERY",
       typeahead_identifier_value: "display"
 

--- a/spec/requests/occupations_spec.rb
+++ b/spec/requests/occupations_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Occupation", type: :request do
       get occupations_path, params: {format: "json", q: "Mech"}
 
       expect(response_json[0][:display]).to eq "Mechanic"
-      expect(response_json[0][:link]).to eq "/occupations"
+      expect(response_json[0][:link]).to eq "/occupation_standards"
 
       expect(response).to be_successful
       expect(response.content_type).to eq "application/json; charset=utf-8"
@@ -20,12 +20,12 @@ RSpec.describe "Occupation", type: :request do
       get occupations_path, params: {format: "json", q: "12-34"}
 
       expect(response_json[0][:display]).to eq "Mechanic"
-      expect(response_json[0][:link]).to eq "/occupations"
+      expect(response_json[0][:link]).to eq "/occupation_standards"
 
       get occupations_path, params: {format: "json", q: "567"}
 
       expect(response_json[0][:display]).to eq "Mechanic"
-      expect(response_json[0][:link]).to eq "/occupations"
+      expect(response_json[0][:link]).to eq "/occupation_standards"
     end
   end
 end

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -285,48 +285,6 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_link "Pipe Fitter"
     end
 
-    it "shows suggestions based on occupation title", :js do
-      mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
-      pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter")
-
-      visit occupation_standards_path
-
-      expect(page).to_not have_selector "div", class: "tt-suggestion"
-
-      fill_in "q", with: "Mec"
-
-      expect(page).to have_selector "div", class: "tt-suggestion", text: mechanic.display_for_typeahead
-      expect(page).to_not have_selector "div", class: "tt-suggestion", text: pipe_fitter.display_for_typeahead
-    end
-
-    it "shows suggestions based on onet code", :js do
-      mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12-1234")
-      pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "51-6789")
-
-      visit occupation_standards_path
-
-      expect(page).to_not have_selector "div", class: "tt-suggestion"
-
-      fill_in "q", with: "12-"
-
-      expect(page).to have_selector "div", class: "tt-suggestion", text: mechanic.display_for_typeahead
-      expect(page).to_not have_selector "div", class: "tt-suggestion", text: pipe_fitter.display_for_typeahead
-    end
-
-    it "shows suggestions based on rapids code", :js do
-      mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", rapids_code: "9108")
-      pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", rapids_code: "1582")
-
-      visit occupation_standards_path
-
-      expect(page).to_not have_selector "div", class: "tt-suggestion"
-
-      fill_in "q", with: "9108"
-
-      expect(page).to have_selector "div", class: "tt-suggestion", text: mechanic.display_for_typeahead
-      expect(page).to_not have_selector "div", class: "tt-suggestion", text: pipe_fitter.display_for_typeahead
-    end
-
     it "expands similar results accordion when accordion button is clicked", js: true do
       Flipper.enable :similar_programs_accordion
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
@@ -739,12 +697,12 @@ RSpec.describe "occupation_standards/index" do
 
     it "shows suggestions based on occupation title", :js do
       Flipper.enable :use_elasticsearch_for_search
-      mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
-      pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter")
-      pippen_apple_collector = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pippen Apple Collector")
+      mechanic = create(:occupation, title: "Mechanic")
+      pipe_fitter = create(:occupation, title: "Pipe Fitter")
+      pippen_apple_collector = create(:occupation, title: "Pippen Apple Collector")
 
-      OccupationStandard.import
-      OccupationStandard.__elasticsearch__.refresh_index!
+      Occupation.import
+      Occupation.__elasticsearch__.refresh_index!
 
       visit occupation_standards_path
 
@@ -776,11 +734,13 @@ RSpec.describe "occupation_standards/index" do
 
     it "shows suggestions based on onet code", :js do
       Flipper.enable :use_elasticsearch_for_search
-      mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12-1234")
-      pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "51-6789")
+      mechanic_onet = create(:onet, code: "12-1234")
+      mechanic = create(:occupation, title: "Mechanic", onet: mechanic_onet)
+      pipe_fitter_onet = create(:onet, code: "51-6789")
+      pipe_fitter = create(:occupation, title: "Pipe Fitter", onet: pipe_fitter_onet)
 
-      OccupationStandard.import
-      OccupationStandard.__elasticsearch__.refresh_index!
+      Occupation.import
+      Occupation.__elasticsearch__.refresh_index!
 
       visit occupation_standards_path
 
@@ -795,11 +755,11 @@ RSpec.describe "occupation_standards/index" do
 
     it "shows suggestions based on rapids code", :js do
       Flipper.enable :use_elasticsearch_for_search
-      mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", rapids_code: "9108")
-      pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", rapids_code: "1582")
+      mechanic = create(:occupation, title: "Mechanic", rapids_code: "9108")
+      pipe_fitter = create(:occupation, title: "Pipe Fitter", rapids_code: "1582")
 
-      OccupationStandard.import
-      OccupationStandard.__elasticsearch__.refresh_index!
+      Occupation.import
+      Occupation.__elasticsearch__.refresh_index!
 
       visit occupation_standards_path
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205523364822698/f

This uses the titles for typeahead search, but still searches the occupation standards once a title is selected. We are using the occupation titles for searching so users can see the whole universe of possible titles, not just the ones we happen to have standards for.
