### PR TITLE
Upgrade to Elasticsearch 8

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -35,7 +35,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.10.3
         ports:
           - 9200:9200
           - 9300:9300

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.2"
 
-gem "bonsai-elasticsearch-rails", "~> 7"
 gem "elasticsearch", "< 7.14"
 gem "elasticsearch-rails"
 gem "elasticsearch-model"

--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,12 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.2"
 
-gem "elasticsearch", "< 7.14"
-gem "elasticsearch-rails"
-gem "elasticsearch-model"
-gem "elasticsearch-dsl"
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.8"
+
+gem "elasticsearch", "8.10.0"
+gem "elasticsearch-model", github: "elastic/elasticsearch-rails", branch: "8.x"
+gem "elasticsearch-rails", github: "elastic/elasticsearch-rails", branch: "8.x"
+gem "elasticsearch-dsl"
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,17 @@ GIT
       capybara (>= 3.36.0)
 
 GIT
+  remote: https://github.com/elastic/elasticsearch-rails.git
+  revision: bb6fbe89b4e3eac590c042963b5359644061ca33
+  branch: 8.x
+  specs:
+    elasticsearch-model (8.0.0)
+      activesupport (> 3)
+      elasticsearch (~> 8)
+      hashie
+    elasticsearch-rails (8.0.0)
+
+GIT
   remote: https://github.com/mvz/non-digest-assets.git
   revision: 4bb1e9c669c605f87694e91bb1d57ecde9ce319d
   branch: master
@@ -117,6 +128,7 @@ GEM
       aws-sigv4 (~> 1.6)
     aws-sigv4 (1.6.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.1.1)
     bcrypt (3.1.18)
     better_html (2.0.2)
       actionview (>= 6.0)
@@ -169,20 +181,15 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    elasticsearch (7.13.3)
-      elasticsearch-api (= 7.13.3)
-      elasticsearch-transport (= 7.13.3)
-    elasticsearch-api (7.13.3)
+    elastic-transport (8.3.0)
+      faraday (< 3)
+      multi_json
+    elasticsearch (8.10.0)
+      elastic-transport (~> 8)
+      elasticsearch-api (= 8.10.0)
+    elasticsearch-api (8.10.0)
       multi_json
     elasticsearch-dsl (0.1.10)
-    elasticsearch-model (7.2.1)
-      activesupport (> 3)
-      elasticsearch (~> 7)
-      hashie
-    elasticsearch-rails (7.2.1)
-    elasticsearch-transport (7.13.3)
-      faraday (~> 1)
-      multi_json
     erb_lint (0.5.0)
       activesupport
       better_html (>= 2.0.1)
@@ -197,29 +204,11 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+    faraday (2.7.11)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     flipper (1.0.0)
       brow (~> 0.4.1)
@@ -283,7 +272,6 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.1)
     multi_json (1.15.0)
-    multipart-post (2.3.0)
     net-imap (0.3.7)
       date
       net-protocol
@@ -513,10 +501,10 @@ DEPENDENCIES
   devise_invitable (~> 2.0.0)
   docx
   dotenv-rails
-  elasticsearch (< 7.14)
+  elasticsearch (= 8.10.0)
   elasticsearch-dsl
-  elasticsearch-model
-  elasticsearch-rails
+  elasticsearch-model!
+  elasticsearch-rails!
   erb_lint
   erblint-github
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,9 +127,6 @@ GEM
       smart_properties
     bindex (0.8.1)
     blueprinter (0.30.0)
-    bonsai-elasticsearch-rails (7.0.1)
-      elasticsearch-model (< 8)
-      elasticsearch-rails (< 8)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     brow (0.4.1)
@@ -507,7 +504,6 @@ DEPENDENCIES
   after_party
   aws-sdk-s3
   blueprinter
-  bonsai-elasticsearch-rails (~> 7)
   bootsnap
   bullet
   capybara

--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@ The ApprenticeshipStandards.org application is currently running on Ruby 3,
 Rails 7, and PostgreSQL 14.
 
 ## Development setup
+1. [Install Elasticsearch](#elasticsearch-setup)
+2. Start `elasticsearch` in the terminal, as the setup command
+   will run some tasks to create Elasticsearch indexes
 1. Run `bin/setup`
-2. Install [libvips][libvips] for use with ActiveStorage
+2. Kill `elasticsearch` as it will get started with the `bin/dev`
+   command below
 3. Install [mailcatcher][mailcatcher] to preview emails. See the
    [troubleshooting](#mailcatcher-troubleshooting) section if you have
    installation issues.
-4. [Install Elasticsearch](#elasticsearch-setup)
 4. To access the admin pages, you must modify your `/etc/hosts` file:
    ```
    # Added for ApprenticeshipStandards.org
@@ -19,10 +22,7 @@ Rails 7, and PostgreSQL 14.
     * The public facing application will be available at http://localhost:3000
     * The admin pages will be available at http://admin.example.localhost:3000
     * Email previews will be available at http://localhost:1080
-6. See the [Populate Elasticsearch](#populate-elasticsearch) section to import
-   data into Elasticsearch
 
-[libvips]: https://www.libvips.org/install.html
 [mailcatcher]: https://mailcatcher.me
 
 ### Mailcatcher troubleshooting
@@ -83,25 +83,16 @@ command.
 The promotion can also be done through the Heroku Dashboard on the [Pipelines page](https://dashboard.heroku.com/pipelines/3657e91f-455e-4fa7-9da7-f6ddc1beb854).
 
 ## Elasticsearch setup
-We are currently using Elasticsearch version 7.17.4. See the [Elasticsearch
-documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/install-elasticsearch.html)
-for installation options. The Homebrew installation may no longer work due to
-licensing issues.
+We are currently using Elasticsearch version 8.10.3. See the [Elasticsearch
+documentation][ES-documentation]
+for installation options. To debug any queries, set `log: true` in
+the `config/initializers/elasticsearch.rb` client setup.
 
-### Populate Elasticsearch
-Once the app is running with the `bin/dev` command, set up the index for the
-OccupationStandard model and import any existing records into Elasticsearch
-through the Rails console:
-
-```
-> OccupationStandard.__elasticsearch__.create_index!
-> OccupationStandard.import
-```
+[ES-documentation]: https://www.elastic.co/guide/en/elasticsearch/reference/8.10/install-elasticsearch.html
 
 ### Kibana setup
 If you are working on any tasks related to Elasticsearch, then it may be helpful
-to set up
-[Kibana](https://www.elastic.co/guide/en/kibana/7.17/introduction.html).
+to set up [Kibana][kibana].
 
 To start Kibana, make sure that elasticsearch is already running, then run
 `kibana` in the terminal. Kibana will be available at http://localhost:5601. To
@@ -125,6 +116,8 @@ the right.
 If you need to view the names of all your indices, under the Management section
 go to "Stack Management". Then under the Data section, click "Index Management"
 to see the list of all the available indices.
+
+[kibana]: https://www.elastic.co/guide/en/kibana/current/install.html
 
 ## AWS setup
 If you will have access to AWS to manage the S3 buckets, [view the setup

--- a/app/queries/occupation_elasticsearch_query.rb
+++ b/app/queries/occupation_elasticsearch_query.rb
@@ -3,12 +3,11 @@ require "elasticsearch/dsl"
 class OccupationElasticsearchQuery
   include Elasticsearch::DSL
 
-  attr_reader :search_params, :offset, :debug
+  attr_reader :search_params, :offset
 
-  def initialize(search_params:, offset: 0, debug: false)
+  def initialize(search_params:, offset: 0)
     @search_params = search_params
     @offset = offset
-    @debug = debug
   end
 
   def call
@@ -46,21 +45,6 @@ class OccupationElasticsearchQuery
       definition,
       from: offset
     )
-    debug_query(response)
     response
-  end
-
-  private
-
-  def debug_query(response)
-    if debug
-      puts "BODY"
-      puts response.search.definition[:body].to_json
-      puts "HITS: #{response.results.total}"
-      response.results.each do |result|
-        #        puts result.inspect
-        puts "#{result._id}: #{result._score}"
-      end
-    end
   end
 end

--- a/app/queries/occupation_elasticsearch_query.rb
+++ b/app/queries/occupation_elasticsearch_query.rb
@@ -41,10 +41,9 @@ class OccupationElasticsearchQuery
         end
       end
     end
-    response = Occupation.__elasticsearch__.search(
+    Occupation.__elasticsearch__.search(
       definition,
       from: offset
     )
-    response
   end
 end

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -122,11 +122,10 @@ class OccupationStandardElasticsearchQuery
     end
     # Size and From must be passed here rather than defined in the query in
     # order for Pagy to work correctly.
-    response = OccupationStandard.__elasticsearch__.search(
+    OccupationStandard.__elasticsearch__.search(
       definition,
       from: offset,
       size: Pagy::DEFAULT[:items]
     )
-    response
   end
 end

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -3,12 +3,11 @@ require "elasticsearch/dsl"
 class OccupationStandardElasticsearchQuery
   include Elasticsearch::DSL
 
-  attr_reader :search_params, :offset, :debug
+  attr_reader :search_params, :offset
 
-  def initialize(search_params:, offset: 0, debug: false)
+  def initialize(search_params:, offset: 0)
     @search_params = search_params
     @offset = offset
-    @debug = debug
   end
 
   def call
@@ -128,25 +127,6 @@ class OccupationStandardElasticsearchQuery
       from: offset,
       size: Pagy::DEFAULT[:items]
     )
-    debug_query(response)
     response
-  end
-
-  private
-
-  def debug_query(response)
-    if debug
-      puts "BODY"
-      puts response.search.definition[:body].to_json
-      puts "HITS: #{response.results.total}"
-      response.results.each do |result|
-        puts "PARENT: #{result._id}: #{result._score}"
-        result.inner_hits.children.each do |child|
-          child[1].hits.each do |hit|
-            puts "\tCHILD ID: #{hit._id}: #{hit._score}"
-          end
-        end
-      end
-    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,10 @@ require "rack/rewrite"
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
 
+# Display information about the search request (duration, search definition)
+# during development, and to include the information in the Rails log file
+require "elasticsearch/rails/instrumentation"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,0 +1,3 @@
+require "elasticsearch"
+host = ENV.fetch("FOUNDELASTICSEARCH_URL", "http://localhost:9200")
+Elasticsearch::Model.client = Elasticsearch::Client.new(host: host, log: false)

--- a/spec/support/elasticseach.rb
+++ b/spec/support/elasticseach.rb
@@ -6,7 +6,7 @@ RSpec.configure do |config|
           model.__elasticsearch__.delete_index!
           model.__elasticsearch__.create_index!
           model.__elasticsearch__.refresh_index!
-        rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+        rescue Elastic::Transport::Transport::Errors::NotFound => e
           puts "There was an error creating the elasticsearch index
                 for #{model.name}: #{e.inspect}"
         end
@@ -20,7 +20,7 @@ RSpec.configure do |config|
         begin
           model.__elasticsearch__.delete_index!
           model.__elasticsearch__.create_index!
-        rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+        rescue Elastic::Transport::Transport::Errors::NotFound => e
           puts "There was an error removing the elasticsearch index
                 for #{model.name}: #{e.inspect}"
         end


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1203289004376659/1205692341581078/f

In order to use the Elasticsearch Synonyms API, we need to upgrade to Elasticsearch 8. The Bonsai add-on in Heroku was replaced with the Elasticsearch add-on instead, as the Bonsai add-on did not support Elasticsearch 8.

