### PR TITLE
Change onets name field to title to match online db

### DIFF
--- a/app/dashboards/onet_dashboard.rb
+++ b/app/dashboards/onet_dashboard.rb
@@ -4,7 +4,7 @@ class OnetDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::String,
     code: Field::String,
-    name: Field::String,
+    title: Field::String,
     related_job_titles: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
@@ -12,13 +12,13 @@ class OnetDashboard < Administrate::BaseDashboard
 
   COLLECTION_ATTRIBUTES = %i[
     code
-    name
+    title
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     code
-    name
+    title
     related_job_titles
     created_at
     updated_at

--- a/app/models/onet.rb
+++ b/app/models/onet.rb
@@ -1,8 +1,8 @@
 class Onet < ApplicationRecord
-  validates :name, :code, presence: true
+  validates :title, :code, presence: true
   validates :code, uniqueness: true
 
   def to_s
-    "#{name} (#{code})"
+    "#{title} (#{code})"
   end
 end

--- a/app/services/scrape_onet_codes.rb
+++ b/app/services/scrape_onet_codes.rb
@@ -2,7 +2,7 @@ class ScrapeOnetCodes
   def call
     file = URI.open("https://www.onetonline.org/find/all/All_Occupations.csv?fmt=csv")
     CSV.parse(file, headers: true) do |row|
-      onet = Onet.find_or_initialize_by(name: row["Occupation"])
+      onet = Onet.find_or_initialize_by(title: row["Occupation"])
       onet.update!(code: row["Code"])
       OnetWebService.new(onet).call
     end

--- a/db/migrate/20231003201145_rename_onets_name_to_title.rb
+++ b/db/migrate/20231003201145_rename_onets_name_to_title.rb
@@ -1,0 +1,5 @@
+class RenameOnetsNameToTitle < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :onets, :name, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_30_191114) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_03_201145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -174,7 +174,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_30_191114) do
   end
 
   create_table "onets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name"
+    t.string "title"
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/onets.rb
+++ b/spec/factories/onets.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :onet do
-    name { "Actors" }
+    title { "Actors" }
     code { "27-2011.00" }
   end
 end

--- a/spec/services/scrape_onet_codes_spec.rb
+++ b/spec/services/scrape_onet_codes_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ScrapeOnetCodes do
   describe "#call" do
     it "creates onet records" do
       stub_responses
-      onet = create(:onet, name: "Actuaries", code: "1234.56")
+      onet = create(:onet, title: "Actuaries", code: "1234.56")
 
       service = instance_double("OnetWebService", call: nil)
       expect(OnetWebService).to receive(:new).and_return(service).thrice
@@ -15,15 +15,15 @@ RSpec.describe ScrapeOnetCodes do
       }.to change(Onet, :count).by(2)
 
       onet.reload
-      expect(onet.name).to eq "Actuaries"
+      expect(onet.title).to eq "Actuaries"
       expect(onet.code).to eq "15-2011.00"
 
       onet1 = Onet.second
-      expect(onet1.name).to eq "Accountants and Auditors"
+      expect(onet1.title).to eq "Accountants and Auditors"
       expect(onet1.code).to eq "13-2011.00"
 
       onet2 = Onet.third
-      expect(onet2.name).to eq "Actors"
+      expect(onet2.title).to eq "Actors"
       expect(onet2.code).to eq "27-2011.00"
     end
   end


### PR DESCRIPTION
Precursor to [Asana ticket](https://app.asana.com/0/1203289004376659/1205551105604503/f)

The spreadsheet source tables for the ONET codes uses "Title" as the column name. Changing the `name` field to `title` to match the source data more closely, as well as to have consistency with our other tables which also use `title`.
