### PR TITLE
Set current version on existing onets

### DIFF
--- a/app/models/onet.rb
+++ b/app/models/onet.rb
@@ -1,6 +1,6 @@
 class Onet < ApplicationRecord
-  validates :title, :code, presence: true
-  validates :code, uniqueness: true
+  validates :title, presence: true
+  validates :code, presence: true, uniqueness: {scope: :version}
 
   def to_s
     "#{title} (#{code})"

--- a/app/models/onet.rb
+++ b/app/models/onet.rb
@@ -2,6 +2,8 @@ class Onet < ApplicationRecord
   validates :title, presence: true
   validates :code, presence: true, uniqueness: {scope: :version}
 
+  CURRENT_VERSION = "2019".freeze
+
   def to_s
     "#{title} (#{code})"
   end

--- a/app/services/scrape_onet_codes.rb
+++ b/app/services/scrape_onet_codes.rb
@@ -4,9 +4,9 @@ class ScrapeOnetCodes
     CSV.parse(file, headers: true) do |row|
       onet = Onet.find_or_initialize_by(
         version: Onet::CURRENT_VERSION,
-        title: row["Occupation"]
+        code: row["Code"]
       )
-      onet.update!(code: row["Code"])
+      onet.update!(title: row["Occupation"])
       OnetWebService.new(onet).call
     end
   end

--- a/app/services/scrape_onet_codes.rb
+++ b/app/services/scrape_onet_codes.rb
@@ -2,7 +2,10 @@ class ScrapeOnetCodes
   def call
     file = URI.open("https://www.onetonline.org/find/all/All_Occupations.csv?fmt=csv")
     CSV.parse(file, headers: true) do |row|
-      onet = Onet.find_or_initialize_by(title: row["Occupation"])
+      onet = Onet.find_or_initialize_by(
+        version: Onet::CURRENT_VERSION,
+        title: row["Occupation"]
+      )
       onet.update!(code: row["Code"])
       OnetWebService.new(onet).call
     end

--- a/db/migrate/20231003233621_add_version_to_onets.rb
+++ b/db/migrate/20231003233621_add_version_to_onets.rb
@@ -1,0 +1,5 @@
+class AddVersionToOnets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :onets, :version, :string
+  end
+end

--- a/db/migrate/20231003233735_add_version_and_code_constraint_on_onets_table.rb
+++ b/db/migrate/20231003233735_add_version_and_code_constraint_on_onets_table.rb
@@ -1,6 +1,11 @@
 class AddVersionAndCodeConstraintOnOnetsTable < ActiveRecord::Migration[7.0]
-  def change
+  def up
     remove_index :onets, :code
     add_index :onets, [:version, :code], unique: true
+  end
+
+  def down
+    remove_index :onets, [:version, :code]
+    add_index :onets, :code, name: :unique_code, unique: true
   end
 end

--- a/db/migrate/20231003233735_add_version_and_code_constraint_on_onets_table.rb
+++ b/db/migrate/20231003233735_add_version_and_code_constraint_on_onets_table.rb
@@ -1,0 +1,6 @@
+class AddVersionAndCodeConstraintOnOnetsTable < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :onets, :code
+    add_index :onets, [:version, :code], unique: true
+  end
+end

--- a/db/migrate/20231004163826_add_index_to_code_on_onets_table.rb
+++ b/db/migrate/20231004163826_add_index_to_code_on_onets_table.rb
@@ -1,0 +1,5 @@
+class AddIndexToCodeOnOnetsTable < ActiveRecord::Migration[7.0]
+  def change
+    add_index :onets, :code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_03_233735) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_04_163826) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -180,6 +180,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_03_233735) do
     t.datetime "updated_at", null: false
     t.string "related_job_titles", default: [], array: true
     t.string "version"
+    t.index ["code"], name: "index_onets_on_code"
     t.index ["version", "code"], name: "index_onets_on_version_and_code", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_03_201145) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_03_233621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -179,6 +179,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_03_201145) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "related_job_titles", default: [], array: true
+    t.string "version"
     t.index ["code"], name: "unique_code", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_03_233621) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_03_233735) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -180,7 +180,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_03_233621) do
     t.datetime "updated_at", null: false
     t.string "related_job_titles", default: [], array: true
     t.string "version"
-    t.index ["code"], name: "unique_code", unique: true
+    t.index ["version", "code"], name: "index_onets_on_version_and_code", unique: true
   end
 
   create_table "organizations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/deployment/20231003194756_set_default_version_on_onets_table.rake
+++ b/lib/tasks/deployment/20231003194756_set_default_version_on_onets_table.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: set_default_version_on_onets_table'
+  task set_default_version_on_onets_table: :environment do
+    puts "Running deploy task 'set_default_version_on_onets_table'"
+
+    Onet.update_all(version: "2019")
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20231003194756_set_default_version_on_onets_table.rake
+++ b/lib/tasks/deployment/20231003194756_set_default_version_on_onets_table.rake
@@ -1,5 +1,5 @@
 namespace :after_party do
-  desc 'Deployment task: set_default_version_on_onets_table'
+  desc "Deployment task: set_default_version_on_onets_table"
   task set_default_version_on_onets_table: :environment do
     puts "Running deploy task 'set_default_version_on_onets_table'"
 

--- a/spec/factories/onets.rb
+++ b/spec/factories/onets.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :onet do
     title { "Actors" }
     code { "27-2011.00" }
+    version { Onet::CURRENT_VERSION }
   end
 end

--- a/spec/models/onet_spec.rb
+++ b/spec/models/onet_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Onet, type: :model do
   end
 
   it "has unique code wrt version" do
-    onet = create(:onet, code: "12-3456.00", version: "2019")
-    new_onet = build(:onet, code: "12-3456.00", version: "2019")
+    create(:onet, code: "12-3456.00", version: "2019")
+    onet = build(:onet, code: "12-3456.00", version: "2019")
 
-    expect(new_onet).to_not be_valid
+    expect(onet).to_not be_valid
 
-    new_onet.version = "2020"
-    expect(new_onet).to be_valid
+    onet.version = "2020"
+    expect(onet).to be_valid
   end
 end

--- a/spec/models/onet_spec.rb
+++ b/spec/models/onet_spec.rb
@@ -6,4 +6,14 @@ RSpec.describe Onet, type: :model do
 
     expect(onet).to be_valid
   end
+
+  it "has unique code wrt version" do
+    onet = create(:onet, code: "12-3456.00", version: "2019")
+    new_onet = build(:onet, code: "12-3456.00", version: "2019")
+
+    expect(new_onet).to_not be_valid
+
+    new_onet.version = "2020"
+    expect(new_onet).to be_valid
+  end
 end

--- a/spec/services/scrape_onet_codes_spec.rb
+++ b/spec/services/scrape_onet_codes_spec.rb
@@ -17,14 +17,17 @@ RSpec.describe ScrapeOnetCodes do
       onet.reload
       expect(onet.title).to eq "Actuaries"
       expect(onet.code).to eq "15-2011.00"
+      expect(onet.version).to eq "2019"
 
       onet1 = Onet.second
       expect(onet1.title).to eq "Accountants and Auditors"
       expect(onet1.code).to eq "13-2011.00"
+      expect(onet.version).to eq "2019"
 
       onet2 = Onet.third
       expect(onet2.title).to eq "Actors"
       expect(onet2.code).to eq "27-2011.00"
+      expect(onet.version).to eq "2019"
     end
   end
 

--- a/spec/services/scrape_onet_codes_spec.rb
+++ b/spec/services/scrape_onet_codes_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ScrapeOnetCodes do
   describe "#call" do
     it "creates onet records" do
       stub_responses
-      onet = create(:onet, title: "Actuaries", code: "1234.56")
+      onet = create(:onet, title: "Not actually an actuary", code: "15-2011.00")
 
       service = instance_double("OnetWebService", call: nil)
       expect(OnetWebService).to receive(:new).and_return(service).thrice


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205644361039903/f

The current taxonomy in use for ONET SOC-codes is 2019. This adds a `version` field to the onets table and populates the current records with the "2019" version. This also makes a slight modification to the ScrapeOnetCodes service to treat the ONET code as the canonical source for the record, rather than the title.

