### PR TITLE
Reduce headline size

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -266,13 +266,15 @@ class OccupationStandard < ApplicationRecord
       work_processes.flat_map(&:competencies) + work_processes
     end
 
-    [
+    key = [
       state&.abbreviation,
       ojt_type,
       title.parameterize,
       work_processes_hours.to_s,
       associations.map(&:title).compact.map(&:parameterize)
     ].flatten.compact.join("-")
+
+    Digest::SHA2.hexdigest(key)
   end
 
   def competencies_count

--- a/lib/tasks/deployment/20230927202811_rerun_elastic_search_indexes_with_updated_headline.rake
+++ b/lib/tasks/deployment/20230927202811_rerun_elastic_search_indexes_with_updated_headline.rake
@@ -1,5 +1,5 @@
 namespace :after_party do
-  desc 'Deployment task: rerun_elastic_search_indexes_with_updated_headline'
+  desc "Deployment task: rerun_elastic_search_indexes_with_updated_headline"
   task rerun_elastic_search_indexes_with_updated_headline: :environment do
     puts "Running deploy task 'rerun_elastic_search_indexes_with_updated_headline'"
 

--- a/lib/tasks/deployment/20230927202811_rerun_elastic_search_indexes_with_updated_headline.rake
+++ b/lib/tasks/deployment/20230927202811_rerun_elastic_search_indexes_with_updated_headline.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc 'Deployment task: rerun_elastic_search_indexes_with_updated_headline'
+  task rerun_elastic_search_indexes_with_updated_headline: :environment do
+    puts "Running deploy task 'rerun_elastic_search_indexes_with_updated_headline'"
+
+    OccupationStandard.__elasticsearch__.create_index!(force: true)
+    OccupationStandard.import
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -701,7 +701,9 @@ RSpec.describe OccupationStandard, type: :model do
 
           occupation_standard.reload
 
-          expect(occupation_standard.headline).to eq "#{state.abbreviation}-time-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          expect(occupation_standard.headline).to eq Digest::SHA2.hexdigest(
+            "#{state.abbreviation}-time-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          )
         end
       end
 
@@ -715,7 +717,9 @@ RSpec.describe OccupationStandard, type: :model do
 
           occupation_standard.reload
 
-          expect(occupation_standard.headline).to eq "time-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          expect(occupation_standard.headline).to eq Digest::SHA2.hexdigest(
+            "time-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          )
         end
       end
     end
@@ -735,7 +739,9 @@ RSpec.describe OccupationStandard, type: :model do
 
           occupation_standard.reload
 
-          expect(occupation_standard.headline).to eq "#{state.abbreviation}-competency-pipe-fitter-0-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          expect(occupation_standard.headline).to eq Digest::SHA2.hexdigest(
+            "#{state.abbreviation}-competency-pipe-fitter-0-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          )
         end
       end
 
@@ -752,7 +758,9 @@ RSpec.describe OccupationStandard, type: :model do
 
           occupation_standard.reload
 
-          expect(occupation_standard.headline).to eq "competency-pipe-fitter-0-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          expect(occupation_standard.headline).to eq Digest::SHA2.hexdigest(
+            "competency-pipe-fitter-0-the-quick-brown-fox-jumps-over-the-lazy-dog"
+          )
         end
       end
     end
@@ -772,7 +780,9 @@ RSpec.describe OccupationStandard, type: :model do
 
           occupation_standard.reload
 
-          expect(occupation_standard.headline).to eq "#{state.abbreviation}-hybrid-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog-wp2-wp1"
+          expect(occupation_standard.headline).to eq Digest::SHA2.hexdigest(
+            "#{state.abbreviation}-hybrid-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog-wp2-wp1"
+          )
         end
       end
 
@@ -789,7 +799,9 @@ RSpec.describe OccupationStandard, type: :model do
 
           occupation_standard.reload
 
-          expect(occupation_standard.headline).to eq "hybrid-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog-wp2-wp1"
+          expect(occupation_standard.headline).to eq Digest::SHA2.hexdigest(
+            "hybrid-pipe-fitter-700-the-quick-brown-fox-jumps-over-the-lazy-dog-wp2-wp1"
+          )
         end
       end
     end

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -337,9 +337,6 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     os3 = create(:occupation_standard, :time, registration_agency: agency, title: "Pipe")
     create(:work_process, occupation_standard: os3, sort_order: 2, title: "fox jumps over", maximum_hours: 100)
     create(:work_process, occupation_standard: os3, sort_order: 1, title: "The quick brown", maximum_hours: 200)
-    puts os1.id
-    puts os2.id
-    puts os3.id
 
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205542807244423/f

We now use Digest::SHA2.hexdigest to digest the headline value we use to do ES collapse


