### PR TITLE
Move populating onets and occupations out of seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,4 @@ if Rails.env.development?
     name: "Admin User",
     password: "passwordpassword"
   )
-
-  ScrapeRAPIDSCode.new.call
-  ScrapeOnetCodes.new.call
 end

--- a/lib/tasks/deployment/20231013155029_populate_onets_and_occupations.rake
+++ b/lib/tasks/deployment/20231013155029_populate_onets_and_occupations.rake
@@ -1,0 +1,16 @@
+namespace :after_party do
+  desc "Deployment task: populate_onets_and_occupations"
+  task populate_onets_and_occupations: :environment do
+    puts "Running deploy task 'populate_onets_and_occupations'"
+
+    if Rails.env.development?
+      ScrapeRAPIDSCode.new.call
+      ScrapeOnetCodes.new.call
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
The `bin/setup` task runs the seeds file, which in turn
was running the tasks to populate the onets table and
the occupations table. The onets population task is
particularly time-consuming now as it makes a call
to a 3rd-party API to populate the related job titles fields.
These tasks really only need to be run once for dev
environment setup, so they are being moved to a
one-time After Party task.

