### PR TITLE
Remove code related to typeahead for occupation standards

### DIFF
--- a/app/blueprints/occupation_standard_blueprint.rb
+++ b/app/blueprints/occupation_standard_blueprint.rb
@@ -1,9 +1,0 @@
-class OccupationStandardBlueprint < Blueprinter::Base
-  identifier :id
-
-  field :display_for_typeahead, name: :display
-
-  field :link do |resource, options|
-    Rails.application.routes.url_helpers.occupation_standards_path
-  end
-end

--- a/app/controllers/occupation_standards_controller.rb
+++ b/app/controllers/occupation_standards_controller.rb
@@ -28,13 +28,6 @@ class OccupationStandardsController < ApplicationController
     end
 
     @search_term = search_term_params[:q]
-
-    respond_to do |format|
-      format.json do
-        render json: OccupationStandardBlueprint.render(@occupation_standards)
-      end
-      format.html {}
-    end
   end
 
   def show

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -122,9 +122,7 @@ class OccupationStandard < ApplicationRecord
       indexes :rapids_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
       indexes :state, type: :text, analyzer: :keyword
       indexes :state_id, type: :keyword
-      indexes :title, type: :text, analyzer: :rebuilt_english do
-        indexes :typeahead, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
-      end
+      indexes :title, type: :text, analyzer: :rebuilt_english
       indexes :work_process_titles, type: :text, analyzer: :english
       indexes :related_job_titles, type: :text, analyzer: :rebuilt_english
       indexes :created_at, type: :date
@@ -359,10 +357,6 @@ class OccupationStandard < ApplicationRecord
     national_occupational_framework? &&
       organization_id.present? &&
       organization_id == Organization.urban_institute&.id
-  end
-
-  def display_for_typeahead
-    title.strip
   end
 
   def hours_meet_occupation_requirements?

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -91,11 +91,6 @@ class OccupationStandardElasticsearchQuery
                   }
                 end
                 should do
-                  match "title.typeahead": {
-                    query: q
-                  }
-                end
-                should do
                   match related_job_titles: {
                     query: q,
                     boost: 1.2

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -541,20 +541,6 @@ RSpec.describe OccupationStandard, type: :model do
     end
   end
 
-  describe "#display_for_typeahead" do
-    it "returns title" do
-      occupation_standard = build_stubbed(:occupation_standard, title: "Mechanic")
-
-      expect(occupation_standard.display_for_typeahead).to eq "Mechanic"
-    end
-
-    it "returns trimmed title" do
-      occupation_standard = build_stubbed(:occupation_standard, title: " Mechanical Engineer ")
-
-      expect(occupation_standard.display_for_typeahead).to eq "Mechanical Engineer"
-    end
-  end
-
   describe "#hours_meet_occupation_requirements?" do
     it "returns true if work_process hours match occupation hours" do
       occupation = create(:occupation, time_based_hours: 1000)

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -313,12 +313,12 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     params = {q: "usER expERience"}
     response = described_class.new(search_params: params).call
 
-    expect(response.records.pluck(:id)).to eq [os1.id, os2.id]
+    expect(response.records.pluck(:id)).to match_array [os1.id, os2.id]
 
     params = {q: "ux design"}
     response = described_class.new(search_params: params).call
 
-    expect(response.records.pluck(:id)).to eq [os2.id, os1.id]
+    expect(response.records.pluck(:id)).to match_array [os2.id, os1.id]
   end
 
   it "collapses search results across headline" do

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -104,55 +104,6 @@ RSpec.describe "OccupationStandard", type: :request do
     end
   end
 
-  describe "GET /index.json" do
-    it "returns http success" do
-      create(:occupation_standard, :with_data_import, title: "Mechanic")
-
-      get occupation_standards_path, params: {format: "json", q: "Mech"}
-
-      expect(response).to be_successful
-    end
-
-    it "returns a json response" do
-      create(:occupation_standard, :with_data_import, title: "Mechanic")
-
-      get occupation_standards_path, params: {format: "json", q: "Mech"}
-
-      expect(response.content_type).to eq "application/json; charset=utf-8"
-    end
-
-    context "when not using Elasticsearch for results" do
-      it "returns expected fields" do
-        occupation_standard = create(:occupation_standard, :with_data_import, title: "Mechanic")
-
-        get occupation_standards_path, params: {format: "json", q: "Mech"}
-        parsed_response = JSON.parse(response.body)
-        result = parsed_response.first
-
-        expect(result["id"]).to eq occupation_standard.id
-        expect(result["display"]).to eq occupation_standard.display_for_typeahead
-        expect(result["link"]).to eq occupation_standards_path
-      end
-    end
-
-    context "when using Elasticsearch for results", :elasticsearch do
-      it "returns expected fields" do
-        occupation_standard = create(:occupation_standard, :with_data_import, title: "Mechanic")
-
-        OccupationStandard.import
-        OccupationStandard.__elasticsearch__.refresh_index!
-
-        get occupation_standards_path, params: {format: "json", q: "Mech"}
-        parsed_response = JSON.parse(response.body)
-        result = parsed_response.first
-
-        expect(result["id"]).to eq occupation_standard.id
-        expect(result["display"]).to eq occupation_standard.display_for_typeahead
-        expect(result["link"]).to eq occupation_standards_path
-      end
-    end
-  end
-
   describe "GET /show/:id" do
     context "when guest" do
       it "returns http success" do


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205523364822698/f

The typeahead searching was moved to the Occupation model, so this removes the old code which was using the OccupationStandard model.
