### PR TITLE
Elasticsearch client configuration fix for Docker

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,6 +1,6 @@
 require "elasticsearch"
 
-args = if Rails.env.production?
+args = if Rails.env.production? && ENV["ELASTIC_CLOUD_ID"].present?
   {
     cloud_id: ENV.fetch("ELASTIC_CLOUD_ID"),
     user: ENV.fetch("ELASTIC_USER"),


### PR DESCRIPTION
The `rake assets:precompile` command in the
Dockerfile is expecting the existence of the
`ELASTIC_` environment variables. This change
adds a conditional check for the `ELASTIC_` variables
so the Elasticsearch client configuration is skipped
during the asset precompilation task.

[Asana ticket](https://app.asana.com/0/1203289004376659/1205710899303710/f)
