### PR TITLE
Use Elastic Cloud ID to configure Heroku add-on

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,19 +1,14 @@
 require "elasticsearch"
 
-host = ENV.fetch("FOUNDELASTICSEARCH_URL", "http://localhost:9200")
-
-args = {
-  host: host,
-  log: false
-}
-
-if Rails.env.production?
-  args.merge(
-    port: "443",
-    scheme: "https",
-    user: ENV.fetch("ELASTICSEARCH_USER"),
-    password: ENV.fetch("ELASTICSEARCH_PASSWORD")
-  )
+args = if Rails.env.production?
+  {
+    cloud_id: ENV.fetch("ELASTIC_CLOUD_ID"),
+    user: ENV.fetch("ELASTIC_USER"),
+    password: ENV.fetch("ELASTIC_PASSWORD"),
+    log: false
+  }
+else
+  {log: false}
 end
 
 Elasticsearch::Model.client = Elasticsearch::Client.new(args)


### PR DESCRIPTION
I had gotten the previous configuration to work playing around in the Heroku console, but now can't seem to reconfigure successful connection with it. Using the Cloud ID instead. [Ref](https://github.com/elastic/elasticsearch-ruby/tree/7.16/elasticsearch-transport#connect-using-an-elastic-cloud-id).

[Asana ticket](https://app.asana.com/0/1203289004376659/1205710899303710/f)
