### PR TITLE
Allow Elasticsearch logging to be enabled in production

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,11 +1,12 @@
 require "elasticsearch"
 
 args = if Rails.env.production? && ENV["ELASTIC_CLOUD_ID"].present?
+  enable_logging = ENV.fetch("ELASTIC_LOGGING_ENABLED", "false")
   {
     cloud_id: ENV.fetch("ELASTIC_CLOUD_ID"),
     user: ENV.fetch("ELASTIC_USER"),
     password: ENV.fetch("ELASTIC_PASSWORD"),
-    log: false
+    log: ActiveModel::Type::Boolean.new.cast(enable_logging)
   }
 else
   {log: false}


### PR DESCRIPTION
Add an environment variable that allows us to turn on Elasticsearch logging in production.