### PR TITLE
Fix flaky spec: add forgotten :elasticsearch tag on request specs

### DIFF
--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "OccupationStandard", type: :request do
         end
       end
 
-      context "with ES search" do
+      context "with ES search", :elasticsearch do
         it "makes one Elasticsearch query if no search params" do
           Flipper.enable :use_elasticsearch_for_search
           create(:occupation_standard, :with_work_processes, :with_data_import)


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205644361042012/f

Not 100% sure this is the fix, but I did notice that the failing specs noted in GitHub Action are missing the `:elasticsearch` tag. The spec error was:

```
Elasticsearch::Transport::Transport::Errors::BadRequest:
       [400] {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"unknown type for collapse field 
`headline`, only keywords and numbers are accepted"}],"type":"search_phase_execution_exception","reason":"all shards 
failed","phase":"query","grouped":true,"failed_shards":
[{"shard":0,"index":"occupation_standards_test","node":"iDEeG8DvT-OR6Er7EzuSgg","reason":
{"type":"illegal_argument_exception","reason":"unknown type for collapse field `headline`, only keywords and numbers are 
accepted"}}],"caused_by":{"type":"illegal_argument_exception","reason":"unknown type for collapse field `headline`, only 
keywords and numbers are accepted","caused_by":{"type":"illegal_argument_exception","reason":"unknown type for 
collapse field `headline`, only keywords and numbers are accepted"}}},"status":400}
```

but the `headline` field is of type `keyword`, so not sure what other changes can be made.
