### PR TITLE
Format onet code when importing

### DIFF
--- a/app/services/scrape_onet_codes.rb
+++ b/app/services/scrape_onet_codes.rb
@@ -2,12 +2,17 @@ class ScrapeOnetCodes
   def call
     file = URI.open("https://www.onetonline.org/find/all/All_Occupations.csv?fmt=csv")
     CSV.parse(file, headers: true) do |row|
+      formatted_code = format_code(row["Code"])
       onet = Onet.find_or_initialize_by(
         version: Onet::CURRENT_VERSION,
-        code: row["Code"]
+        code: formatted_code
       )
       onet.update!(title: row["Occupation"])
       OnetWebService.new(onet).call
     end
+  end
+
+  def format_code(code)
+    code.sub(/^(\d{2})\./, '\1-')
   end
 end

--- a/spec/fixtures/files/scraper/onet-codes.csv
+++ b/spec/fixtures/files/scraper/onet-codes.csv
@@ -2,3 +2,4 @@ Job Zone,Code,Occupation,Data-level
 4,13-2011.00,Accountants and Auditors,Y
 2,27-2011.00,Actors,Y
 4,15-2011.00,Actuaries,Y
+4,17.2011.00,Aerospace Engineers,Y

--- a/spec/services/scrape_onet_codes_spec.rb
+++ b/spec/services/scrape_onet_codes_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe ScrapeOnetCodes do
       onet = create(:onet, title: "Not actually an actuary", code: "15-2011.00")
 
       service = instance_double("OnetWebService", call: nil)
-      expect(OnetWebService).to receive(:new).and_return(service).thrice
-      expect(service).to receive(:call).thrice
+      expect(OnetWebService).to receive(:new).and_return(service).exactly(4).times
+      expect(service).to receive(:call).exactly(4).times
 
       expect {
         described_class.new.call
-      }.to change(Onet, :count).by(2)
+      }.to change(Onet, :count).by(3)
 
       onet.reload
       expect(onet.title).to eq "Actuaries"
@@ -22,12 +22,17 @@ RSpec.describe ScrapeOnetCodes do
       onet1 = Onet.second
       expect(onet1.title).to eq "Accountants and Auditors"
       expect(onet1.code).to eq "13-2011.00"
-      expect(onet.version).to eq "2019"
+      expect(onet1.version).to eq "2019"
 
       onet2 = Onet.third
       expect(onet2.title).to eq "Actors"
       expect(onet2.code).to eq "27-2011.00"
-      expect(onet.version).to eq "2019"
+      expect(onet2.version).to eq "2019"
+
+      onet3 = Onet.fourth
+      expect(onet3.title).to eq "Aerospace Engineers"
+      expect(onet3.code).to eq "17-2011.00"
+      expect(onet3.version).to eq "2019"
     end
   end
 


### PR DESCRIPTION
Asana ticket: [https://app.asana.com/0/1203289004376659/1204540724864282/f](https://app.asana.com/0/1203289004376659/1204540724864282/f)

I updated the Onet scraper so that if there is a code that is formatted incorrectly like "47.3011.00", then it will be formatted correctly to "47-3011.00".
