### PR TITLE
Map old ONET codes to the next version

### DIFF
--- a/app/models/onet.rb
+++ b/app/models/onet.rb
@@ -2,6 +2,9 @@ class Onet < ApplicationRecord
   validates :title, presence: true
   validates :code, presence: true, uniqueness: {scope: :version}
 
+  has_many :onet_mappings
+  has_many :next_versions, through: :onet_mappings, source: :next_version_onet
+
   CURRENT_VERSION = "2019".freeze
 
   def to_s

--- a/app/models/onet_mapping.rb
+++ b/app/models/onet_mapping.rb
@@ -1,0 +1,4 @@
+class OnetMapping < ApplicationRecord
+  belongs_to :onet
+  belongs_to :next_version_onet, class_name: "Onet"
+end

--- a/app/models/onet_mapping.rb
+++ b/app/models/onet_mapping.rb
@@ -1,4 +1,6 @@
 class OnetMapping < ApplicationRecord
   belongs_to :onet
   belongs_to :next_version_onet, class_name: "Onet"
+
+  validates :onet, uniqueness: {scope: :next_version_onet}
 end

--- a/db/migrate/20231019234540_create_onet_mappings.rb
+++ b/db/migrate/20231019234540_create_onet_mappings.rb
@@ -1,0 +1,10 @@
+class CreateOnetMappings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :onet_mappings, id: :uuid do |t|
+      t.references :onet, null: false, foreign_key: true, type: :uuid
+      t.references :next_version_onet, null: false, foreign_key: {to_table: :onets}, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231020000522_add_unique_constraint_on_onet_and_next_version_in_onet_mappings.rb
+++ b/db/migrate/20231020000522_add_unique_constraint_on_onet_and_next_version_in_onet_mappings.rb
@@ -1,0 +1,6 @@
+class AddUniqueConstraintOnOnetAndNextVersionInOnetMappings < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :onet_mappings, :onet_id
+    add_index :onet_mappings, [:onet_id, :next_version_onet_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_06_161013) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_19_234540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -173,6 +173,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_161013) do
     t.index ["onet_id"], name: "index_occupations_on_onet_id"
   end
 
+  create_table "onet_mappings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "onet_id", null: false
+    t.uuid "next_version_onet_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["next_version_onet_id"], name: "index_onet_mappings_on_next_version_onet_id"
+    t.index ["onet_id"], name: "index_onet_mappings_on_onet_id"
+  end
+
   create_table "onets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title"
     t.string "code"
@@ -330,6 +339,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_161013) do
   add_foreign_key "occupation_standards", "organizations"
   add_foreign_key "occupation_standards", "registration_agencies"
   add_foreign_key "occupations", "onets"
+  add_foreign_key "onet_mappings", "onets"
+  add_foreign_key "onet_mappings", "onets", column: "next_version_onet_id"
   add_foreign_key "registration_agencies", "states"
   add_foreign_key "related_instructions", "courses"
   add_foreign_key "related_instructions", "courses", column: "default_course_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_19_234540) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_20_000522) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -179,7 +179,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_19_234540) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["next_version_onet_id"], name: "index_onet_mappings_on_next_version_onet_id"
-    t.index ["onet_id"], name: "index_onet_mappings_on_onet_id"
+    t.index ["onet_id", "next_version_onet_id"], name: "index_onet_mappings_on_onet_id_and_next_version_onet_id", unique: true
   end
 
   create_table "onets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/deployment/20231019235724_import_2018_to_2019_onet_crosswalk.rake
+++ b/lib/tasks/deployment/20231019235724_import_2018_to_2019_onet_crosswalk.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc "Deployment task: import_2018_to_2019_onet_crosswalk"
+  task import_2018_to_2019_onet_crosswalk: :environment do
+    puts "Running deploy task 'import_2018_to_2019_onet_crosswalk'"
+
+    filename = File.join(Rails.root, "lib", "tasks", "files", "2019_to_SOC_Crosswalk.csv")
+    CSV.foreach(filename, headers: true) do |row|
+      onet2019 = Onet.where(version: "2019", code: row["O*NET-SOC 2019 Code"]).sole
+      onet2018 = Onet.where(version: "2018", code: row["2018 SOC Code"]).sole
+
+      OnetMapping.create(onet: onet2018, next_version_onet: onet2019)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20231020001518_import_2010_to_2019_onet_crosswalk.rake
+++ b/lib/tasks/deployment/20231020001518_import_2010_to_2019_onet_crosswalk.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc "Deployment task: import_2010_to_2019_onet_crosswalk"
+  task import_2010_to_2019_onet_crosswalk: :environment do
+    puts "Running deploy task 'import_2010_to_2019_onet_crosswalk'"
+
+    filename = File.join(Rails.root, "lib", "tasks", "files", "2010_to_2019_Crosswalk.csv")
+    CSV.foreach(filename, headers: true) do |row|
+      onet2019 = Onet.where(version: "2019", code: row["O*NET-SOC 2019 Code"]).sole
+      onet2010 = Onet.where(version: "2010", code: row["O*NET-SOC 2010 Code"]).sole
+
+      OnetMapping.create(onet: onet2010, next_version_onet: onet2019)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20231020002043_import_2009_to_2010_onet_crosswalk.rake
+++ b/lib/tasks/deployment/20231020002043_import_2009_to_2010_onet_crosswalk.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc "Deployment task: import_2009_to_2010_onet_crosswalk"
+  task import_2009_to_2010_onet_crosswalk: :environment do
+    puts "Running deploy task 'import_2009_to_2010_onet_crosswalk'"
+
+    filename = File.join(Rails.root, "lib", "tasks", "files", "2009_to_2010_Crosswalk.csv")
+    CSV.foreach(filename, headers: true) do |row|
+      onet2010 = Onet.where(version: "2010", code: row["O*NET-SOC 2010 Code"]).sole
+      onet2009 = Onet.where(version: "2009", code: row["O*NET-SOC 2009 Code"]).sole
+
+      OnetMapping.create(onet: onet2009, next_version_onet: onet2010)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20231020002445_import_2006_to_2009_onet_crosswalk.rake
+++ b/lib/tasks/deployment/20231020002445_import_2006_to_2009_onet_crosswalk.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc "Deployment task: import_2006_to_2009_onet_crosswalk"
+  task import_2006_to_2009_onet_crosswalk: :environment do
+    puts "Running deploy task 'import_2006_to_2009_onet_crosswalk'"
+
+    filename = File.join(Rails.root, "lib", "tasks", "files", "2006_to_2009_Crosswalk.csv")
+    CSV.foreach(filename, headers: true) do |row|
+      onet2009 = Onet.where(version: "2009", code: row["O*NET-SOC 2009 Code"]).sole
+      onet2006 = Onet.where(version: "2006", code: row["O*NET-SOC 2006 Code"]).sole
+
+      OnetMapping.create(onet: onet2006, next_version_onet: onet2009)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20231020002918_import_2000_to_2006_onet_crosswalk.rake
+++ b/lib/tasks/deployment/20231020002918_import_2000_to_2006_onet_crosswalk.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc "Deployment task: import_2000_to_2006_onet_crosswalk"
+  task import_2000_to_2006_onet_crosswalk: :environment do
+    puts "Running deploy task 'import_2000_to_2006_onet_crosswalk'"
+
+    filename = File.join(Rails.root, "lib", "tasks", "files", "2000_to_2006_Crosswalk.csv")
+    CSV.foreach(filename, headers: true) do |row|
+      onet2006 = Onet.where(version: "2006", code: row["O*NET-SOC 2006 Code"]).sole
+      onet2000 = Onet.where(version: "2000", code: row["O*NET-SOC 2000 Code"]).sole
+
+      OnetMapping.create(onet: onet2000, next_version_onet: onet2006)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/files/2000_to_2006_Crosswalk.csv
+++ b/lib/tasks/files/2000_to_2006_Crosswalk.csv
@@ -1,0 +1,1168 @@
+O*NET-SOC 2000 Code,O*NET-SOC 2000 Title,O*NET-SOC 2006 Code,O*NET-SOC 2006 Title
+11-1011.00,Chief Executives,11-1011.00,Chief Executives
+11-1011.01,Government Service Executives,11-1011.00,Chief Executives
+11-1011.02,Private Sector Executives,11-1011.00,Chief Executives
+11-1021.00,General and Operations Managers,11-1021.00,General and Operations Managers
+11-1031.00,Legislators,11-1031.00,Legislators
+11-2011.00,Advertising and Promotions Managers,11-2011.00,Advertising and Promotions Managers
+11-2021.00,Marketing Managers,11-2021.00,Marketing Managers
+11-2022.00,Sales Managers,11-2022.00,Sales Managers
+11-2031.00,Public Relations Managers,11-2031.00,Public Relations Managers
+11-3011.00,Administrative Services Managers,11-3011.00,Administrative Services Managers
+11-3021.00,Computer and Information Systems Managers,11-3021.00,Computer and Information Systems Managers
+11-3031.00,Financial Managers,11-3031.00,Financial Managers
+11-3031.01,"Treasurers, Controllers, and Chief Financial Officers",11-3031.01,Treasurers and Controllers
+11-3031.02,"Financial Managers, Branch or Department",11-3031.02,"Financial Managers, Branch or Department"
+11-3040.00,Human Resources Managers,11-3040.00,Human Resources Managers
+11-3041.00,Compensation and Benefits Managers,11-3041.00,Compensation and Benefits Managers
+11-3042.00,Training and Development Managers,11-3042.00,Training and Development Managers
+11-3049.99,"Human Resources Managers, All Other",11-3049.99,"Human Resources Managers, All Other"
+11-3051.00,Industrial Production Managers,11-3051.00,Industrial Production Managers
+11-3061.00,Purchasing Managers,11-3061.00,Purchasing Managers
+11-3071.00,"Transportation, Storage, and Distribution Managers",11-3071.00,"Transportation, Storage, and Distribution Managers"
+11-3071.01,Transportation Managers,11-3071.01,Transportation Managers
+11-3071.02,Storage and Distribution Managers,11-3071.02,Storage and Distribution Managers
+11-9011.00,"Farm, Ranch, and Other Agricultural Managers",11-9011.00,"Farm, Ranch, and Other Agricultural Managers"
+11-9011.01,Nursery and Greenhouse Managers,11-9011.01,Nursery and Greenhouse Managers
+11-9011.02,Agricultural Crop Farm Managers,11-9011.02,Crop and Livestock Managers
+11-9011.03,Fish Hatchery Managers,11-9011.03,Aquacultural Managers
+11-9012.00,Farmers and Ranchers,11-9012.00,Farmers and Ranchers
+11-9021.00,Construction Managers,11-9021.00,Construction Managers
+11-9031.00,"Education Administrators, Preschool and Child Care Center/Program",11-9031.00,"Education Administrators, Preschool and Child Care Center/Program"
+11-9032.00,"Education Administrators, Elementary and Secondary School",11-9032.00,"Education Administrators, Elementary and Secondary School"
+11-9033.00,"Education Administrators, Postsecondary",11-9033.00,"Education Administrators, Postsecondary"
+11-9039.99,"Education Administrators, All Other",11-9039.99,"Education Administrators, All Other"
+11-9041.00,Engineering Managers,11-9041.00,Engineering Managers
+11-9051.00,Food Service Managers,11-9051.00,Food Service Managers
+11-9061.00,Funeral Directors,11-9061.00,Funeral Directors
+11-9071.00,Gaming Managers,11-9071.00,Gaming Managers
+11-9081.00,Lodging Managers,11-9081.00,Lodging Managers
+11-9111.00,Medical and Health Services Managers,11-9111.00,Medical and Health Services Managers
+11-9121.00,Natural Sciences Managers,11-9121.00,Natural Sciences Managers
+11-9131.00,Postmasters and Mail Superintendents,11-9131.00,Postmasters and Mail Superintendents
+11-9141.00,"Property, Real Estate, and Community Association Managers",11-9141.00,"Property, Real Estate, and Community Association Managers"
+11-9151.00,Social and Community Service Managers,11-9151.00,Social and Community Service Managers
+11-9199.99,"Managers, All Other",11-9199.99,"Managers, All Other"
+13-1011.00,"Agents and Business Managers of Artists, Performers, and Athletes",13-1011.00,"Agents and Business Managers of Artists, Performers, and Athletes"
+13-1021.00,"Purchasing Agents and Buyers, Farm Products",13-1021.00,"Purchasing Agents and Buyers, Farm Products"
+13-1022.00,"Wholesale and Retail Buyers, Except Farm Products",13-1022.00,"Wholesale and Retail Buyers, Except Farm Products"
+13-1023.00,"Purchasing Agents, Except Wholesale, Retail, and Farm Products",13-1023.00,"Purchasing Agents, Except Wholesale, Retail, and Farm Products"
+13-1031.00,"Claims Adjusters, Examiners, and Investigators",13-1031.00,"Claims Adjusters, Examiners, and Investigators"
+13-1031.01,"Claims Examiners, Property and Casualty Insurance",13-1031.01,"Claims Examiners, Property and Casualty Insurance"
+13-1031.02,"Insurance Adjusters, Examiners, and Investigators",13-1031.02,"Insurance Adjusters, Examiners, and Investigators"
+13-1032.00,"Insurance Appraisers, Auto Damage",13-1032.00,"Insurance Appraisers, Auto Damage"
+13-1041.00,"Compliance Officers, Except Agriculture, Construction, Health and Safety, and Transportation",13-1041.00,"Compliance Officers, Except Agriculture, Construction, Health and Safety, and Transportation"
+13-1041.01,Environmental Compliance Inspectors,13-1041.01,Environmental Compliance Inspectors
+13-1041.02,Licensing Examiners and Inspectors,13-1041.02,Licensing Examiners and Inspectors
+13-1041.03,Equal Opportunity Representatives and Officers,13-1041.03,Equal Opportunity Representatives and Officers
+13-1041.04,Government Property Inspectors and Investigators,13-1041.04,Government Property Inspectors and Investigators
+13-1041.05,Pressure Vessel Inspectors,47-4011.00,Construction and Building Inspectors
+13-1041.06,Coroners,13-1041.06,Coroners
+13-1051.00,Cost Estimators,13-1051.00,Cost Estimators
+13-1061.00,Emergency Management Specialists,13-1061.00,Emergency Management Specialists
+13-1071.00,"Employment, Recruitment, and Placement Specialists",13-1071.00,"Employment, Recruitment, and Placement Specialists"
+13-1071.01,"Employment Interviewers, Private or Public Employment Service",13-1071.01,Employment Interviewers
+13-1071.02,Personnel Recruiters,13-1071.02,Personnel Recruiters
+13-1072.00,"Compensation, Benefits, and Job Analysis Specialists",13-1072.00,"Compensation, Benefits, and Job Analysis Specialists"
+13-1073.00,Training and Development Specialists,13-1073.00,Training and Development Specialists
+13-1079.99,"Human Resources, Training, and Labor Relations Specialists, All Other",13-1079.99,"Human Resources, Training, and Labor Relations Specialists, All Other"
+13-1081.00,Logisticians,13-1081.00,Logisticians
+13-1111.00,Management Analysts,13-1111.00,Management Analysts
+13-1121.00,Meeting and Convention Planners,13-1121.00,Meeting and Convention Planners
+13-1199.99,"Business Operations Specialists, All Other",13-1199.99,"Business Operations Specialists, All Other"
+13-2011.00,Accountants and Auditors,13-2011.00,Accountants and Auditors
+13-2011.01,Accountants,13-2011.01,Accountants
+13-2011.02,Auditors,13-2011.02,Auditors
+13-2021.00,Appraisers and Assessors of Real Estate,13-2021.00,Appraisers and Assessors of Real Estate
+13-2021.01,Assessors,13-2021.01,Assessors
+13-2021.02,"Appraisers, Real Estate",13-2021.02,"Appraisers, Real Estate"
+13-2031.00,Budget Analysts,13-2031.00,Budget Analysts
+13-2041.00,Credit Analysts,13-2041.00,Credit Analysts
+13-2051.00,Financial Analysts,13-2051.00,Financial Analysts
+13-2052.00,Personal Financial Advisors,13-2052.00,Personal Financial Advisors
+13-2053.00,Insurance Underwriters,13-2053.00,Insurance Underwriters
+13-2061.00,Financial Examiners,13-2061.00,Financial Examiners
+13-2071.00,Loan Counselors,13-2071.00,Loan Counselors
+13-2072.00,Loan Officers,13-2072.00,Loan Officers
+13-2081.00,"Tax Examiners, Collectors, and Revenue Agents",13-2081.00,"Tax Examiners, Collectors, and Revenue Agents"
+13-2082.00,Tax Preparers,13-2082.00,Tax Preparers
+13-2099.99,"Financial Specialists, All Other",13-2099.99,"Financial Specialists, All Other"
+15-1011.00,"Computer and Information Scientists, Research",15-1011.00,"Computer and Information Scientists, Research"
+15-1021.00,Computer Programmers,15-1021.00,Computer Programmers
+15-1031.00,"Computer Software Engineers, Applications",15-1031.00,"Computer Software Engineers, Applications"
+15-1032.00,"Computer Software Engineers, Systems Software",15-1032.00,"Computer Software Engineers, Systems Software"
+15-1041.00,Computer Support Specialists,15-1041.00,Computer Support Specialists
+15-1051.00,Computer Systems Analysts,15-1051.00,Computer Systems Analysts
+15-1061.00,Database Administrators,15-1061.00,Database Administrators
+15-1071.00,Network and Computer Systems Administrators,15-1071.00,Network and Computer Systems Administrators
+15-1071.01,Computer Security Specialists,15-1071.01,Computer Security Specialists
+15-1081.00,Network Systems and Data Communications Analysts,15-1081.00,Network Systems and Data Communications Analysts
+15-1099.99,"Computer Specialists, All Other",15-1099.99,"Computer Specialists, All Other"
+15-2011.00,Actuaries,15-2011.00,Actuaries
+15-2021.00,Mathematicians,15-2021.00,Mathematicians
+15-2031.00,Operations Research Analysts,15-2031.00,Operations Research Analysts
+15-2041.00,Statisticians,15-2041.00,Statisticians
+15-2091.00,Mathematical Technicians,15-2091.00,Mathematical Technicians
+15-2099.99,"Mathematical Science Occupations, All Other",15-2099.99,"Mathematical Science Occupations, All Other"
+17-1011.00,"Architects, Except Landscape and Naval",17-1011.00,"Architects, Except Landscape and Naval"
+17-1012.00,Landscape Architects,17-1012.00,Landscape Architects
+17-1021.00,Cartographers and Photogrammetrists,17-1021.00,Cartographers and Photogrammetrists
+17-1022.00,Surveyors,17-1022.00,Surveyors
+17-2011.00,Aerospace Engineers,17-2011.00,Aerospace Engineers
+17-2021.00,Agricultural Engineers,17-2021.00,Agricultural Engineers
+17-2031.00,Biomedical Engineers,17-2031.00,Biomedical Engineers
+17-2041.00,Chemical Engineers,17-2041.00,Chemical Engineers
+17-2051.00,Civil Engineers,17-2051.00,Civil Engineers
+17-2061.00,Computer Hardware Engineers,17-2061.00,Computer Hardware Engineers
+17-2071.00,Electrical Engineers,17-2071.00,Electrical Engineers
+17-2072.00,"Electronics Engineers, Except Computer",17-2072.00,"Electronics Engineers, Except Computer"
+17-2081.00,Environmental Engineers,17-2081.00,Environmental Engineers
+17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors",17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors"
+17-2111.01,Industrial Safety and Health Engineers,17-2111.01,Industrial Safety and Health Engineers
+17-2111.02,Fire-Prevention and Protection Engineers,17-2111.02,Fire-Prevention and Protection Engineers
+17-2111.03,Product Safety Engineers,17-2111.03,Product Safety Engineers
+17-2112.00,Industrial Engineers,17-2112.00,Industrial Engineers
+17-2121.00,Marine Engineers and Naval Architects,17-2121.00,Marine Engineers and Naval Architects
+17-2121.01,Marine Engineers,17-2121.01,Marine Engineers
+17-2121.02,Marine Architects,17-2121.02,Marine Architects
+17-2131.00,Materials Engineers,17-2131.00,Materials Engineers
+17-2141.00,Mechanical Engineers,17-2141.00,Mechanical Engineers
+17-2151.00,"Mining and Geological Engineers, Including Mining Safety Engineers",17-2151.00,"Mining and Geological Engineers, Including Mining Safety Engineers"
+17-2161.00,Nuclear Engineers,17-2161.00,Nuclear Engineers
+17-2171.00,Petroleum Engineers,17-2171.00,Petroleum Engineers
+17-2199.99,"Engineers, All Other",17-2199.99,"Engineers, All Other"
+17-3011.00,Architectural and Civil Drafters,17-3011.00,Architectural and Civil Drafters
+17-3011.01,Architectural Drafters,17-3011.01,Architectural Drafters
+17-3011.02,Civil Drafters,17-3011.02,Civil Drafters
+17-3012.00,Electrical and Electronics Drafters,17-3012.00,Electrical and Electronics Drafters
+17-3012.01,Electronic Drafters,17-3012.01,Electronic Drafters
+17-3012.02,Electrical Drafters,17-3012.02,Electrical Drafters
+17-3013.00,Mechanical Drafters,17-3013.00,Mechanical Drafters
+17-3019.99,"Drafters, All Other",17-3019.99,"Drafters, All Other"
+17-3021.00,Aerospace Engineering and Operations Technicians,17-3021.00,Aerospace Engineering and Operations Technicians
+17-3022.00,Civil Engineering Technicians,17-3022.00,Civil Engineering Technicians
+17-3023.00,Electrical and Electronic Engineering Technicians,17-3023.00,Electrical and Electronic Engineering Technicians
+17-3023.01,Electronics Engineering Technicians,17-3023.01,Electronics Engineering Technicians
+17-3023.02,Calibration and Instrumentation Technicians,17-3023.01,Electronics Engineering Technicians
+17-3023.03,Electrical Engineering Technicians,17-3023.03,Electrical Engineering Technicians
+17-3024.00,Electro-Mechanical Technicians,17-3024.00,Electro-Mechanical Technicians
+17-3025.00,Environmental Engineering Technicians,17-3025.00,Environmental Engineering Technicians
+17-3026.00,Industrial Engineering Technicians,17-3026.00,Industrial Engineering Technicians
+17-3027.00,Mechanical Engineering Technicians,17-3027.00,Mechanical Engineering Technicians
+17-3029.99,"Engineering Technicians, Except Drafters, All Other",17-3029.99,"Engineering Technicians, Except Drafters, All Other"
+17-3031.00,Surveying and Mapping Technicians,17-3031.00,Surveying and Mapping Technicians
+17-3031.01,Surveying Technicians,17-3031.01,Surveying Technicians
+17-3031.02,Mapping Technicians,17-3031.02,Mapping Technicians
+19-1011.00,Animal Scientists,19-1011.00,Animal Scientists
+19-1012.00,Food Scientists and Technologists,19-1012.00,Food Scientists and Technologists
+19-1013.00,Soil and Plant Scientists,19-1013.00,Soil and Plant Scientists
+19-1013.01,Plant Scientists,19-1013.00,Soil and Plant Scientists
+19-1013.02,Soil Scientists,19-1013.00,Soil and Plant Scientists
+19-1020.01,Biologists,19-1020.01,Biologists
+19-1021.00,Biochemists and Biophysicists,19-1021.00,Biochemists and Biophysicists
+19-1021.01,Biochemists,19-1021.00,Biochemists and Biophysicists
+19-1021.02,Biophysicists,19-1021.00,Biochemists and Biophysicists
+19-1022.00,Microbiologists,19-1022.00,Microbiologists
+19-1023.00,Zoologists and Wildlife Biologists,19-1023.00,Zoologists and Wildlife Biologists
+19-1029.99,"Biological Scientists, All Other",19-1029.99,"Biological Scientists, All Other"
+19-1031.00,Conservation Scientists,19-1031.00,Conservation Scientists
+19-1031.01,Soil Conservationists,19-1031.01,Soil and Water Conservationists
+19-1031.02,Range Managers,19-1031.02,Range Managers
+19-1031.03,Park Naturalists,19-1031.03,Park Naturalists
+19-1032.00,Foresters,19-1032.00,Foresters
+19-1041.00,Epidemiologists,19-1041.00,Epidemiologists
+19-1042.00,"Medical Scientists, Except Epidemiologists",19-1042.00,"Medical Scientists, Except Epidemiologists"
+19-1099.99,"Life Scientists, All Other",19-1099.99,"Life Scientists, All Other"
+19-2011.00,Astronomers,19-2011.00,Astronomers
+19-2012.00,Physicists,19-2012.00,Physicists
+19-2021.00,Atmospheric and Space Scientists,19-2021.00,Atmospheric and Space Scientists
+19-2031.00,Chemists,19-2031.00,Chemists
+19-2032.00,Materials Scientists,19-2032.00,Materials Scientists
+19-2041.00,"Environmental Scientists and Specialists, Including Health",19-2041.00,"Environmental Scientists and Specialists, Including Health"
+19-2042.00,"Geoscientists, Except Hydrologists and Geographers",19-2042.00,"Geoscientists, Except Hydrologists and Geographers"
+19-2042.01,Geologists,19-2042.00,"Geoscientists, Except Hydrologists and Geographers"
+19-2043.00,Hydrologists,19-2043.00,Hydrologists
+19-2099.99,"Physical Scientists, All Other",19-2099.99,"Physical Scientists, All Other"
+19-3011.00,Economists,19-3011.00,Economists
+19-3021.00,Market Research Analysts,19-3021.00,Market Research Analysts
+19-3022.00,Survey Researchers,19-3022.00,Survey Researchers
+19-3031.00,"Clinical, Counseling, and School Psychologists",19-3031.00,"Clinical, Counseling, and School Psychologists"
+19-3031.01,School Psychologists,19-3031.01,School Psychologists
+19-3031.02,Clinical Psychologists,19-3031.02,Clinical Psychologists
+19-3031.03,Counseling Psychologists,19-3031.03,Counseling Psychologists
+19-3032.00,Industrial-Organizational Psychologists,19-3032.00,Industrial-Organizational Psychologists
+19-3039.99,"Psychologists, All Other",19-3039.99,"Psychologists, All Other"
+19-3041.00,Sociologists,19-3041.00,Sociologists
+19-3051.00,Urban and Regional Planners,19-3051.00,Urban and Regional Planners
+19-3091.00,Anthropologists and Archeologists,19-3091.00,Anthropologists and Archeologists
+19-3091.01,Anthropologists,19-3091.01,Anthropologists
+19-3091.02,Archeologists,19-3091.02,Archeologists
+19-3092.00,Geographers,19-3092.00,Geographers
+19-3093.00,Historians,19-3093.00,Historians
+19-3094.00,Political Scientists,19-3094.00,Political Scientists
+19-3099.99,"Social Scientists and Related Workers, All Other",19-3099.99,"Social Scientists and Related Workers, All Other"
+19-4011.00,Agricultural and Food Science Technicians,19-4011.00,Agricultural and Food Science Technicians
+19-4011.01,Agricultural Technicians,19-4011.01,Agricultural Technicians
+19-4011.02,Food Science Technicians,19-4011.02,Food Science Technicians
+19-4021.00,Biological Technicians,19-4021.00,Biological Technicians
+19-4031.00,Chemical Technicians,19-4031.00,Chemical Technicians
+19-4041.00,Geological and Petroleum Technicians,19-4041.00,Geological and Petroleum Technicians
+19-4041.01,Geological Data Technicians,19-4041.01,Geophysical Data Technicians
+19-4041.02,Geological Sample Test Technicians,19-4041.02,Geological Sample Test Technicians
+19-4051.00,Nuclear Technicians,19-4051.00,Nuclear Technicians
+19-4051.01,Nuclear Equipment Operation Technicians,19-4051.01,Nuclear Equipment Operation Technicians
+19-4051.02,Nuclear Monitoring Technicians,19-4051.02,Nuclear Monitoring Technicians
+19-4061.00,Social Science Research Assistants,19-4061.00,Social Science Research Assistants
+19-4061.01,City and Regional Planning Aides,19-4061.01,City and Regional Planning Aides
+19-4091.00,"Environmental Science and Protection Technicians, Including Health",19-4091.00,"Environmental Science and Protection Technicians, Including Health"
+19-4092.00,Forensic Science Technicians,19-4092.00,Forensic Science Technicians
+19-4093.00,Forest and Conservation Technicians,19-4093.00,Forest and Conservation Technicians
+19-4099.99,"Life, Physical, and Social Science Technicians, All Other",19-4099.99,"Life, Physical, and Social Science Technicians, All Other"
+21-1011.00,Substance Abuse and Behavioral Disorder Counselors,21-1011.00,Substance Abuse and Behavioral Disorder Counselors
+21-1012.00,"Educational, Vocational, and School Counselors",21-1012.00,"Educational, Vocational, and School Counselors"
+21-1013.00,Marriage and Family Therapists,21-1013.00,Marriage and Family Therapists
+21-1014.00,Mental Health Counselors,21-1014.00,Mental Health Counselors
+21-1015.00,Rehabilitation Counselors,21-1015.00,Rehabilitation Counselors
+21-1019.99,"Counselors, All Other",21-1019.99,"Counselors, All Other"
+21-1021.00,"Child, Family, and School Social Workers",21-1021.00,"Child, Family, and School Social Workers"
+21-1022.00,Medical and Public Health Social Workers,21-1022.00,Medical and Public Health Social Workers
+21-1023.00,Mental Health and Substance Abuse Social Workers,21-1023.00,Mental Health and Substance Abuse Social Workers
+21-1029.99,"Social Workers, All Other",21-1029.99,"Social Workers, All Other"
+21-1091.00,Health Educators,21-1091.00,Health Educators
+21-1092.00,Probation Officers and Correctional Treatment Specialists,21-1092.00,Probation Officers and Correctional Treatment Specialists
+21-1093.00,Social and Human Service Assistants,21-1093.00,Social and Human Service Assistants
+21-1099.99,"Community and Social Service Specialists, All Other",21-1099.99,"Community and Social Service Specialists, All Other"
+21-2011.00,Clergy,21-2011.00,Clergy
+21-2021.00,"Directors, Religious Activities and Education",21-2021.00,"Directors, Religious Activities and Education"
+21-2099.99,"Religious Workers, All Other",21-2099.99,"Religious Workers, All Other"
+23-1011.00,Lawyers,23-1011.00,Lawyers
+23-1021.00,"Administrative Law Judges, Adjudicators, and Hearing Officers",23-1021.00,"Administrative Law Judges, Adjudicators, and Hearing Officers"
+23-1022.00,"Arbitrators, Mediators, and Conciliators",23-1022.00,"Arbitrators, Mediators, and Conciliators"
+23-1023.00,"Judges, Magistrate Judges, and Magistrates",23-1023.00,"Judges, Magistrate Judges, and Magistrates"
+23-2011.00,Paralegals and Legal Assistants,23-2011.00,Paralegals and Legal Assistants
+23-2091.00,Court Reporters,23-2091.00,Court Reporters
+23-2092.00,Law Clerks,23-2092.00,Law Clerks
+23-2093.00,"Title Examiners, Abstractors, and Searchers",23-2093.00,"Title Examiners, Abstractors, and Searchers"
+23-2093.01,Title Searchers,23-2093.00,"Title Examiners, Abstractors, and Searchers"
+23-2093.02,Title Examiners and Abstractors,23-2093.00,"Title Examiners, Abstractors, and Searchers"
+23-2099.99,"Legal Support Workers, All Other",23-2099.99,"Legal Support Workers, All Other"
+25-1011.00,"Business Teachers, Postsecondary",25-1011.00,"Business Teachers, Postsecondary"
+25-1021.00,"Computer Science Teachers, Postsecondary",25-1021.00,"Computer Science Teachers, Postsecondary"
+25-1022.00,"Mathematical Science Teachers, Postsecondary",25-1022.00,"Mathematical Science Teachers, Postsecondary"
+25-1031.00,"Architecture Teachers, Postsecondary",25-1031.00,"Architecture Teachers, Postsecondary"
+25-1032.00,"Engineering Teachers, Postsecondary",25-1032.00,"Engineering Teachers, Postsecondary"
+25-1041.00,"Agricultural Sciences Teachers, Postsecondary",25-1041.00,"Agricultural Sciences Teachers, Postsecondary"
+25-1042.00,"Biological Science Teachers, Postsecondary",25-1042.00,"Biological Science Teachers, Postsecondary"
+25-1043.00,"Forestry and Conservation Science Teachers, Postsecondary",25-1043.00,"Forestry and Conservation Science Teachers, Postsecondary"
+25-1051.00,"Atmospheric, Earth, Marine, and Space Sciences Teachers, Postsecondary",25-1051.00,"Atmospheric, Earth, Marine, and Space Sciences Teachers, Postsecondary"
+25-1052.00,"Chemistry Teachers, Postsecondary",25-1052.00,"Chemistry Teachers, Postsecondary"
+25-1053.00,"Environmental Science Teachers, Postsecondary",25-1053.00,"Environmental Science Teachers, Postsecondary"
+25-1054.00,"Physics Teachers, Postsecondary",25-1054.00,"Physics Teachers, Postsecondary"
+25-1061.00,"Anthropology and Archeology Teachers, Postsecondary",25-1061.00,"Anthropology and Archeology Teachers, Postsecondary"
+25-1062.00,"Area, Ethnic, and Cultural Studies Teachers, Postsecondary",25-1062.00,"Area, Ethnic, and Cultural Studies Teachers, Postsecondary"
+25-1063.00,"Economics Teachers, Postsecondary",25-1063.00,"Economics Teachers, Postsecondary"
+25-1064.00,"Geography Teachers, Postsecondary",25-1064.00,"Geography Teachers, Postsecondary"
+25-1065.00,"Political Science Teachers, Postsecondary",25-1065.00,"Political Science Teachers, Postsecondary"
+25-1066.00,"Psychology Teachers, Postsecondary",25-1066.00,"Psychology Teachers, Postsecondary"
+25-1067.00,"Sociology Teachers, Postsecondary",25-1067.00,"Sociology Teachers, Postsecondary"
+25-1069.99,"Social Sciences Teachers, Postsecondary, All Other",25-1069.99,"Social Sciences Teachers, Postsecondary, All Other"
+25-1071.00,"Health Specialties Teachers, Postsecondary",25-1071.00,"Health Specialties Teachers, Postsecondary"
+25-1072.00,"Nursing Instructors and Teachers, Postsecondary",25-1072.00,"Nursing Instructors and Teachers, Postsecondary"
+25-1081.00,"Education Teachers, Postsecondary",25-1081.00,"Education Teachers, Postsecondary"
+25-1082.00,"Library Science Teachers, Postsecondary",25-1082.00,"Library Science Teachers, Postsecondary"
+25-1111.00,"Criminal Justice and Law Enforcement Teachers, Postsecondary",25-1111.00,"Criminal Justice and Law Enforcement Teachers, Postsecondary"
+25-1112.00,"Law Teachers, Postsecondary",25-1112.00,"Law Teachers, Postsecondary"
+25-1113.00,"Social Work Teachers, Postsecondary",25-1113.00,"Social Work Teachers, Postsecondary"
+25-1121.00,"Art, Drama, and Music Teachers, Postsecondary",25-1121.00,"Art, Drama, and Music Teachers, Postsecondary"
+25-1122.00,"Communications Teachers, Postsecondary",25-1122.00,"Communications Teachers, Postsecondary"
+25-1123.00,"English Language and Literature Teachers, Postsecondary",25-1123.00,"English Language and Literature Teachers, Postsecondary"
+25-1124.00,"Foreign Language and Literature Teachers, Postsecondary",25-1124.00,"Foreign Language and Literature Teachers, Postsecondary"
+25-1125.00,"History Teachers, Postsecondary",25-1125.00,"History Teachers, Postsecondary"
+25-1126.00,"Philosophy and Religion Teachers, Postsecondary",25-1126.00,"Philosophy and Religion Teachers, Postsecondary"
+25-1191.00,Graduate Teaching Assistants,25-1191.00,Graduate Teaching Assistants
+25-1192.00,"Home Economics Teachers, Postsecondary",25-1192.00,"Home Economics Teachers, Postsecondary"
+25-1193.00,"Recreation and Fitness Studies Teachers, Postsecondary",25-1193.00,"Recreation and Fitness Studies Teachers, Postsecondary"
+25-1194.00,"Vocational Education Teachers, Postsecondary",25-1194.00,"Vocational Education Teachers, Postsecondary"
+25-1199.99,"Postsecondary Teachers, All Other",25-1199.99,"Postsecondary Teachers, All Other"
+25-2011.00,"Preschool Teachers, Except Special Education",25-2011.00,"Preschool Teachers, Except Special Education"
+25-2012.00,"Kindergarten Teachers, Except Special Education",25-2012.00,"Kindergarten Teachers, Except Special Education"
+25-2021.00,"Elementary School Teachers, Except Special Education",25-2021.00,"Elementary School Teachers, Except Special Education"
+25-2022.00,"Middle School Teachers, Except Special and Vocational Education",25-2022.00,"Middle School Teachers, Except Special and Vocational Education"
+25-2023.00,"Vocational Education Teachers, Middle School",25-2023.00,"Vocational Education Teachers, Middle School"
+25-2031.00,"Secondary School Teachers, Except Special and Vocational Education",25-2031.00,"Secondary School Teachers, Except Special and Vocational Education"
+25-2032.00,"Vocational Education Teachers, Secondary School",25-2032.00,"Vocational Education Teachers, Secondary School"
+25-2041.00,"Special Education Teachers, Preschool, Kindergarten, and Elementary School",25-2041.00,"Special Education Teachers, Preschool, Kindergarten, and Elementary School"
+25-2042.00,"Special Education Teachers, Middle School",25-2042.00,"Special Education Teachers, Middle School"
+25-2043.00,"Special Education Teachers, Secondary School",25-2043.00,"Special Education Teachers, Secondary School"
+25-3011.00,"Adult Literacy, Remedial Education, and GED Teachers and Instructors",25-3011.00,"Adult Literacy, Remedial Education, and GED Teachers and Instructors"
+25-3021.00,Self-Enrichment Education Teachers,25-3021.00,Self-Enrichment Education Teachers
+25-3099.99,"Teachers and Instructors, All Other",25-3099.99,"Teachers and Instructors, All Other"
+25-4011.00,Archivists,25-4011.00,Archivists
+25-4012.00,Curators,25-4012.00,Curators
+25-4013.00,Museum Technicians and Conservators,25-4013.00,Museum Technicians and Conservators
+25-4021.00,Librarians,25-4021.00,Librarians
+25-4031.00,Library Technicians,25-4031.00,Library Technicians
+25-9011.00,Audio-Visual Collections Specialists,25-9011.00,Audio-Visual Collections Specialists
+25-9021.00,Farm and Home Management Advisors,25-9021.00,Farm and Home Management Advisors
+25-9031.00,Instructional Coordinators,25-9031.00,Instructional Coordinators
+25-9041.00,Teacher Assistants,25-9041.00,Teacher Assistants
+25-9099.99,"Education, Training, and Library Workers, All Other",25-9099.99,"Education, Training, and Library Workers, All Other"
+27-1011.00,Art Directors,27-1011.00,Art Directors
+27-1012.00,Craft Artists,27-1012.00,Craft Artists
+27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators",27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators"
+27-1013.01,Painters and Illustrators,27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators"
+27-1013.02,Sketch Artists,27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators"
+27-1013.03,Cartoonists,27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators"
+27-1013.04,Sculptors,27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators"
+27-1014.00,Multi-Media Artists and Animators,27-1014.00,Multi-Media Artists and Animators
+27-1019.99,"Artists and Related Workers, All Other",27-1019.99,"Artists and Related Workers, All Other"
+27-1021.00,Commercial and Industrial Designers,27-1021.00,Commercial and Industrial Designers
+27-1022.00,Fashion Designers,27-1022.00,Fashion Designers
+27-1023.00,Floral Designers,27-1023.00,Floral Designers
+27-1024.00,Graphic Designers,27-1024.00,Graphic Designers
+27-1025.00,Interior Designers,27-1025.00,Interior Designers
+27-1026.00,Merchandise Displayers and Window Trimmers,27-1026.00,Merchandise Displayers and Window Trimmers
+27-1027.00,Set and Exhibit Designers,27-1027.00,Set and Exhibit Designers
+27-1027.01,Set Designers,27-1027.00,Set and Exhibit Designers
+27-1027.02,Exhibit Designers,27-1027.00,Set and Exhibit Designers
+27-1029.99,"Designers, All Other",27-1029.99,"Designers, All Other"
+27-2011.00,Actors,27-2011.00,Actors
+27-2012.00,Producers and Directors,27-2012.00,Producers and Directors
+27-2012.01,Producers,27-2012.01,Producers
+27-2012.02,"Directors- Stage, Motion Pictures, Television, and Radio",27-2012.02,"Directors- Stage, Motion Pictures, Television, and Radio"
+27-2012.03,Program Directors,27-2012.03,Program Directors
+27-2012.04,Talent Directors,27-2012.04,Talent Directors
+27-2012.05,Technical Directors/Managers,27-2012.05,Technical Directors/Managers
+27-2021.00,Athletes and Sports Competitors,27-2021.00,Athletes and Sports Competitors
+27-2022.00,Coaches and Scouts,27-2022.00,Coaches and Scouts
+27-2023.00,"Umpires, Referees, and Other Sports Officials",27-2023.00,"Umpires, Referees, and Other Sports Officials"
+27-2031.00,Dancers,27-2031.00,Dancers
+27-2032.00,Choreographers,27-2032.00,Choreographers
+27-2041.00,Music Directors and Composers,27-2041.00,Music Directors and Composers
+27-2041.01,Music Directors,27-2041.01,Music Directors
+27-2041.02,Music Arrangers and Orchestrators,27-2041.04,Music Composers and Arrangers
+27-2041.03,Composers,27-2041.04,Music Composers and Arrangers
+27-2042.00,Musicians and Singers,27-2042.00,Musicians and Singers
+27-2042.01,Singers,27-2042.01,Singers
+27-2042.02,"Musicians, Instrumental",27-2042.02,"Musicians, Instrumental"
+27-2099.99,"Entertainers and Performers, Sports and Related Workers, All Other",27-2099.99,"Entertainers and Performers, Sports and Related Workers, All Other"
+27-3011.00,Radio and Television Announcers,27-3011.00,Radio and Television Announcers
+27-3012.00,Public Address System and Other Announcers,27-3012.00,Public Address System and Other Announcers
+27-3021.00,Broadcast News Analysts,27-3021.00,Broadcast News Analysts
+27-3022.00,Reporters and Correspondents,27-3022.00,Reporters and Correspondents
+27-3031.00,Public Relations Specialists,27-3031.00,Public Relations Specialists
+27-3041.00,Editors,27-3041.00,Editors
+27-3042.00,Technical Writers,27-3042.00,Technical Writers
+27-3043.00,Writers and Authors,27-3043.00,Writers and Authors
+27-3043.01,Poets and Lyricists,27-3043.05,"Poets, Lyricists and Creative Writers"
+27-3043.02,Creative Writers,27-3043.05,"Poets, Lyricists and Creative Writers"
+27-3043.03,Caption Writers,23-2091.00,Court Reporters
+27-3043.04,Copy Writers,27-3043.04,Copy Writers
+27-3091.00,Interpreters and Translators,27-3091.00,Interpreters and Translators
+27-3099.99,"Media and Communication Workers, All Other",27-3099.99,"Media and Communication Workers, All Other"
+27-4011.00,Audio and Video Equipment Technicians,27-4011.00,Audio and Video Equipment Technicians
+27-4012.00,Broadcast Technicians,27-4012.00,Broadcast Technicians
+27-4013.00,Radio Operators,27-4013.00,Radio Operators
+27-4014.00,Sound Engineering Technicians,27-4014.00,Sound Engineering Technicians
+27-4021.00,Photographers,27-4021.00,Photographers
+27-4021.01,Professional Photographers,27-4021.00,Photographers
+27-4021.02,"Photographers, Scientific",27-4021.00,Photographers
+27-4031.00,"Camera Operators, Television, Video, and Motion Picture",27-4031.00,"Camera Operators, Television, Video, and Motion Picture"
+27-4032.00,Film and Video Editors,27-4032.00,Film and Video Editors
+27-4099.99,"Media and Communication Equipment Workers, All Other",27-4099.99,"Media and Communication Equipment Workers, All Other"
+29-1011.00,Chiropractors,29-1011.00,Chiropractors
+29-1021.00,"Dentists, General",29-1021.00,"Dentists, General"
+29-1022.00,Oral and Maxillofacial Surgeons,29-1022.00,Oral and Maxillofacial Surgeons
+29-1023.00,Orthodontists,29-1023.00,Orthodontists
+29-1024.00,Prosthodontists,29-1024.00,Prosthodontists
+29-1029.99,"Dentists, All Other Specialists",29-1029.99,"Dentists, All Other Specialists"
+29-1031.00,Dietitians and Nutritionists,29-1031.00,Dietitians and Nutritionists
+29-1041.00,Optometrists,29-1041.00,Optometrists
+29-1051.00,Pharmacists,29-1051.00,Pharmacists
+29-1061.00,Anesthesiologists,29-1061.00,Anesthesiologists
+29-1062.00,Family and General Practitioners,29-1062.00,Family and General Practitioners
+29-1063.00,"Internists, General",29-1063.00,"Internists, General"
+29-1064.00,Obstetricians and Gynecologists,29-1064.00,Obstetricians and Gynecologists
+29-1065.00,"Pediatricians, General",29-1065.00,"Pediatricians, General"
+29-1066.00,Psychiatrists,29-1066.00,Psychiatrists
+29-1067.00,Surgeons,29-1067.00,Surgeons
+29-1069.99,"Physicians and Surgeons, All Other",29-1069.99,"Physicians and Surgeons, All Other"
+29-1071.00,Physician Assistants,29-1071.00,Physician Assistants
+29-1081.00,Podiatrists,29-1081.00,Podiatrists
+29-1111.00,Registered Nurses,29-1111.00,Registered Nurses
+29-1121.00,Audiologists,29-1121.00,Audiologists
+29-1122.00,Occupational Therapists,29-1122.00,Occupational Therapists
+29-1123.00,Physical Therapists,29-1123.00,Physical Therapists
+29-1124.00,Radiation Therapists,29-1124.00,Radiation Therapists
+29-1125.00,Recreational Therapists,29-1125.00,Recreational Therapists
+29-1126.00,Respiratory Therapists,29-1126.00,Respiratory Therapists
+29-1127.00,Speech-Language Pathologists,29-1127.00,Speech-Language Pathologists
+29-1129.99,"Therapists, All Other",29-1129.99,"Therapists, All Other"
+29-1131.00,Veterinarians,29-1131.00,Veterinarians
+29-1199.99,"Health Diagnosing and Treating Practitioners, All Other",29-1199.99,"Health Diagnosing and Treating Practitioners, All Other"
+29-2011.00,Medical and Clinical Laboratory Technologists,29-2011.00,Medical and Clinical Laboratory Technologists
+29-2012.00,Medical and Clinical Laboratory Technicians,29-2012.00,Medical and Clinical Laboratory Technicians
+29-2021.00,Dental Hygienists,29-2021.00,Dental Hygienists
+29-2031.00,Cardiovascular Technologists and Technicians,29-2031.00,Cardiovascular Technologists and Technicians
+29-2032.00,Diagnostic Medical Sonographers,29-2032.00,Diagnostic Medical Sonographers
+29-2033.00,Nuclear Medicine Technologists,29-2033.00,Nuclear Medicine Technologists
+29-2034.00,Radiologic Technologists and Technicians,29-2034.00,Radiologic Technologists and Technicians
+29-2034.01,Radiologic Technologists,29-2034.01,Radiologic Technologists
+29-2034.02,Radiologic Technicians,29-2034.02,Radiologic Technicians
+29-2041.00,Emergency Medical Technicians and Paramedics,29-2041.00,Emergency Medical Technicians and Paramedics
+29-2051.00,Dietetic Technicians,29-2051.00,Dietetic Technicians
+29-2052.00,Pharmacy Technicians,29-2052.00,Pharmacy Technicians
+29-2053.00,Psychiatric Technicians,29-2053.00,Psychiatric Technicians
+29-2054.00,Respiratory Therapy Technicians,29-2054.00,Respiratory Therapy Technicians
+29-2055.00,Surgical Technologists,29-2055.00,Surgical Technologists
+29-2056.00,Veterinary Technologists and Technicians,29-2056.00,Veterinary Technologists and Technicians
+29-2061.00,Licensed Practical and Licensed Vocational Nurses,29-2061.00,Licensed Practical and Licensed Vocational Nurses
+29-2071.00,Medical Records and Health Information Technicians,29-2071.00,Medical Records and Health Information Technicians
+29-2081.00,"Opticians, Dispensing",29-2081.00,"Opticians, Dispensing"
+29-2091.00,Orthotists and Prosthetists,29-2091.00,Orthotists and Prosthetists
+29-2099.99,"Health Technologists and Technicians, All Other",29-2099.99,"Health Technologists and Technicians, All Other"
+29-9011.00,Occupational Health and Safety Specialists,29-9011.00,Occupational Health and Safety Specialists
+29-9012.00,Occupational Health and Safety Technicians,29-9012.00,Occupational Health and Safety Technicians
+29-9091.00,Athletic Trainers,29-9091.00,Athletic Trainers
+29-9099.99,"Healthcare Practitioners and Technical Workers, All Other",29-9099.99,"Healthcare Practitioners and Technical Workers, All Other"
+31-1011.00,Home Health Aides,31-1011.00,Home Health Aides
+31-1012.00,"Nursing Aides, Orderlies, and Attendants",31-1012.00,"Nursing Aides, Orderlies, and Attendants"
+31-1013.00,Psychiatric Aides,31-1013.00,Psychiatric Aides
+31-2011.00,Occupational Therapist Assistants,31-2011.00,Occupational Therapist Assistants
+31-2012.00,Occupational Therapist Aides,31-2012.00,Occupational Therapist Aides
+31-2021.00,Physical Therapist Assistants,31-2021.00,Physical Therapist Assistants
+31-2022.00,Physical Therapist Aides,31-2022.00,Physical Therapist Aides
+31-9011.00,Massage Therapists,31-9011.00,Massage Therapists
+31-9091.00,Dental Assistants,31-9091.00,Dental Assistants
+31-9092.00,Medical Assistants,31-9092.00,Medical Assistants
+31-9093.00,Medical Equipment Preparers,31-9093.00,Medical Equipment Preparers
+31-9094.00,Medical Transcriptionists,31-9094.00,Medical Transcriptionists
+31-9095.00,Pharmacy Aides,31-9095.00,Pharmacy Aides
+31-9096.00,Veterinary Assistants and Laboratory Animal Caretakers,31-9096.00,Veterinary Assistants and Laboratory Animal Caretakers
+31-9099.99,"Healthcare Support Workers, All Other",31-9099.99,"Healthcare Support Workers, All Other"
+33-1011.00,First-Line Supervisors/Managers of Correctional Officers,33-1011.00,First-Line Supervisors/Managers of Correctional Officers
+33-1012.00,First-Line Supervisors/Managers of Police and Detectives,33-1012.00,First-Line Supervisors/Managers of Police and Detectives
+33-1021.00,First-Line Supervisors/Managers of Fire Fighting and Prevention Workers,33-1021.00,First-Line Supervisors/Managers of Fire Fighting and Prevention Workers
+33-1021.01,Municipal Fire Fighting and Prevention Supervisors,33-1021.01,Municipal Fire Fighting and Prevention Supervisors
+33-1021.02,Forest Fire Fighting and Prevention Supervisors,33-1021.02,Forest Fire Fighting and Prevention Supervisors
+33-1099.99,"First-Line Supervisors/Managers, Protective Service Workers, All Other",33-1099.99,"First-Line Supervisors/Managers, Protective Service Workers, All Other"
+33-2011.00,Fire Fighters,33-2011.00,Fire Fighters
+33-2011.01,Municipal Fire Fighters,33-2011.01,Municipal Fire Fighters
+33-2011.02,Forest Fire Fighters,33-2011.02,Forest Fire Fighters
+33-2021.00,Fire Inspectors and Investigators,33-2021.00,Fire Inspectors and Investigators
+33-2021.01,Fire Inspectors,33-2021.01,Fire Inspectors
+33-2021.02,Fire Investigators,33-2021.02,Fire Investigators
+33-2022.00,Forest Fire Inspectors and Prevention Specialists,33-2022.00,Forest Fire Inspectors and Prevention Specialists
+33-3011.00,Bailiffs,33-3011.00,Bailiffs
+33-3012.00,Correctional Officers and Jailers,33-3012.00,Correctional Officers and Jailers
+33-3021.00,Detectives and Criminal Investigators,33-3021.00,Detectives and Criminal Investigators
+33-3021.01,Police Detectives,33-3021.01,Police Detectives
+33-3021.02,Police Identification and Records Officers,33-3021.02,Police Identification and Records Officers
+33-3021.03,Criminal Investigators and Special Agents,33-3021.03,Criminal Investigators and Special Agents
+33-3021.04,"Child Support, Missing Persons, and Unemployment Insurance Fraud Investigators",33-3021.03,Criminal Investigators and Special Agents
+33-3021.05,Immigration and Customs Inspectors,33-3021.05,Immigration and Customs Inspectors
+33-3031.00,Fish and Game Wardens,33-3031.00,Fish and Game Wardens
+33-3041.00,Parking Enforcement Workers,33-3041.00,Parking Enforcement Workers
+33-3051.00,Police and Sheriff's Patrol Officers,33-3051.00,Police and Sheriff's Patrol Officers
+33-3051.01,Police Patrol Officers,33-3051.01,Police Patrol Officers
+33-3051.02,Highway Patrol Pilots,33-3051.01,Police Patrol Officers
+33-3051.03,Sheriffs and Deputy Sheriffs,33-3051.03,Sheriffs and Deputy Sheriffs
+33-3052.00,Transit and Railroad Police,33-3052.00,Transit and Railroad Police
+33-9011.00,Animal Control Workers,33-9011.00,Animal Control Workers
+33-9021.00,Private Detectives and Investigators,33-9021.00,Private Detectives and Investigators
+33-9031.00,Gaming Surveillance Officers and Gaming Investigators,33-9031.00,Gaming Surveillance Officers and Gaming Investigators
+33-9032.00,Security Guards,33-9032.00,Security Guards
+33-9091.00,Crossing Guards,33-9091.00,Crossing Guards
+33-9092.00,"Lifeguards, Ski Patrol, and Other Recreational Protective Service Workers",33-9092.00,"Lifeguards, Ski Patrol, and Other Recreational Protective Service Workers"
+33-9099.99,"Protective Service Workers, All Other",33-9099.99,"Protective Service Workers, All Other"
+35-1011.00,Chefs and Head Cooks,35-1011.00,Chefs and Head Cooks
+35-1012.00,First-Line Supervisors/Managers of Food Preparation and Serving Workers,35-1012.00,First-Line Supervisors/Managers of Food Preparation and Serving Workers
+35-2011.00,"Cooks, Fast Food",35-2011.00,"Cooks, Fast Food"
+35-2012.00,"Cooks, Institution and Cafeteria",35-2012.00,"Cooks, Institution and Cafeteria"
+35-2013.00,"Cooks, Private Household",35-2013.00,"Cooks, Private Household"
+35-2014.00,"Cooks, Restaurant",35-2014.00,"Cooks, Restaurant"
+35-2015.00,"Cooks, Short Order",35-2015.00,"Cooks, Short Order"
+35-2019.99,"Cooks, All Other",35-2019.99,"Cooks, All Other"
+35-2021.00,Food Preparation Workers,35-2021.00,Food Preparation Workers
+35-3011.00,Bartenders,35-3011.00,Bartenders
+35-3021.00,"Combined Food Preparation and Serving Workers, Including Fast Food",35-3021.00,"Combined Food Preparation and Serving Workers, Including Fast Food"
+35-3022.00,"Counter Attendants, Cafeteria, Food Concession, and Coffee Shop",35-3022.00,"Counter Attendants, Cafeteria, Food Concession, and Coffee Shop"
+35-3031.00,Waiters and Waitresses,35-3031.00,Waiters and Waitresses
+35-3041.00,"Food Servers, Nonrestaurant",35-3041.00,"Food Servers, Nonrestaurant"
+35-9011.00,Dining Room and Cafeteria Attendants and Bartender Helpers,35-9011.00,Dining Room and Cafeteria Attendants and Bartender Helpers
+35-9021.00,Dishwashers,35-9021.00,Dishwashers
+35-9031.00,"Hosts and Hostesses, Restaurant, Lounge, and Coffee Shop",35-9031.00,"Hosts and Hostesses, Restaurant, Lounge, and Coffee Shop"
+35-9099.99,"Food Preparation and Serving Related Workers, All Other",35-9099.99,"Food Preparation and Serving Related Workers, All Other"
+37-1011.00,First-Line Supervisors/Managers of Housekeeping and Janitorial Workers,37-1011.00,First-Line Supervisors/Managers of Housekeeping and Janitorial Workers
+37-1011.01,Housekeeping Supervisors,37-1011.00,First-Line Supervisors/Managers of Housekeeping and Janitorial Workers
+37-1011.02,Janitorial Supervisors,37-1011.00,First-Line Supervisors/Managers of Housekeeping and Janitorial Workers
+37-1012.00,"First-Line Supervisors/Managers of Landscaping, Lawn Service, and Groundskeeping Workers",37-1012.00,"First-Line Supervisors/Managers of Landscaping, Lawn Service, and Groundskeeping Workers"
+37-1012.01,Lawn Service Managers,37-1012.00,"First-Line Supervisors/Managers of Landscaping, Lawn Service, and Groundskeeping Workers"
+37-1012.02,First-Line Supervisors and Manager/Supervisors - Landscaping Workers,37-1012.00,"First-Line Supervisors/Managers of Landscaping, Lawn Service, and Groundskeeping Workers"
+37-2011.00,"Janitors and Cleaners, Except Maids and Housekeeping Cleaners",37-2011.00,"Janitors and Cleaners, Except Maids and Housekeeping Cleaners"
+37-2012.00,Maids and Housekeeping Cleaners,37-2012.00,Maids and Housekeeping Cleaners
+37-2019.99,"Building Cleaning Workers, All Other",37-2019.99,"Building Cleaning Workers, All Other"
+37-2021.00,Pest Control Workers,37-2021.00,Pest Control Workers
+37-3011.00,Landscaping and Groundskeeping Workers,37-3011.00,Landscaping and Groundskeeping Workers
+37-3012.00,"Pesticide Handlers, Sprayers, and Applicators, Vegetation",37-3012.00,"Pesticide Handlers, Sprayers, and Applicators, Vegetation"
+37-3013.00,Tree Trimmers and Pruners,37-3013.00,Tree Trimmers and Pruners
+37-3019.99,"Grounds Maintenance Workers, All Other",37-3019.99,"Grounds Maintenance Workers, All Other"
+39-1011.00,Gaming Supervisors,39-1011.00,Gaming Supervisors
+39-1012.00,Slot Key Persons,39-1012.00,Slot Key Persons
+39-1021.00,First-Line Supervisors/Managers of Personal Service Workers,39-1021.00,First-Line Supervisors/Managers of Personal Service Workers
+39-2011.00,Animal Trainers,39-2011.00,Animal Trainers
+39-2021.00,Nonfarm Animal Caretakers,39-2021.00,Nonfarm Animal Caretakers
+39-3011.00,Gaming Dealers,39-3011.00,Gaming Dealers
+39-3012.00,Gaming and Sports Book Writers and Runners,39-3012.00,Gaming and Sports Book Writers and Runners
+39-3019.99,"Gaming Service Workers, All Other",39-3019.99,"Gaming Service Workers, All Other"
+39-3021.00,Motion Picture Projectionists,39-3021.00,Motion Picture Projectionists
+39-3031.00,"Ushers, Lobby Attendants, and Ticket Takers",39-3031.00,"Ushers, Lobby Attendants, and Ticket Takers"
+39-3091.00,Amusement and Recreation Attendants,39-3091.00,Amusement and Recreation Attendants
+39-3092.00,Costume Attendants,39-3092.00,Costume Attendants
+39-3093.00,"Locker Room, Coatroom, and Dressing Room Attendants",39-3093.00,"Locker Room, Coatroom, and Dressing Room Attendants"
+39-3099.99,"Entertainment Attendants and Related Workers, All Other",39-3099.99,"Entertainment Attendants and Related Workers, All Other"
+39-4011.00,Embalmers,39-4011.00,Embalmers
+39-4021.00,Funeral Attendants,39-4021.00,Funeral Attendants
+39-5011.00,Barbers,39-5011.00,Barbers
+39-5012.00,"Hairdressers, Hairstylists, and Cosmetologists",39-5012.00,"Hairdressers, Hairstylists, and Cosmetologists"
+39-5091.00,"Makeup Artists, Theatrical and Performance",39-5091.00,"Makeup Artists, Theatrical and Performance"
+39-5092.00,Manicurists and Pedicurists,39-5092.00,Manicurists and Pedicurists
+39-5093.00,Shampooers,39-5093.00,Shampooers
+39-5094.00,Skin Care Specialists,39-5094.00,Skin Care Specialists
+39-6011.00,Baggage Porters and Bellhops,39-6011.00,Baggage Porters and Bellhops
+39-6012.00,Concierges,39-6012.00,Concierges
+39-6021.00,Tour Guides and Escorts,39-6021.00,Tour Guides and Escorts
+39-6022.00,Travel Guides,39-6022.00,Travel Guides
+39-6031.00,Flight Attendants,39-6031.00,Flight Attendants
+39-6032.00,"Transportation Attendants, Except Flight Attendants and Baggage Porters",39-6032.00,"Transportation Attendants, Except Flight Attendants and Baggage Porters"
+39-9011.00,Child Care Workers,39-9011.00,Child Care Workers
+39-9011.01,Nannies,39-9011.01,Nannies
+39-9021.00,Personal and Home Care Aides,39-9021.00,Personal and Home Care Aides
+39-9031.00,Fitness Trainers and Aerobics Instructors,39-9031.00,Fitness Trainers and Aerobics Instructors
+39-9032.00,Recreation Workers,39-9032.00,Recreation Workers
+39-9041.00,Residential Advisors,39-9041.00,Residential Advisors
+39-9099.99,"Personal Care and Service Workers, All Other",39-9099.99,"Personal Care and Service Workers, All Other"
+41-1011.00,First-Line Supervisors/Managers of Retail Sales Workers,41-1011.00,First-Line Supervisors/Managers of Retail Sales Workers
+41-1012.00,First-Line Supervisors/Managers of Non-Retail Sales Workers,41-1012.00,First-Line Supervisors/Managers of Non-Retail Sales Workers
+41-2011.00,Cashiers,41-2011.00,Cashiers
+41-2012.00,Gaming Change Persons and Booth Cashiers,41-2012.00,Gaming Change Persons and Booth Cashiers
+41-2021.00,Counter and Rental Clerks,41-2021.00,Counter and Rental Clerks
+41-2022.00,Parts Salespersons,41-2022.00,Parts Salespersons
+41-2031.00,Retail Salespersons,41-2031.00,Retail Salespersons
+41-3011.00,Advertising Sales Agents,41-3011.00,Advertising Sales Agents
+41-3021.00,Insurance Sales Agents,41-3021.00,Insurance Sales Agents
+41-3031.00,"Securities, Commodities, and Financial Services Sales Agents",41-3031.00,"Securities, Commodities, and Financial Services Sales Agents"
+41-3031.01,"Sales Agents, Securities and Commodities",41-3031.01,"Sales Agents, Securities and Commodities"
+41-3031.02,"Sales Agents, Financial Services",41-3031.02,"Sales Agents, Financial Services"
+41-3041.00,Travel Agents,41-3041.00,Travel Agents
+41-3099.99,"Sales Representatives, Services, All Other",41-3099.99,"Sales Representatives, Services, All Other"
+41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4011.01,"Sales Representatives, Agricultural",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4011.02,"Sales Representatives, Chemical and Pharmaceutical",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4011.03,"Sales Representatives, Electrical/Electronic",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4011.04,"Sales Representatives, Mechanical Equipment and Supplies",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4011.05,"Sales Representatives, Medical",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4011.06,"Sales Representatives, Instruments",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4012.00,"Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products",41-4012.00,"Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products"
+41-9011.00,Demonstrators and Product Promoters,41-9011.00,Demonstrators and Product Promoters
+41-9012.00,Models,41-9012.00,Models
+41-9021.00,Real Estate Brokers,41-9021.00,Real Estate Brokers
+41-9022.00,Real Estate Sales Agents,41-9022.00,Real Estate Sales Agents
+41-9031.00,Sales Engineers,41-9031.00,Sales Engineers
+41-9041.00,Telemarketers,41-9041.00,Telemarketers
+41-9091.00,"Door-To-Door Sales Workers, News and Street Vendors, and Related Workers",41-9091.00,"Door-To-Door Sales Workers, News and Street Vendors, and Related Workers"
+41-9099.99,"Sales and Related Workers, All Other",41-9099.99,"Sales and Related Workers, All Other"
+43-1011.00,First-Line Supervisors/Managers of Office and Administrative Support Workers,43-1011.00,First-Line Supervisors/Managers of Office and Administrative Support Workers
+43-1011.01,"First-Line Supervisors, Customer Service",43-1011.00,First-Line Supervisors/Managers of Office and Administrative Support Workers
+43-1011.02,"First-Line Supervisors, Administrative Support",43-1011.00,First-Line Supervisors/Managers of Office and Administrative Support Workers
+43-2011.00,"Switchboard Operators, Including Answering Service",43-2011.00,"Switchboard Operators, Including Answering Service"
+43-2021.00,Telephone Operators,43-2021.00,Telephone Operators
+43-2021.01,Directory Assistance Operators,43-2021.00,Telephone Operators
+43-2021.02,Central Office Operators,43-2021.00,Telephone Operators
+43-2099.99,"Communications Equipment Operators, All Other",43-2099.99,"Communications Equipment Operators, All Other"
+43-3011.00,Bill and Account Collectors,43-3011.00,Bill and Account Collectors
+43-3021.00,Billing and Posting Clerks and Machine Operators,43-3021.00,Billing and Posting Clerks and Machine Operators
+43-3021.01,Statement Clerks,43-3021.01,Statement Clerks
+43-3021.02,"Billing, Cost, and Rate Clerks",43-3021.02,"Billing, Cost, and Rate Clerks"
+43-3021.03,"Billing, Posting, and Calculating Machine Operators",43-3021.03,"Billing, Posting, and Calculating Machine Operators"
+43-3031.00,"Bookkeeping, Accounting, and Auditing Clerks",43-3031.00,"Bookkeeping, Accounting, and Auditing Clerks"
+43-3041.00,Gaming Cage Workers,43-3041.00,Gaming Cage Workers
+43-3051.00,Payroll and Timekeeping Clerks,43-3051.00,Payroll and Timekeeping Clerks
+43-3061.00,Procurement Clerks,43-3061.00,Procurement Clerks
+43-3071.00,Tellers,43-3071.00,Tellers
+43-4011.00,Brokerage Clerks,43-4011.00,Brokerage Clerks
+43-4021.00,Correspondence Clerks,43-4021.00,Correspondence Clerks
+43-4031.00,"Court, Municipal, and License Clerks",43-4031.00,"Court, Municipal, and License Clerks"
+43-4031.01,Court Clerks,43-4031.01,Court Clerks
+43-4031.02,Municipal Clerks,43-4031.02,Municipal Clerks
+43-4031.03,License Clerks,43-4031.03,License Clerks
+43-4041.00,"Credit Authorizers, Checkers, and Clerks",43-4041.00,"Credit Authorizers, Checkers, and Clerks"
+43-4041.01,Credit Authorizers,43-4041.01,Credit Authorizers
+43-4041.02,Credit Checkers,43-4041.02,Credit Checkers
+43-4051.00,Customer Service Representatives,43-4051.00,Customer Service Representatives
+43-4051.01,Adjustment Clerks,43-4051.00,Customer Service Representatives
+43-4051.02,"Customer Service Representatives, Utilities",43-4051.00,Customer Service Representatives
+43-4061.00,"Eligibility Interviewers, Government Programs",43-4061.00,"Eligibility Interviewers, Government Programs"
+43-4061.01,"Claims Takers, Unemployment Benefits",43-4061.00,"Eligibility Interviewers, Government Programs"
+43-4061.02,Welfare Eligibility Workers and Interviewers,43-4061.00,"Eligibility Interviewers, Government Programs"
+43-4071.00,File Clerks,43-4071.00,File Clerks
+43-4081.00,"Hotel, Motel, and Resort Desk Clerks",43-4081.00,"Hotel, Motel, and Resort Desk Clerks"
+43-4111.00,"Interviewers, Except Eligibility and Loan",43-4111.00,"Interviewers, Except Eligibility and Loan"
+43-4121.00,"Library Assistants, Clerical",43-4121.00,"Library Assistants, Clerical"
+43-4131.00,Loan Interviewers and Clerks,43-4131.00,Loan Interviewers and Clerks
+43-4141.00,New Accounts Clerks,43-4141.00,New Accounts Clerks
+43-4151.00,Order Clerks,43-4151.00,Order Clerks
+43-4161.00,"Human Resources Assistants, Except Payroll and Timekeeping",43-4161.00,"Human Resources Assistants, Except Payroll and Timekeeping"
+43-4171.00,Receptionists and Information Clerks,43-4171.00,Receptionists and Information Clerks
+43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks,43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks
+43-4181.01,Travel Clerks,43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks
+43-4181.02,Reservation and Transportation Ticket Agents,43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks
+43-4199.99,"Information and Record Clerks, All Other",43-4199.99,"Information and Record Clerks, All Other"
+43-5011.00,Cargo and Freight Agents,43-5011.00,Cargo and Freight Agents
+43-5021.00,Couriers and Messengers,43-5021.00,Couriers and Messengers
+43-5031.00,"Police, Fire, and Ambulance Dispatchers",43-5031.00,"Police, Fire, and Ambulance Dispatchers"
+43-5032.00,"Dispatchers, Except Police, Fire, and Ambulance",43-5032.00,"Dispatchers, Except Police, Fire, and Ambulance"
+43-5041.00,"Meter Readers, Utilities",43-5041.00,"Meter Readers, Utilities"
+43-5051.00,Postal Service Clerks,43-5051.00,Postal Service Clerks
+43-5052.00,Postal Service Mail Carriers,43-5052.00,Postal Service Mail Carriers
+43-5053.00,"Postal Service Mail Sorters, Processors, and Processing Machine Operators",43-5053.00,"Postal Service Mail Sorters, Processors, and Processing Machine Operators"
+43-5061.00,"Production, Planning, and Expediting Clerks",43-5061.00,"Production, Planning, and Expediting Clerks"
+43-5071.00,"Shipping, Receiving, and Traffic Clerks",43-5071.00,"Shipping, Receiving, and Traffic Clerks"
+43-5081.00,Stock Clerks and Order Fillers,43-5081.00,Stock Clerks and Order Fillers
+43-5081.01,"Stock Clerks, Sales Floor",43-5081.01,"Stock Clerks, Sales Floor"
+43-5081.02,Marking Clerks,43-5081.02,Marking Clerks
+43-5081.03,"Stock Clerks- Stockroom, Warehouse, or Storage Yard",43-5081.03,"Stock Clerks- Stockroom, Warehouse, or Storage Yard"
+43-5081.04,"Order Fillers, Wholesale and Retail Sales",43-5081.04,"Order Fillers, Wholesale and Retail Sales"
+43-5111.00,"Weighers, Measurers, Checkers, and Samplers, Recordkeeping",43-5111.00,"Weighers, Measurers, Checkers, and Samplers, Recordkeeping"
+43-6011.00,Executive Secretaries and Administrative Assistants,43-6011.00,Executive Secretaries and Administrative Assistants
+43-6012.00,Legal Secretaries,43-6012.00,Legal Secretaries
+43-6013.00,Medical Secretaries,43-6013.00,Medical Secretaries
+43-6014.00,"Secretaries, Except Legal, Medical, and Executive",43-6014.00,"Secretaries, Except Legal, Medical, and Executive"
+43-9011.00,Computer Operators,43-9011.00,Computer Operators
+43-9021.00,Data Entry Keyers,43-9021.00,Data Entry Keyers
+43-9022.00,Word Processors and Typists,43-9022.00,Word Processors and Typists
+43-9031.00,Desktop Publishers,43-9031.00,Desktop Publishers
+43-9041.00,Insurance Claims and Policy Processing Clerks,43-9041.00,Insurance Claims and Policy Processing Clerks
+43-9041.01,Insurance Claims Clerks,43-9041.01,Insurance Claims Clerks
+43-9041.02,Insurance Policy Processing Clerks,43-9041.02,Insurance Policy Processing Clerks
+43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service",43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service"
+43-9051.01,"Mail Machine Operators, Preparation and Handling",43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service"
+43-9051.02,"Mail Clerks, Except Mail Machine Operators and Postal Service",43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service"
+43-9061.00,"Office Clerks, General",43-9061.00,"Office Clerks, General"
+43-9071.00,"Office Machine Operators, Except Computer",43-9071.00,"Office Machine Operators, Except Computer"
+43-9071.01,Duplicating Machine Operators,43-9071.00,"Office Machine Operators, Except Computer"
+43-9081.00,Proofreaders and Copy Markers,43-9081.00,Proofreaders and Copy Markers
+43-9111.00,Statistical Assistants,43-9111.00,Statistical Assistants
+43-9199.99,"Office and Administrative Support Workers, All Other",43-9199.99,"Office and Administrative Support Workers, All Other"
+45-1011.00,"First-Line Supervisors/Managers of Farming, Fishing, and Forestry Workers",45-1011.00,"First-Line Supervisors/Managers of Farming, Fishing, and Forestry Workers"
+45-1011.01,First-Line Supervisors and Manager/Supervisors - Agricultural Crop Workers,45-1011.07,First-Line Supervisors/Managers of Agricultural Crop and Horticultural Workers
+45-1011.02,First-Line Supervisors and Manager/Supervisors - Animal Husbandry Workers,45-1011.08,First-Line Supervisors/Managers of Animal Husbandry and Animal Care Workers
+45-1011.03,"First-Line Supervisors and Manager/Supervisors - Animal Care Workers, Except Livestock",45-1011.08,First-Line Supervisors/Managers of Animal Husbandry and Animal Care Workers
+45-1011.04,First-Line Supervisors and Manager/Supervisors - Horticultural Workers,45-1011.07,First-Line Supervisors/Managers of Agricultural Crop and Horticultural Workers
+45-1011.05,First-Line Supervisors and Manager/Supervisors - Logging Workers,45-1011.05,First-Line Supervisors/Managers of Logging Workers
+45-1011.06,First-Line Supervisors and Manager/Supervisors - Fishery Workers,45-1011.06,First-Line Supervisors/Managers of Aquacultural Workers
+45-1012.00,Farm Labor Contractors,45-1012.00,Farm Labor Contractors
+45-2011.00,Agricultural Inspectors,45-2011.00,Agricultural Inspectors
+45-2021.00,Animal Breeders,45-2021.00,Animal Breeders
+45-2041.00,"Graders and Sorters, Agricultural Products",45-2041.00,"Graders and Sorters, Agricultural Products"
+45-2091.00,Agricultural Equipment Operators,45-2091.00,Agricultural Equipment Operators
+45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse",45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse"
+45-2092.01,Nursery Workers,45-2092.01,Nursery Workers
+45-2092.02,General Farmworkers,45-2092.02,"Farmworkers and Laborers, Crop"
+45-2093.00,"Farmworkers, Farm and Ranch Animals",45-2093.00,"Farmworkers, Farm and Ranch Animals"
+45-2099.99,"Agricultural Workers, All Other",45-2099.99,"Agricultural Workers, All Other"
+45-3011.00,Fishers and Related Fishing Workers,45-3011.00,Fishers and Related Fishing Workers
+45-3021.00,Hunters and Trappers,45-3021.00,Hunters and Trappers
+45-4011.00,Forest and Conservation Workers,45-4011.00,Forest and Conservation Workers
+45-4021.00,Fallers,45-4021.00,Fallers
+45-4022.00,Logging Equipment Operators,45-4022.00,Logging Equipment Operators
+45-4022.01,Logging Tractor Operators,45-4022.00,Logging Equipment Operators
+45-4023.00,Log Graders and Scalers,45-4023.00,Log Graders and Scalers
+45-4029.99,"Logging Workers, All Other",45-4029.99,"Logging Workers, All Other"
+47-1011.00,First-Line Supervisors/Managers of Construction Trades and Extraction Workers,47-1011.00,First-Line Supervisors/Managers of Construction Trades and Extraction Workers
+47-1011.01,First-Line Supervisors and Manager/Supervisors- Construction Trades Workers,47-1011.00,First-Line Supervisors/Managers of Construction Trades and Extraction Workers
+47-1011.02,First-Line Supervisors and Manager/Supervisors- Extractive Workers,47-1011.00,First-Line Supervisors/Managers of Construction Trades and Extraction Workers
+47-2011.00,Boilermakers,47-2011.00,Boilermakers
+47-2021.00,Brickmasons and Blockmasons,47-2021.00,Brickmasons and Blockmasons
+47-2022.00,Stonemasons,47-2022.00,Stonemasons
+47-2031.00,Carpenters,47-2031.00,Carpenters
+47-2031.01,Construction Carpenters,47-2031.01,Construction Carpenters
+47-2031.02,Rough Carpenters,47-2031.02,Rough Carpenters
+47-2031.03,Carpenter Assemblers and Repairers,47-2031.01,Construction Carpenters
+47-2031.04,Ship Carpenters and Joiners,47-2031.01,Construction Carpenters
+47-2031.05,Boat Builders and Shipwrights,47-2031.01,Construction Carpenters
+47-2031.06,Brattice Builders,47-2031.02,Rough Carpenters
+47-2041.00,Carpet Installers,47-2041.00,Carpet Installers
+47-2042.00,"Floor Layers, Except Carpet, Wood, and Hard Tiles",47-2042.00,"Floor Layers, Except Carpet, Wood, and Hard Tiles"
+47-2043.00,Floor Sanders and Finishers,47-2043.00,Floor Sanders and Finishers
+47-2044.00,Tile and Marble Setters,47-2044.00,Tile and Marble Setters
+47-2051.00,Cement Masons and Concrete Finishers,47-2051.00,Cement Masons and Concrete Finishers
+47-2053.00,Terrazzo Workers and Finishers,47-2053.00,Terrazzo Workers and Finishers
+47-2061.00,Construction Laborers,47-2061.00,Construction Laborers
+47-2071.00,"Paving, Surfacing, and Tamping Equipment Operators",47-2071.00,"Paving, Surfacing, and Tamping Equipment Operators"
+47-2072.00,Pile-Driver Operators,47-2072.00,Pile-Driver Operators
+47-2073.00,Operating Engineers and Other Construction Equipment Operators,47-2073.00,Operating Engineers and Other Construction Equipment Operators
+47-2073.01,"Grader, Bulldozer, and Scraper Operators",47-2073.00,Operating Engineers and Other Construction Equipment Operators
+47-2073.02,Operating Engineers,47-2073.00,Operating Engineers and Other Construction Equipment Operators
+47-2081.00,Drywall and Ceiling Tile Installers,47-2081.00,Drywall and Ceiling Tile Installers
+47-2081.01,Ceiling Tile Installers,47-2081.00,Drywall and Ceiling Tile Installers
+47-2081.02,Drywall Installers,47-2081.00,Drywall and Ceiling Tile Installers
+47-2082.00,Tapers,47-2082.00,Tapers
+47-2111.00,Electricians,47-2111.00,Electricians
+47-2121.00,Glaziers,47-2121.00,Glaziers
+47-2131.00,"Insulation Workers, Floor, Ceiling, and Wall",47-2131.00,"Insulation Workers, Floor, Ceiling, and Wall"
+47-2132.00,"Insulation Workers, Mechanical",47-2132.00,"Insulation Workers, Mechanical"
+47-2141.00,"Painters, Construction and Maintenance",47-2141.00,"Painters, Construction and Maintenance"
+47-2142.00,Paperhangers,47-2142.00,Paperhangers
+47-2151.00,Pipelayers,47-2151.00,Pipelayers
+47-2152.00,"Plumbers, Pipefitters, and Steamfitters",47-2152.00,"Plumbers, Pipefitters, and Steamfitters"
+47-2152.01,Pipe Fitters,47-2152.01,Pipe Fitters and Steamfitters
+47-2152.02,Plumbers,47-2152.02,Plumbers
+47-2152.03,Pipelaying Fitters,47-2151.00,Pipelayers
+47-2161.00,Plasterers and Stucco Masons,47-2161.00,Plasterers and Stucco Masons
+47-2171.00,Reinforcing Iron and Rebar Workers,47-2171.00,Reinforcing Iron and Rebar Workers
+47-2181.00,Roofers,47-2181.00,Roofers
+47-2211.00,Sheet Metal Workers,47-2211.00,Sheet Metal Workers
+47-2221.00,Structural Iron and Steel Workers,47-2221.00,Structural Iron and Steel Workers
+47-3011.00,"Helpers--Brickmasons, Blockmasons, Stonemasons, and Tile and Marble Setters",47-3011.00,"Helpers--Brickmasons, Blockmasons, Stonemasons, and Tile and Marble Setters"
+47-3012.00,Helpers--Carpenters,47-3012.00,Helpers--Carpenters
+47-3013.00,Helpers--Electricians,47-3013.00,Helpers--Electricians
+47-3014.00,"Helpers--Painters, Paperhangers, Plasterers, and Stucco Masons",47-3014.00,"Helpers--Painters, Paperhangers, Plasterers, and Stucco Masons"
+47-3015.00,"Helpers--Pipelayers, Plumbers, Pipefitters, and Steamfitters",47-3015.00,"Helpers--Pipelayers, Plumbers, Pipefitters, and Steamfitters"
+47-3016.00,Helpers--Roofers,47-3016.00,Helpers--Roofers
+47-3019.99,"Helpers, Construction Trades, All Other",47-3019.99,"Helpers, Construction Trades, All Other"
+47-4011.00,Construction and Building Inspectors,47-4011.00,Construction and Building Inspectors
+47-4021.00,Elevator Installers and Repairers,47-4021.00,Elevator Installers and Repairers
+47-4031.00,Fence Erectors,47-4031.00,Fence Erectors
+47-4041.00,Hazardous Materials Removal Workers,47-4041.00,Hazardous Materials Removal Workers
+47-4041.01,Irradiated-Fuel Handlers,47-4041.00,Hazardous Materials Removal Workers
+47-4051.00,Highway Maintenance Workers,47-4051.00,Highway Maintenance Workers
+47-4061.00,Rail-Track Laying and Maintenance Equipment Operators,47-4061.00,Rail-Track Laying and Maintenance Equipment Operators
+47-4071.00,Septic Tank Servicers and Sewer Pipe Cleaners,47-4071.00,Septic Tank Servicers and Sewer Pipe Cleaners
+47-4091.00,Segmental Pavers,47-4091.00,Segmental Pavers
+47-4099.99,"Construction and Related Workers, All Other",47-4099.99,"Construction and Related Workers, All Other"
+47-5011.00,"Derrick Operators, Oil and Gas",47-5011.00,"Derrick Operators, Oil and Gas"
+47-5012.00,"Rotary Drill Operators, Oil and Gas",47-5012.00,"Rotary Drill Operators, Oil and Gas"
+47-5013.00,"Service Unit Operators, Oil, Gas, and Mining",47-5013.00,"Service Unit Operators, Oil, Gas, and Mining"
+47-5021.00,"Earth Drillers, Except Oil and Gas",47-5021.00,"Earth Drillers, Except Oil and Gas"
+47-5021.01,Construction Drillers,47-5021.00,"Earth Drillers, Except Oil and Gas"
+47-5021.02,Well and Core Drill Operators,47-5021.00,"Earth Drillers, Except Oil and Gas"
+47-5031.00,"Explosives Workers, Ordnance Handling Experts, and Blasters",47-5031.00,"Explosives Workers, Ordnance Handling Experts, and Blasters"
+47-5041.00,Continuous Mining Machine Operators,47-5041.00,Continuous Mining Machine Operators
+47-5042.00,Mine Cutting and Channeling Machine Operators,47-5042.00,Mine Cutting and Channeling Machine Operators
+47-5049.99,"Mining Machine Operators, All Other",47-5049.99,"Mining Machine Operators, All Other"
+47-5051.00,"Rock Splitters, Quarry",47-5051.00,"Rock Splitters, Quarry"
+47-5061.00,"Roof Bolters, Mining",47-5061.00,"Roof Bolters, Mining"
+47-5071.00,"Roustabouts, Oil and Gas",47-5071.00,"Roustabouts, Oil and Gas"
+47-5081.00,Helpers--Extraction Workers,47-5081.00,Helpers--Extraction Workers
+47-5099.99,"Extraction Workers, All Other",47-5099.99,"Extraction Workers, All Other"
+49-1011.00,"First-Line Supervisors/Managers of Mechanics, Installers, and Repairers",49-1011.00,"First-Line Supervisors/Managers of Mechanics, Installers, and Repairers"
+49-2011.00,"Computer, Automated Teller, and Office Machine Repairers",49-2011.00,"Computer, Automated Teller, and Office Machine Repairers"
+49-2011.01,Automatic Teller Machine Servicers,49-9091.00,"Coin, Vending, and Amusement Machine Servicers and Repairers"
+49-2011.02,Data Processing Equipment Repairers,49-2011.00,"Computer, Automated Teller, and Office Machine Repairers"
+49-2011.03,Office Machine and Cash Register Servicers,49-2011.00,"Computer, Automated Teller, and Office Machine Repairers"
+49-2021.00,Radio Mechanics,49-2021.00,Radio Mechanics
+49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers",49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers"
+49-2022.01,Central Office and PBX Installers and Repairers,49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers"
+49-2022.02,"Frame Wirers, Central Office",49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers"
+49-2022.03,"Communication Equipment Mechanics, Installers, and Repairers",49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers"
+49-2022.04,Telecommunications Facility Examiners,49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers"
+49-2022.05,"Station Installers and Repairers, Telephone",49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers"
+49-2091.00,Avionics Technicians,49-2091.00,Avionics Technicians
+49-2092.00,"Electric Motor, Power Tool, and Related Repairers",49-2092.00,"Electric Motor, Power Tool, and Related Repairers"
+49-2092.01,Electric Home Appliance and Power Tool Repairers,49-9031.00,Home Appliance Repairers
+49-2092.02,Electric Motor and Switch Assemblers and Repairers,49-2092.00,"Electric Motor, Power Tool, and Related Repairers"
+49-2092.03,Battery Repairers,49-2092.00,"Electric Motor, Power Tool, and Related Repairers"
+49-2092.04,Transformer Repairers,49-2092.00,"Electric Motor, Power Tool, and Related Repairers"
+49-2092.05,Electrical Parts Reconditioners,49-2092.00,"Electric Motor, Power Tool, and Related Repairers"
+49-2092.06,Hand and Portable Power Tool Repairers,49-2092.00,"Electric Motor, Power Tool, and Related Repairers"
+49-2093.00,"Electrical and Electronics Installers and Repairers, Transportation Equipment",49-2093.00,"Electrical and Electronics Installers and Repairers, Transportation Equipment"
+49-2094.00,"Electrical and Electronics Repairers, Commercial and Industrial Equipment",49-2094.00,"Electrical and Electronics Repairers, Commercial and Industrial Equipment"
+49-2095.00,"Electrical and Electronics Repairers, Powerhouse, Substation, and Relay",49-2095.00,"Electrical and Electronics Repairers, Powerhouse, Substation, and Relay"
+49-2096.00,"Electronic Equipment Installers and Repairers, Motor Vehicles",49-2096.00,"Electronic Equipment Installers and Repairers, Motor Vehicles"
+49-2097.00,Electronic Home Entertainment Equipment Installers and Repairers,49-2097.00,Electronic Home Entertainment Equipment Installers and Repairers
+49-2098.00,Security and Fire Alarm Systems Installers,49-2098.00,Security and Fire Alarm Systems Installers
+49-3011.00,Aircraft Mechanics and Service Technicians,49-3011.00,Aircraft Mechanics and Service Technicians
+49-3011.01,Airframe-and-Power-Plant Mechanics,49-3011.00,Aircraft Mechanics and Service Technicians
+49-3011.02,Aircraft Engine Specialists,49-3011.00,Aircraft Mechanics and Service Technicians
+49-3011.03,Aircraft Body and Bonded Structure Repairers,49-3011.00,Aircraft Mechanics and Service Technicians
+49-3021.00,Automotive Body and Related Repairers,49-3021.00,Automotive Body and Related Repairers
+49-3022.00,Automotive Glass Installers and Repairers,49-3022.00,Automotive Glass Installers and Repairers
+49-3023.00,Automotive Service Technicians and Mechanics,49-3023.00,Automotive Service Technicians and Mechanics
+49-3023.01,Automotive Master Mechanics,49-3023.01,Automotive Master Mechanics
+49-3023.02,Automotive Specialty Technicians,49-3023.02,Automotive Specialty Technicians
+49-3031.00,Bus and Truck Mechanics and Diesel Engine Specialists,49-3031.00,Bus and Truck Mechanics and Diesel Engine Specialists
+49-3041.00,Farm Equipment Mechanics,49-3041.00,Farm Equipment Mechanics
+49-3042.00,"Mobile Heavy Equipment Mechanics, Except Engines",49-3042.00,"Mobile Heavy Equipment Mechanics, Except Engines"
+49-3043.00,Rail Car Repairers,49-3043.00,Rail Car Repairers
+49-3051.00,Motorboat Mechanics,49-3051.00,Motorboat Mechanics
+49-3052.00,Motorcycle Mechanics,49-3052.00,Motorcycle Mechanics
+49-3053.00,Outdoor Power Equipment and Other Small Engine Mechanics,49-3053.00,Outdoor Power Equipment and Other Small Engine Mechanics
+49-3091.00,Bicycle Repairers,49-3091.00,Bicycle Repairers
+49-3092.00,Recreational Vehicle Service Technicians,49-3092.00,Recreational Vehicle Service Technicians
+49-3093.00,Tire Repairers and Changers,49-3093.00,Tire Repairers and Changers
+49-9011.00,Mechanical Door Repairers,49-9011.00,Mechanical Door Repairers
+49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door",49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door"
+49-9012.01,Electric Meter Installers and Repairers,49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door"
+49-9012.02,Valve and Regulator Repairers,49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door"
+49-9012.03,Meter Mechanics,49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door"
+49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers",49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers"
+49-9021.01,Heating and Air Conditioning Mechanics,49-9021.01,Heating and Air Conditioning Mechanics and Installers
+49-9021.02,Refrigeration Mechanics,49-9021.02,Refrigeration Mechanics and Installers
+49-9031.00,Home Appliance Repairers,49-9031.00,Home Appliance Repairers
+49-9031.01,Home Appliance Installers,49-9031.00,Home Appliance Repairers
+49-9031.02,Gas Appliance Repairers,49-9031.00,Home Appliance Repairers
+49-9041.00,Industrial Machinery Mechanics,49-9041.00,Industrial Machinery Mechanics
+49-9042.00,"Maintenance and Repair Workers, General",49-9042.00,"Maintenance and Repair Workers, General"
+49-9043.00,"Maintenance Workers, Machinery",49-9043.00,"Maintenance Workers, Machinery"
+49-9044.00,Millwrights,49-9044.00,Millwrights
+49-9045.00,"Refractory Materials Repairers, Except Brickmasons",49-9045.00,"Refractory Materials Repairers, Except Brickmasons"
+49-9051.00,Electrical Power-Line Installers and Repairers,49-9051.00,Electrical Power-Line Installers and Repairers
+49-9052.00,Telecommunications Line Installers and Repairers,49-9052.00,Telecommunications Line Installers and Repairers
+49-9061.00,Camera and Photographic Equipment Repairers,49-9061.00,Camera and Photographic Equipment Repairers
+49-9062.00,Medical Equipment Repairers,49-9062.00,Medical Equipment Repairers
+49-9063.00,Musical Instrument Repairers and Tuners,49-9063.00,Musical Instrument Repairers and Tuners
+49-9063.01,Keyboard Instrument Repairers and Tuners,49-9063.00,Musical Instrument Repairers and Tuners
+49-9063.02,Stringed Instrument Repairers and Tuners,49-9063.00,Musical Instrument Repairers and Tuners
+49-9063.03,Reed or Wind Instrument Repairers and Tuners,49-9063.00,Musical Instrument Repairers and Tuners
+49-9063.04,Percussion Instrument Repairers and Tuners,49-9063.00,Musical Instrument Repairers and Tuners
+49-9064.00,Watch Repairers,49-9064.00,Watch Repairers
+49-9069.99,"Precision Instrument and Equipment Repairers, All Other",49-9069.99,"Precision Instrument and Equipment Repairers, All Other"
+49-9091.00,"Coin, Vending, and Amusement Machine Servicers and Repairers",49-9091.00,"Coin, Vending, and Amusement Machine Servicers and Repairers"
+49-9092.00,Commercial Divers,49-9092.00,Commercial Divers
+49-9093.00,"Fabric Menders, Except Garment",49-9093.00,"Fabric Menders, Except Garment"
+49-9094.00,Locksmiths and Safe Repairers,49-9094.00,Locksmiths and Safe Repairers
+49-9095.00,Manufactured Building and Mobile Home Installers,49-9095.00,Manufactured Building and Mobile Home Installers
+49-9096.00,Riggers,49-9096.00,Riggers
+49-9097.00,Signal and Track Switch Repairers,49-9097.00,Signal and Track Switch Repairers
+49-9098.00,"Helpers--Installation, Maintenance, and Repair Workers",49-9098.00,"Helpers--Installation, Maintenance, and Repair Workers"
+49-9099.99,"Installation, Maintenance, and Repair Workers, All Other",49-9099.99,"Installation, Maintenance, and Repair Workers, All Other"
+51-1011.00,First-Line Supervisors/Managers of Production and Operating Workers,51-1011.00,First-Line Supervisors/Managers of Production and Operating Workers
+51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers",51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers"
+51-2011.01,"Aircraft Structure Assemblers, Precision",51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers"
+51-2011.02,"Aircraft Systems Assemblers, Precision",51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers"
+51-2011.03,Aircraft Rigging Assemblers,51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers"
+51-2021.00,"Coil Winders, Tapers, and Finishers",51-2021.00,"Coil Winders, Tapers, and Finishers"
+51-2022.00,Electrical and Electronic Equipment Assemblers,51-2022.00,Electrical and Electronic Equipment Assemblers
+51-2023.00,Electromechanical Equipment Assemblers,51-2023.00,Electromechanical Equipment Assemblers
+51-2031.00,Engine and Other Machine Assemblers,51-2031.00,Engine and Other Machine Assemblers
+51-2041.00,Structural Metal Fabricators and Fitters,51-2041.00,Structural Metal Fabricators and Fitters
+51-2041.01,"Metal Fabricators, Structural Metal Products",51-2041.00,Structural Metal Fabricators and Fitters
+51-2041.02,"Fitters, Structural Metal- Precision",51-2041.00,Structural Metal Fabricators and Fitters
+51-2091.00,Fiberglass Laminators and Fabricators,51-2091.00,Fiberglass Laminators and Fabricators
+51-2092.00,Team Assemblers,51-2092.00,Team Assemblers
+51-2093.00,"Timing Device Assemblers, Adjusters, and Calibrators",51-2093.00,"Timing Device Assemblers, Adjusters, and Calibrators"
+51-2099.99,"Assemblers and Fabricators, All Other",51-2099.99,"Assemblers and Fabricators, All Other"
+51-3011.00,Bakers,51-3011.00,Bakers
+51-3011.01,"Bakers, Bread and Pastry",35-1011.00,Chefs and Head Cooks
+51-3011.02,"Bakers, Manufacturing",51-3011.00,Bakers
+51-3021.00,Butchers and Meat Cutters,51-3021.00,Butchers and Meat Cutters
+51-3022.00,"Meat, Poultry, and Fish Cutters and Trimmers",51-3022.00,"Meat, Poultry, and Fish Cutters and Trimmers"
+51-3023.00,Slaughterers and Meat Packers,51-3023.00,Slaughterers and Meat Packers
+51-3091.00,"Food and Tobacco Roasting, Baking, and Drying Machine Operators and Tenders",51-3091.00,"Food and Tobacco Roasting, Baking, and Drying Machine Operators and Tenders"
+51-3092.00,Food Batchmakers,51-3092.00,Food Batchmakers
+51-3093.00,Food Cooking Machine Operators and Tenders,51-3093.00,Food Cooking Machine Operators and Tenders
+51-4011.00,"Computer-Controlled Machine Tool Operators, Metal and Plastic",51-4011.00,"Computer-Controlled Machine Tool Operators, Metal and Plastic"
+51-4011.01,"Numerical Control Machine Tool Operators and Tenders, Metal and Plastic",51-4011.00,"Computer-Controlled Machine Tool Operators, Metal and Plastic"
+51-4012.00,Numerical Tool and Process Control Programmers,51-4012.00,Numerical Tool and Process Control Programmers
+51-4021.00,"Extruding and Drawing Machine Setters, Operators, and Tenders, Metal and Plastic",51-4021.00,"Extruding and Drawing Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4022.00,"Forging Machine Setters, Operators, and Tenders, Metal and Plastic",51-4022.00,"Forging Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4023.00,"Rolling Machine Setters, Operators, and Tenders, Metal and Plastic",51-4023.00,"Rolling Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic",51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4031.01,"Sawing Machine Tool Setters and Set-Up Operators, Metal and Plastic",51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4031.02,"Punching Machine Setters and Set-Up Operators, Metal and Plastic",51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4031.03,"Press and Press Brake Machine Setters and Set-Up Operators, Metal and Plastic",51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4031.04,"Shear and Slitter Machine Setters and Set-Up Operators, Metal and Plastic",51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4032.00,"Drilling and Boring Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4032.00,"Drilling and Boring Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4033.01,"Grinding, Honing, Lapping, and Deburring Machine Set-Up Operators",51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4033.02,Buffing and Polishing Set-Up Operators,51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4034.00,"Lathe and Turning Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4034.00,"Lathe and Turning Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4035.00,"Milling and Planing Machine Setters, Operators, and Tenders, Metal and Plastic",51-4035.00,"Milling and Planing Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4041.00,Machinists,51-4041.00,Machinists
+51-4051.00,Metal-Refining Furnace Operators and Tenders,51-4051.00,Metal-Refining Furnace Operators and Tenders
+51-4052.00,"Pourers and Casters, Metal",51-4052.00,"Pourers and Casters, Metal"
+51-4061.00,"Model Makers, Metal and Plastic",51-4061.00,"Model Makers, Metal and Plastic"
+51-4062.00,"Patternmakers, Metal and Plastic",51-4062.00,"Patternmakers, Metal and Plastic"
+51-4071.00,Foundry Mold and Coremakers,51-4071.00,Foundry Mold and Coremakers
+51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic",51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4072.01,Plastic Molding and Casting Machine Setters and Set-Up Operators,51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4072.02,Plastic Molding and Casting Machine Operators and Tenders,51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4072.03,"Metal Molding, Coremaking, and Casting Machine Setters and Set-Up Operators",51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4072.04,"Metal Molding, Coremaking, and Casting Machine Operators and Tenders",51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4072.05,Casting Machine Set-Up Operators,51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4081.01,"Combination Machine Tool Setters and Set-Up Operators, Metal and Plastic",51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4081.02,"Combination Machine Tool Operators and Tenders, Metal and Plastic",51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4111.00,Tool and Die Makers,51-4111.00,Tool and Die Makers
+51-4121.00,"Welders, Cutters, Solderers, and Brazers",51-4121.00,"Welders, Cutters, Solderers, and Brazers"
+51-4121.01,"Welders, Production",51-4121.06,"Welders, Cutters, and Welder Fitters"
+51-4121.02,Welders and Cutters,51-4121.06,"Welders, Cutters, and Welder Fitters"
+51-4121.03,Welder-Fitters,51-4121.06,"Welders, Cutters, and Welder Fitters"
+51-4121.04,Solderers,51-4121.07,Solderers and Brazers
+51-4121.05,Brazers,51-4121.07,Solderers and Brazers
+51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders",51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders"
+51-4122.01,Welding Machine Setters and Set-Up Operators,51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders"
+51-4122.02,Welding Machine Operators and Tenders,51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders"
+51-4122.03,Soldering and Brazing Machine Setters and Set-Up Operators,51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders"
+51-4122.04,Soldering and Brazing Machine Operators and Tenders,51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders"
+51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic",51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic"
+51-4191.01,"Heating Equipment Setters and Set-Up Operators, Metal and Plastic",51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic"
+51-4191.02,"Heat Treating, Annealing, and Tempering Machine Operators and Tenders, Metal and Plastic",51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic"
+51-4191.03,"Heaters, Metal and Plastic",51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic"
+51-4192.00,"Lay-Out Workers, Metal and Plastic",51-4192.00,"Lay-Out Workers, Metal and Plastic"
+51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic",51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4193.01,"Electrolytic Plating and Coating Machine Setters and Set-Up Operators, Metal and Plastic",51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4193.02,"Electrolytic Plating and Coating Machine Operators and Tenders, Metal and Plastic",51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4193.03,"Nonelectrolytic Plating and Coating Machine Setters and Set-Up Operators, Metal and Plastic",51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4193.04,"Nonelectrolytic Plating and Coating Machine Operators and Tenders, Metal and Plastic",51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4194.00,"Tool Grinders, Filers, and Sharpeners",51-4194.00,"Tool Grinders, Filers, and Sharpeners"
+51-4199.99,"Metal Workers and Plastic Workers, All Other",51-4199.99,"Metal Workers and Plastic Workers, All Other"
+51-5011.00,Bindery Workers,51-5011.00,Bindery Workers
+51-5011.01,Bindery Machine Setters and Set-Up Operators,51-5011.00,Bindery Workers
+51-5011.02,Bindery Machine Operators and Tenders,51-5011.00,Bindery Workers
+51-5012.00,Bookbinders,51-5012.00,Bookbinders
+51-5021.00,Job Printers,51-5021.00,Job Printers
+51-5022.00,Prepress Technicians and Workers,51-5022.00,Prepress Technicians and Workers
+51-5022.01,Hand Compositors and Typesetters,51-5022.00,Prepress Technicians and Workers
+51-5022.02,Paste-Up Workers,51-5022.00,Prepress Technicians and Workers
+51-5022.03,Photoengravers,51-5022.00,Prepress Technicians and Workers
+51-5022.04,Camera Operators,51-5022.00,Prepress Technicians and Workers
+51-5022.05,Scanner Operators,51-5022.00,Prepress Technicians and Workers
+51-5022.06,Strippers,51-5022.00,Prepress Technicians and Workers
+51-5022.07,Platemakers,51-5022.00,Prepress Technicians and Workers
+51-5022.08,Dot Etchers,51-5022.00,Prepress Technicians and Workers
+51-5022.09,Electronic Masking System Operators,51-5022.00,Prepress Technicians and Workers
+51-5022.10,Electrotypers and Stereotypers,51-5022.00,Prepress Technicians and Workers
+51-5022.11,Plate Finishers,51-5022.00,Prepress Technicians and Workers
+51-5022.12,Typesetting and Composing Machine Operators and Tenders,51-5022.00,Prepress Technicians and Workers
+51-5022.13,Photoengraving and Lithographing Machine Operators and Tenders,51-5022.00,Prepress Technicians and Workers
+51-5023.00,Printing Machine Operators,51-5023.00,Printing Machine Operators
+51-5023.01,Precision Printing Workers,51-5023.00,Printing Machine Operators
+51-5023.02,Offset Lithographic Press Setters and Set-Up Operators,51-5023.00,Printing Machine Operators
+51-5023.03,Letterpress Setters and Set-Up Operators,51-5023.00,Printing Machine Operators
+51-5023.04,Design Printing Machine Setters and Set-Up Operators,51-5023.00,Printing Machine Operators
+51-5023.05,Marking and Identification Printing Machine Setters and Set-Up Operators,51-5023.00,Printing Machine Operators
+51-5023.06,Screen Printing Machine Setters and Set-Up Operators,51-5023.00,Printing Machine Operators
+51-5023.07,Embossing Machine Set-Up Operators,51-5023.00,Printing Machine Operators
+51-5023.08,Engraver Set-Up Operators,51-5023.00,Printing Machine Operators
+51-5023.09,Printing Press Machine Operators and Tenders,51-5023.00,Printing Machine Operators
+51-6011.00,Laundry and Dry-Cleaning Workers,51-6011.00,Laundry and Dry-Cleaning Workers
+51-6011.01,"Spotters, Dry Cleaning",51-6011.00,Laundry and Dry-Cleaning Workers
+51-6011.02,Precision Dyers,51-6011.00,Laundry and Dry-Cleaning Workers
+51-6011.03,"Laundry and Drycleaning Machine Operators and Tenders, Except Pressing",51-6011.00,Laundry and Dry-Cleaning Workers
+51-6021.00,"Pressers, Textile, Garment, and Related Materials",51-6021.00,"Pressers, Textile, Garment, and Related Materials"
+51-6021.01,"Pressers, Delicate Fabrics",51-6021.00,"Pressers, Textile, Garment, and Related Materials"
+51-6021.02,"Pressing Machine Operators and Tenders- Textile, Garment, and Related Materials",51-6021.00,"Pressers, Textile, Garment, and Related Materials"
+51-6021.03,"Pressers, Hand",51-6021.00,"Pressers, Textile, Garment, and Related Materials"
+51-6031.00,Sewing Machine Operators,51-6031.00,Sewing Machine Operators
+51-6031.01,"Sewing Machine Operators, Garment",51-6031.00,Sewing Machine Operators
+51-6031.02,"Sewing Machine Operators, Non-Garment",51-6031.00,Sewing Machine Operators
+51-6041.00,Shoe and Leather Workers and Repairers,51-6041.00,Shoe and Leather Workers and Repairers
+51-6042.00,Shoe Machine Operators and Tenders,51-6042.00,Shoe Machine Operators and Tenders
+51-6051.00,"Sewers, Hand",51-6051.00,"Sewers, Hand"
+51-6052.00,"Tailors, Dressmakers, and Custom Sewers",51-6052.00,"Tailors, Dressmakers, and Custom Sewers"
+51-6052.01,Shop and Alteration Tailors,51-6052.00,"Tailors, Dressmakers, and Custom Sewers"
+51-6052.02,Custom Tailors,51-6052.00,"Tailors, Dressmakers, and Custom Sewers"
+51-6061.00,Textile Bleaching and Dyeing Machine Operators and Tenders,51-6061.00,Textile Bleaching and Dyeing Machine Operators and Tenders
+51-6062.00,"Textile Cutting Machine Setters, Operators, and Tenders",51-6062.00,"Textile Cutting Machine Setters, Operators, and Tenders"
+51-6063.00,"Textile Knitting and Weaving Machine Setters, Operators, and Tenders",51-6063.00,"Textile Knitting and Weaving Machine Setters, Operators, and Tenders"
+51-6064.00,"Textile Winding, Twisting, and Drawing Out Machine Setters, Operators, and Tenders",51-6064.00,"Textile Winding, Twisting, and Drawing Out Machine Setters, Operators, and Tenders"
+51-6091.00,"Extruding and Forming Machine Setters, Operators, and Tenders, Synthetic and Glass Fibers",51-6091.00,"Extruding and Forming Machine Setters, Operators, and Tenders, Synthetic and Glass Fibers"
+51-6091.01,"Extruding and Forming Machine Operators and Tenders, Synthetic or Glass Fibers",51-6091.00,"Extruding and Forming Machine Setters, Operators, and Tenders, Synthetic and Glass Fibers"
+51-6092.00,Fabric and Apparel Patternmakers,51-6092.00,Fabric and Apparel Patternmakers
+51-6093.00,Upholsterers,51-6093.00,Upholsterers
+51-6099.99,"Textile, Apparel, and Furnishings Workers, All Other",51-6099.99,"Textile, Apparel, and Furnishings Workers, All Other"
+51-7011.00,Cabinetmakers and Bench Carpenters,51-7011.00,Cabinetmakers and Bench Carpenters
+51-7021.00,Furniture Finishers,51-7021.00,Furniture Finishers
+51-7031.00,"Model Makers, Wood",51-7031.00,"Model Makers, Wood"
+51-7032.00,"Patternmakers, Wood",51-7032.00,"Patternmakers, Wood"
+51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood",51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood"
+51-7041.01,Sawing Machine Setters and Set-Up Operators,51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood"
+51-7041.02,Sawing Machine Operators and Tenders,51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood"
+51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing",51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing"
+51-7042.01,"Woodworking Machine Setters and Set-Up Operators, Except Sawing",51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing"
+51-7042.02,"Woodworking Machine Operators and Tenders, Except Sawing",51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing"
+51-7099.99,"Woodworkers, All Other",51-7099.99,"Woodworkers, All Other"
+51-8011.00,Nuclear Power Reactor Operators,51-8011.00,Nuclear Power Reactor Operators
+51-8012.00,Power Distributors and Dispatchers,51-8012.00,Power Distributors and Dispatchers
+51-8013.00,Power Plant Operators,51-8013.00,Power Plant Operators
+51-8013.01,"Power Generating Plant Operators, Except Auxiliary Equipment Operators",51-8013.00,Power Plant Operators
+51-8013.02,"Auxiliary Equipment Operators, Power",51-8013.00,Power Plant Operators
+51-8021.00,Stationary Engineers and Boiler Operators,51-8021.00,Stationary Engineers and Boiler Operators
+51-8021.01,"Boiler Operators and Tenders, Low Pressure",51-8021.00,Stationary Engineers and Boiler Operators
+51-8021.02,Stationary Engineers,51-8021.00,Stationary Engineers and Boiler Operators
+51-8031.00,Water and Liquid Waste Treatment Plant and System Operators,51-8031.00,Water and Liquid Waste Treatment Plant and System Operators
+51-8091.00,Chemical Plant and System Operators,51-8091.00,Chemical Plant and System Operators
+51-8092.00,Gas Plant Operators,51-8092.00,Gas Plant Operators
+51-8092.01,Gas Processing Plant Operators,51-8092.00,Gas Plant Operators
+51-8092.02,Gas Distribution Plant Operators,51-8092.00,Gas Plant Operators
+51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers",51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers"
+51-8093.01,Petroleum Pump System Operators,51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers"
+51-8093.02,Petroleum Refinery and Control Panel Operators,51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers"
+51-8093.03,Gaugers,51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers"
+51-8099.99,"Plant and System Operators, All Other",51-8099.99,"Plant and System Operators, All Other"
+51-9011.00,Chemical Equipment Operators and Tenders,51-9011.00,Chemical Equipment Operators and Tenders
+51-9011.01,Chemical Equipment Controllers and Operators,51-9011.00,Chemical Equipment Operators and Tenders
+51-9011.02,Chemical Equipment Tenders,51-9011.00,Chemical Equipment Operators and Tenders
+51-9012.00,"Separating, Filtering, Clarifying, Precipitating, and Still Machine Setters, Operators, and Tenders",51-9012.00,"Separating, Filtering, Clarifying, Precipitating, and Still Machine Setters, Operators, and Tenders"
+51-9021.00,"Crushing, Grinding, and Polishing Machine Setters, Operators, and Tenders",51-9021.00,"Crushing, Grinding, and Polishing Machine Setters, Operators, and Tenders"
+51-9022.00,"Grinding and Polishing Workers, Hand",51-9022.00,"Grinding and Polishing Workers, Hand"
+51-9023.00,"Mixing and Blending Machine Setters, Operators, and Tenders",51-9023.00,"Mixing and Blending Machine Setters, Operators, and Tenders"
+51-9031.00,"Cutters and Trimmers, Hand",51-9031.00,"Cutters and Trimmers, Hand"
+51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders",51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders"
+51-9032.01,Fiber Product Cutting Machine Setters and Set-Up Operators,51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders"
+51-9032.02,Stone Sawyers,51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders"
+51-9032.03,Glass Cutting Machine Setters and Set-Up Operators,51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders"
+51-9032.04,Cutting and Slicing Machine Operators and Tenders,51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders"
+51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders",51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders"
+51-9041.01,"Extruding, Forming, Pressing, and Compacting Machine Setters and Set-Up Operators",51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders"
+51-9041.02,"Extruding, Forming, Pressing, and Compacting Machine Operators and Tenders",51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders"
+51-9051.00,"Furnace, Kiln, Oven, Drier, and Kettle Operators and Tenders",51-9051.00,"Furnace, Kiln, Oven, Drier, and Kettle Operators and Tenders"
+51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers",51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers"
+51-9061.01,Materials Inspectors,51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers"
+51-9061.02,Mechanical Inspectors,51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers"
+51-9061.03,Precision Devices Inspectors and Testers,51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers"
+51-9061.04,Electrical and Electronic Inspectors and Testers,51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers"
+51-9061.05,"Production Inspectors, Testers, Graders, Sorters, Samplers, Weighers",51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers"
+51-9071.00,Jewelers and Precious Stone and Metal Workers,51-9071.00,Jewelers and Precious Stone and Metal Workers
+51-9071.01,Jewelers,51-9071.01,Jewelers
+51-9071.02,Silversmiths,51-9071.07,Precious Metal Workers
+51-9071.03,"Model and Mold Makers, Jewelry",51-9071.01,Jewelers
+51-9071.04,"Bench Workers, Jewelry",51-9071.01,Jewelers
+51-9071.05,Pewter Casters and Finishers,51-9071.07,Precious Metal Workers
+51-9071.06,Gem and Diamond Workers,51-9071.06,Gem and Diamond Workers
+51-9081.00,Dental Laboratory Technicians,51-9081.00,Dental Laboratory Technicians
+51-9082.00,Medical Appliance Technicians,51-9082.00,Medical Appliance Technicians
+51-9083.00,Ophthalmic Laboratory Technicians,51-9083.00,Ophthalmic Laboratory Technicians
+51-9083.01,Precision Lens Grinders and Polishers,51-9083.00,Ophthalmic Laboratory Technicians
+51-9083.02,Optical Instrument Assemblers,51-9083.00,Ophthalmic Laboratory Technicians
+51-9111.00,Packaging and Filling Machine Operators and Tenders,51-9111.00,Packaging and Filling Machine Operators and Tenders
+51-9121.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders",51-9121.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders"
+51-9121.01,"Coating, Painting, and Spraying Machine Setters and Set-Up Operators",51-9121.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders"
+51-9121.02,"Coating, Painting, and Spraying Machine Operators and Tenders",51-9121.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders"
+51-9122.00,"Painters, Transportation Equipment",51-9122.00,"Painters, Transportation Equipment"
+51-9123.00,"Painting, Coating, and Decorating Workers",51-9123.00,"Painting, Coating, and Decorating Workers"
+51-9131.00,Photographic Process Workers,51-9131.00,Photographic Process Workers
+51-9131.01,Photographic Retouchers and Restorers,51-9131.00,Photographic Process Workers
+51-9131.02,Photographic Reproduction Technicians,51-9131.00,Photographic Process Workers
+51-9131.03,Photographic Hand Developers,51-9131.00,Photographic Process Workers
+51-9131.04,Film Laboratory Technicians,51-9131.00,Photographic Process Workers
+51-9132.00,Photographic Processing Machine Operators,51-9132.00,Photographic Processing Machine Operators
+51-9141.00,Semiconductor Processors,51-9141.00,Semiconductor Processors
+51-9191.00,Cementing and Gluing Machine Operators and Tenders,51-9191.00,Cementing and Gluing Machine Operators and Tenders
+51-9192.00,"Cleaning, Washing, and Metal Pickling Equipment Operators and Tenders",51-9192.00,"Cleaning, Washing, and Metal Pickling Equipment Operators and Tenders"
+51-9193.00,Cooling and Freezing Equipment Operators and Tenders,51-9193.00,Cooling and Freezing Equipment Operators and Tenders
+51-9194.00,Etchers and Engravers,51-9194.00,Etchers and Engravers
+51-9194.01,"Precision Etchers and Engravers, Hand or Machine",51-9194.00,Etchers and Engravers
+51-9194.02,Engravers/Carvers,51-9194.00,Etchers and Engravers
+51-9194.03,Etchers,51-9194.00,Etchers and Engravers
+51-9194.04,Pantograph Engravers,51-9194.00,Etchers and Engravers
+51-9194.05,"Etchers, Hand",51-9194.00,Etchers and Engravers
+51-9194.06,"Engravers, Hand",51-9194.00,Etchers and Engravers
+51-9195.00,"Molders, Shapers, and Casters, Except Metal and Plastic",51-9195.00,"Molders, Shapers, and Casters, Except Metal and Plastic"
+51-9195.01,"Precision Mold and Pattern Casters, Except Nonferrous Metals",51-9195.07,Molding and Casting Workers
+51-9195.02,"Precision Pattern and Die Casters, Nonferrous Metals",51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-9195.03,Stone Cutters and Carvers,51-9195.03,"Stone Cutters and Carvers, Manufacturing"
+51-9195.04,"Glass Blowers, Molders, Benders, and Finishers",51-9195.04,"Glass Blowers, Molders, Benders, and Finishers"
+51-9195.05,Potters,51-9195.05,"Potters, Manufacturing"
+51-9195.06,"Mold Makers, Hand",51-9195.07,Molding and Casting Workers
+51-9195.07,Molding and Casting Workers,51-9195.07,Molding and Casting Workers
+51-9196.00,"Paper Goods Machine Setters, Operators, and Tenders",51-9196.00,"Paper Goods Machine Setters, Operators, and Tenders"
+51-9197.00,Tire Builders,51-9197.00,Tire Builders
+51-9198.00,Helpers--Production Workers,51-9198.00,Helpers--Production Workers
+51-9198.01,Production Laborers,51-9198.00,Helpers--Production Workers
+51-9198.02,Production Helpers,51-9198.00,Helpers--Production Workers
+51-9199.99,"Production Workers, All Other",51-9199.99,"Production Workers, All Other"
+53-1011.00,Aircraft Cargo Handling Supervisors,53-1011.00,Aircraft Cargo Handling Supervisors
+53-1021.00,"First-Line Supervisors/Managers of Helpers, Laborers, and Material Movers, Hand",53-1021.00,"First-Line Supervisors/Managers of Helpers, Laborers, and Material Movers, Hand"
+53-1031.00,First-Line Supervisors/Managers of Transportation and Material-Moving Machine and Vehicle Operators,53-1031.00,First-Line Supervisors/Managers of Transportation and Material-Moving Machine and Vehicle Operators
+53-2011.00,"Airline Pilots, Copilots, and Flight Engineers",53-2011.00,"Airline Pilots, Copilots, and Flight Engineers"
+53-2012.00,Commercial Pilots,53-2012.00,Commercial Pilots
+53-2021.00,Air Traffic Controllers,53-2021.00,Air Traffic Controllers
+53-2022.00,Airfield Operations Specialists,53-2022.00,Airfield Operations Specialists
+53-3011.00,"Ambulance Drivers and Attendants, Except Emergency Medical Technicians",53-3011.00,"Ambulance Drivers and Attendants, Except Emergency Medical Technicians"
+53-3021.00,"Bus Drivers, Transit and Intercity",53-3021.00,"Bus Drivers, Transit and Intercity"
+53-3022.00,"Bus Drivers, School",53-3022.00,"Bus Drivers, School"
+53-3031.00,Driver/Sales Workers,53-3031.00,Driver/Sales Workers
+53-3032.00,"Truck Drivers, Heavy and Tractor-Trailer",53-3032.00,"Truck Drivers, Heavy and Tractor-Trailer"
+53-3032.01,"Truck Drivers, Heavy",53-3032.00,"Truck Drivers, Heavy and Tractor-Trailer"
+53-3032.02,Tractor-Trailer Truck Drivers,53-3032.00,"Truck Drivers, Heavy and Tractor-Trailer"
+53-3033.00,"Truck Drivers, Light or Delivery Services",53-3033.00,"Truck Drivers, Light or Delivery Services"
+53-3041.00,Taxi Drivers and Chauffeurs,53-3041.00,Taxi Drivers and Chauffeurs
+53-3099.99,"Motor Vehicle Operators, All Other",53-3099.99,"Motor Vehicle Operators, All Other"
+53-4011.00,Locomotive Engineers,53-4011.00,Locomotive Engineers
+53-4012.00,Locomotive Firers,53-4012.00,Locomotive Firers
+53-4013.00,"Rail Yard Engineers, Dinkey Operators, and Hostlers",53-4013.00,"Rail Yard Engineers, Dinkey Operators, and Hostlers"
+53-4021.00,"Railroad Brake, Signal, and Switch Operators",53-4021.00,"Railroad Brake, Signal, and Switch Operators"
+53-4021.01,Train Crew Members,53-4021.00,"Railroad Brake, Signal, and Switch Operators"
+53-4021.02,Railroad Yard Workers,53-4021.00,"Railroad Brake, Signal, and Switch Operators"
+53-4031.00,Railroad Conductors and Yardmasters,53-4031.00,Railroad Conductors and Yardmasters
+53-4041.00,Subway and Streetcar Operators,53-4041.00,Subway and Streetcar Operators
+53-4099.99,"Rail Transportation Workers, All Other",53-4099.99,"Rail Transportation Workers, All Other"
+53-5011.00,Sailors and Marine Oilers,53-5011.00,Sailors and Marine Oilers
+53-5011.01,Able Seamen,53-5011.00,Sailors and Marine Oilers
+53-5011.02,Ordinary Seamen and Marine Oilers,53-5011.00,Sailors and Marine Oilers
+53-5021.00,"Captains, Mates, and Pilots of Water Vessels",53-5021.00,"Captains, Mates, and Pilots of Water Vessels"
+53-5021.01,Ship and Boat Captains,53-5021.01,Ship and Boat Captains
+53-5021.02,"Mates- Ship, Boat, and Barge",53-5021.02,"Mates- Ship, Boat, and Barge"
+53-5021.03,"Pilots, Ship",53-5021.03,"Pilots, Ship"
+53-5022.00,Motorboat Operators,53-5022.00,Motorboat Operators
+53-5031.00,Ship Engineers,53-5031.00,Ship Engineers
+53-6011.00,Bridge and Lock Tenders,53-6011.00,Bridge and Lock Tenders
+53-6021.00,Parking Lot Attendants,53-6021.00,Parking Lot Attendants
+53-6031.00,Service Station Attendants,53-6031.00,Service Station Attendants
+53-6041.00,Traffic Technicians,53-6041.00,Traffic Technicians
+53-6051.00,Transportation Inspectors,53-6051.00,Transportation Inspectors
+53-6051.01,Aviation Inspectors,53-6051.01,Aviation Inspectors
+53-6051.02,Public Transportation Inspectors,53-6051.07,"Transportation Vehicle, Equipment and Systems Inspectors, Except Aviation"
+53-6051.03,Marine Cargo Inspectors,53-6051.08,Freight and Cargo Inspectors
+53-6051.04,Railroad Inspectors,53-6051.07,"Transportation Vehicle, Equipment and Systems Inspectors, Except Aviation"
+53-6051.05,Motor Vehicle Inspectors,53-6051.07,"Transportation Vehicle, Equipment and Systems Inspectors, Except Aviation"
+53-6051.06,Freight Inspectors,53-6051.08,Freight and Cargo Inspectors
+53-6099.99,"Transportation Workers, All Other",53-6099.99,"Transportation Workers, All Other"
+53-7011.00,Conveyor Operators and Tenders,53-7011.00,Conveyor Operators and Tenders
+53-7021.00,Crane and Tower Operators,53-7021.00,Crane and Tower Operators
+53-7031.00,Dredge Operators,53-7031.00,Dredge Operators
+53-7032.00,Excavating and Loading Machine and Dragline Operators,53-7032.00,Excavating and Loading Machine and Dragline Operators
+53-7032.01,Excavating and Loading Machine Operators,53-7032.00,Excavating and Loading Machine and Dragline Operators
+53-7032.02,Dragline Operators,53-7032.00,Excavating and Loading Machine and Dragline Operators
+53-7033.00,"Loading Machine Operators, Underground Mining",53-7033.00,"Loading Machine Operators, Underground Mining"
+53-7041.00,Hoist and Winch Operators,53-7041.00,Hoist and Winch Operators
+53-7051.00,Industrial Truck and Tractor Operators,53-7051.00,Industrial Truck and Tractor Operators
+53-7061.00,Cleaners of Vehicles and Equipment,53-7061.00,Cleaners of Vehicles and Equipment
+53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand",53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand"
+53-7062.01,"Stevedores, Except Equipment Operators",53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand"
+53-7062.02,"Grips and Set-Up Workers, Motion Picture Sets, Studios, and Stages",53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand"
+53-7062.03,"Freight, Stock, and Material Movers, Hand",53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand"
+53-7063.00,Machine Feeders and Offbearers,53-7063.00,Machine Feeders and Offbearers
+53-7064.00,"Packers and Packagers, Hand",53-7064.00,"Packers and Packagers, Hand"
+53-7071.00,Gas Compressor and Gas Pumping Station Operators,53-7071.00,Gas Compressor and Gas Pumping Station Operators
+53-7071.01,Gas Pumping Station Operators,53-7071.00,Gas Compressor and Gas Pumping Station Operators
+53-7071.02,Gas Compressor Operators,53-7071.00,Gas Compressor and Gas Pumping Station Operators
+53-7072.00,"Pump Operators, Except Wellhead Pumpers",53-7072.00,"Pump Operators, Except Wellhead Pumpers"
+53-7073.00,Wellhead Pumpers,53-7073.00,Wellhead Pumpers
+53-7081.00,Refuse and Recyclable Material Collectors,53-7081.00,Refuse and Recyclable Material Collectors
+53-7111.00,Shuttle Car Operators,53-7111.00,Shuttle Car Operators
+53-7121.00,"Tank Car, Truck, and Ship Loaders",53-7121.00,"Tank Car, Truck, and Ship Loaders"
+53-7199.99,"Material Moving Workers, All Other",53-7199.99,"Material Moving Workers, All Other"
+55-1011.00,Air Crew Officers,55-1011.00,Air Crew Officers
+55-1012.00,Aircraft Launch and Recovery Officers,55-1012.00,Aircraft Launch and Recovery Officers
+55-1013.00,Armored Assault Vehicle Officers,55-1013.00,Armored Assault Vehicle Officers
+55-1014.00,Artillery and Missile Officers,55-1014.00,Artillery and Missile Officers
+55-1015.00,Command and Control Center Officers,55-1015.00,Command and Control Center Officers
+55-1016.00,Infantry Officers,55-1016.00,Infantry Officers
+55-1017.00,Special Forces Officers,55-1017.00,Special Forces Officers
+55-1019.99,"Military Officer Special and Tactical Operations Leaders/Managers, All Other",55-1019.99,"Military Officer Special and Tactical Operations Leaders/Managers, All Other"
+55-2011.00,First-Line Supervisors/Managers of Air Crew Members,55-2011.00,First-Line Supervisors/Managers of Air Crew Members
+55-2012.00,First-Line Supervisors/Managers of Weapons Specialists/Crew Members,55-2012.00,First-Line Supervisors/Managers of Weapons Specialists/Crew Members
+55-2013.00,First-Line Supervisors/Managers of All Other Tactical Operations Specialists,55-2013.00,First-Line Supervisors/Managers of All Other Tactical Operations Specialists
+55-3011.00,Air Crew Members,55-3011.00,Air Crew Members
+55-3012.00,Aircraft Launch and Recovery Specialists,55-3012.00,Aircraft Launch and Recovery Specialists
+55-3013.00,Armored Assault Vehicle Crew Members,55-3013.00,Armored Assault Vehicle Crew Members
+55-3014.00,Artillery and Missile Crew Members,55-3014.00,Artillery and Missile Crew Members
+55-3015.00,Command and Control Center Specialists,55-3015.00,Command and Control Center Specialists
+55-3016.00,Infantry,55-3016.00,Infantry
+55-3017.00,Radar and Sonar Technicians,55-3017.00,Radar and Sonar Technicians
+55-3018.00,Special Forces,55-3018.00,Special Forces
+55-3019.99,"Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members, All Other",55-3019.99,"Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members, All Other"

--- a/lib/tasks/files/2006_to_2009_Crosswalk.csv
+++ b/lib/tasks/files/2006_to_2009_Crosswalk.csv
@@ -1,0 +1,950 @@
+O*NET-SOC 2006 Code,O*NET-SOC 2006 Title,O*NET-SOC 2009 Code,O*NET-SOC 2009 Title
+11-1011.00,Chief Executives,11-1011.00,Chief Executives
+11-1021.00,General and Operations Managers,11-1021.00,General and Operations Managers
+11-1031.00,Legislators,11-1031.00,Legislators
+11-2011.00,Advertising and Promotions Managers,11-2011.00,Advertising and Promotions Managers
+11-2021.00,Marketing Managers,11-2021.00,Marketing Managers
+11-2022.00,Sales Managers,11-2022.00,Sales Managers
+11-2031.00,Public Relations Managers,11-2031.00,Public Relations Managers
+11-3011.00,Administrative Services Managers,11-3011.00,Administrative Services Managers
+11-3021.00,Computer and Information Systems Managers,11-3021.00,Computer and Information Systems Managers
+11-3031.00,Financial Managers,11-3031.00,Financial Managers
+11-3031.01,Treasurers and Controllers,11-3031.01,Treasurers and Controllers
+11-3031.02,"Financial Managers, Branch or Department",11-3031.02,"Financial Managers, Branch or Department"
+11-3040.00,Human Resources Managers,11-3040.00,Human Resources Managers
+11-3041.00,Compensation and Benefits Managers,11-3041.00,Compensation and Benefits Managers
+11-3042.00,Training and Development Managers,11-3042.00,Training and Development Managers
+11-3049.99,"Human Resources Managers, All Other",11-3049.00,"Human Resources Managers, All Other"
+11-3051.00,Industrial Production Managers,11-3051.00,Industrial Production Managers
+11-3061.00,Purchasing Managers,11-3061.00,Purchasing Managers
+11-3071.00,"Transportation, Storage, and Distribution Managers",11-3071.00,"Transportation, Storage, and Distribution Managers"
+11-3071.01,Transportation Managers,11-3071.01,Transportation Managers
+11-3071.02,Storage and Distribution Managers,11-3071.02,Storage and Distribution Managers
+11-9011.00,"Farm, Ranch, and Other Agricultural Managers",11-9011.00,"Farm, Ranch, and Other Agricultural Managers"
+11-9011.01,Nursery and Greenhouse Managers,11-9011.01,Nursery and Greenhouse Managers
+11-9011.02,Crop and Livestock Managers,11-9011.02,Crop and Livestock Managers
+11-9011.03,Aquacultural Managers,11-9011.03,Aquacultural Managers
+11-9012.00,Farmers and Ranchers,11-9012.00,Farmers and Ranchers
+11-9021.00,Construction Managers,11-9021.00,Construction Managers
+11-9031.00,"Education Administrators, Preschool and Child Care Center/Program",11-9031.00,"Education Administrators, Preschool and Child Care Center/Program"
+11-9032.00,"Education Administrators, Elementary and Secondary School",11-9032.00,"Education Administrators, Elementary and Secondary School"
+11-9033.00,"Education Administrators, Postsecondary",11-9033.00,"Education Administrators, Postsecondary"
+11-9039.99,"Education Administrators, All Other",11-9039.00,"Education Administrators, All Other"
+11-9041.00,Engineering Managers,11-9041.00,Engineering Managers
+11-9051.00,Food Service Managers,11-9051.00,Food Service Managers
+11-9061.00,Funeral Directors,11-9061.00,Funeral Directors
+11-9071.00,Gaming Managers,11-9071.00,Gaming Managers
+11-9081.00,Lodging Managers,11-9081.00,Lodging Managers
+11-9111.00,Medical and Health Services Managers,11-9111.00,Medical and Health Services Managers
+11-9121.00,Natural Sciences Managers,11-9121.00,Natural Sciences Managers
+11-9131.00,Postmasters and Mail Superintendents,11-9131.00,Postmasters and Mail Superintendents
+11-9141.00,"Property, Real Estate, and Community Association Managers",11-9141.00,"Property, Real Estate, and Community Association Managers"
+11-9151.00,Social and Community Service Managers,11-9151.00,Social and Community Service Managers
+11-9199.99,"Managers, All Other",11-9199.00,"Managers, All Other"
+13-1011.00,"Agents and Business Managers of Artists, Performers, and Athletes",13-1011.00,"Agents and Business Managers of Artists, Performers, and Athletes"
+13-1021.00,"Purchasing Agents and Buyers, Farm Products",13-1021.00,"Purchasing Agents and Buyers, Farm Products"
+13-1022.00,"Wholesale and Retail Buyers, Except Farm Products",13-1022.00,"Wholesale and Retail Buyers, Except Farm Products"
+13-1023.00,"Purchasing Agents, Except Wholesale, Retail, and Farm Products",13-1023.00,"Purchasing Agents, Except Wholesale, Retail, and Farm Products"
+13-1031.00,"Claims Adjusters, Examiners, and Investigators",13-1031.00,"Claims Adjusters, Examiners, and Investigators"
+13-1031.01,"Claims Examiners, Property and Casualty Insurance",13-1031.01,"Claims Examiners, Property and Casualty Insurance"
+13-1031.02,"Insurance Adjusters, Examiners, and Investigators",13-1031.02,"Insurance Adjusters, Examiners, and Investigators"
+13-1032.00,"Insurance Appraisers, Auto Damage",13-1032.00,"Insurance Appraisers, Auto Damage"
+13-1041.00,"Compliance Officers, Except Agriculture, Construction, Health and Safety, and Transportation",13-1041.00,"Compliance Officers, Except Agriculture, Construction, Health and Safety, and Transportation"
+13-1041.01,Environmental Compliance Inspectors,13-1041.01,Environmental Compliance Inspectors
+13-1041.02,Licensing Examiners and Inspectors,13-1041.02,Licensing Examiners and Inspectors
+13-1041.03,Equal Opportunity Representatives and Officers,13-1041.03,Equal Opportunity Representatives and Officers
+13-1041.04,Government Property Inspectors and Investigators,13-1041.04,Government Property Inspectors and Investigators
+13-1041.06,Coroners,13-1041.06,Coroners
+13-1051.00,Cost Estimators,13-1051.00,Cost Estimators
+13-1061.00,Emergency Management Specialists,13-1061.00,Emergency Management Specialists
+13-1071.00,"Employment, Recruitment, and Placement Specialists",13-1071.00,"Employment, Recruitment, and Placement Specialists"
+13-1071.01,Employment Interviewers,13-1071.01,Employment Interviewers
+13-1071.02,Personnel Recruiters,13-1071.02,Personnel Recruiters
+13-1072.00,"Compensation, Benefits, and Job Analysis Specialists",13-1072.00,"Compensation, Benefits, and Job Analysis Specialists"
+13-1073.00,Training and Development Specialists,13-1073.00,Training and Development Specialists
+13-1079.99,"Human Resources, Training, and Labor Relations Specialists, All Other",13-1079.00,"Human Resources, Training, and Labor Relations Specialists, All Other"
+13-1081.00,Logisticians,13-1081.00,Logisticians
+13-1111.00,Management Analysts,13-1111.00,Management Analysts
+13-1121.00,Meeting and Convention Planners,13-1121.00,Meeting and Convention Planners
+13-1199.99,"Business Operations Specialists, All Other",13-1199.00,"Business Operations Specialists, All Other"
+13-2011.00,Accountants and Auditors,13-2011.00,Accountants and Auditors
+13-2011.01,Accountants,13-2011.01,Accountants
+13-2011.02,Auditors,13-2011.02,Auditors
+13-2021.00,Appraisers and Assessors of Real Estate,13-2021.00,Appraisers and Assessors of Real Estate
+13-2021.01,Assessors,13-2021.01,Assessors
+13-2021.02,"Appraisers, Real Estate",13-2021.02,"Appraisers, Real Estate"
+13-2031.00,Budget Analysts,13-2031.00,Budget Analysts
+13-2041.00,Credit Analysts,13-2041.00,Credit Analysts
+13-2051.00,Financial Analysts,13-2051.00,Financial Analysts
+13-2052.00,Personal Financial Advisors,13-2052.00,Personal Financial Advisors
+13-2053.00,Insurance Underwriters,13-2053.00,Insurance Underwriters
+13-2061.00,Financial Examiners,13-2061.00,Financial Examiners
+13-2071.00,Loan Counselors,13-2071.00,Loan Counselors
+13-2072.00,Loan Officers,13-2072.00,Loan Officers
+13-2081.00,"Tax Examiners, Collectors, and Revenue Agents",13-2081.00,"Tax Examiners, Collectors, and Revenue Agents"
+13-2082.00,Tax Preparers,13-2082.00,Tax Preparers
+13-2099.99,"Financial Specialists, All Other",13-2099.00,"Financial Specialists, All Other"
+15-1011.00,"Computer and Information Scientists, Research",15-1011.00,"Computer and Information Scientists, Research"
+15-1021.00,Computer Programmers,15-1021.00,Computer Programmers
+15-1031.00,"Computer Software Engineers, Applications",15-1031.00,"Computer Software Engineers, Applications"
+15-1032.00,"Computer Software Engineers, Systems Software",15-1032.00,"Computer Software Engineers, Systems Software"
+15-1041.00,Computer Support Specialists,15-1041.00,Computer Support Specialists
+15-1051.00,Computer Systems Analysts,15-1051.00,Computer Systems Analysts
+15-1061.00,Database Administrators,15-1061.00,Database Administrators
+15-1071.00,Network and Computer Systems Administrators,15-1071.00,Network and Computer Systems Administrators
+15-1071.01,Computer Security Specialists,15-1071.01,Computer Security Specialists
+15-1081.00,Network Systems and Data Communications Analysts,15-1081.00,Network Systems and Data Communications Analysts
+15-1099.01,Software Quality Assurance Engineers and Testers,15-1099.01,Software Quality Assurance Engineers and Testers
+15-1099.02,Computer Systems Engineers/Architects,15-1099.02,Computer Systems Engineers/Architects
+15-1099.03,Network Designers,15-1099.03,Network Designers
+15-1099.04,Web Developers,15-1099.04,Web Developers
+15-1099.05,Web Administrators,15-1099.05,Web Administrators
+15-1099.99,"Computer Specialists, All Other",15-1099.00,"Computer Specialists, All Other"
+15-2011.00,Actuaries,15-2011.00,Actuaries
+15-2021.00,Mathematicians,15-2021.00,Mathematicians
+15-2031.00,Operations Research Analysts,15-2031.00,Operations Research Analysts
+15-2041.00,Statisticians,15-2041.00,Statisticians
+15-2091.00,Mathematical Technicians,15-2091.00,Mathematical Technicians
+15-2099.99,"Mathematical Science Occupations, All Other",15-2099.00,"Mathematical Science Occupations, All Other"
+17-1011.00,"Architects, Except Landscape and Naval",17-1011.00,"Architects, Except Landscape and Naval"
+17-1012.00,Landscape Architects,17-1012.00,Landscape Architects
+17-1021.00,Cartographers and Photogrammetrists,17-1021.00,Cartographers and Photogrammetrists
+17-1022.00,Surveyors,17-1022.00,Surveyors
+17-2011.00,Aerospace Engineers,17-2011.00,Aerospace Engineers
+17-2021.00,Agricultural Engineers,17-2021.00,Agricultural Engineers
+17-2031.00,Biomedical Engineers,17-2031.00,Biomedical Engineers
+17-2041.00,Chemical Engineers,17-2041.00,Chemical Engineers
+17-2051.00,Civil Engineers,17-2051.00,Civil Engineers
+17-2061.00,Computer Hardware Engineers,17-2061.00,Computer Hardware Engineers
+17-2071.00,Electrical Engineers,17-2071.00,Electrical Engineers
+17-2072.00,"Electronics Engineers, Except Computer",17-2072.00,"Electronics Engineers, Except Computer"
+17-2081.00,Environmental Engineers,17-2081.00,Environmental Engineers
+17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors",17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors"
+17-2111.01,Industrial Safety and Health Engineers,17-2111.01,Industrial Safety and Health Engineers
+17-2111.02,Fire-Prevention and Protection Engineers,17-2111.02,Fire-Prevention and Protection Engineers
+17-2111.03,Product Safety Engineers,17-2111.03,Product Safety Engineers
+17-2112.00,Industrial Engineers,17-2112.00,Industrial Engineers
+17-2121.00,Marine Engineers and Naval Architects,17-2121.00,Marine Engineers and Naval Architects
+17-2121.01,Marine Engineers,17-2121.01,Marine Engineers
+17-2121.02,Marine Architects,17-2121.02,Marine Architects
+17-2131.00,Materials Engineers,17-2131.00,Materials Engineers
+17-2141.00,Mechanical Engineers,17-2141.00,Mechanical Engineers
+17-2151.00,"Mining and Geological Engineers, Including Mining Safety Engineers",17-2151.00,"Mining and Geological Engineers, Including Mining Safety Engineers"
+17-2161.00,Nuclear Engineers,17-2161.00,Nuclear Engineers
+17-2171.00,Petroleum Engineers,17-2171.00,Petroleum Engineers
+17-2199.99,"Engineers, All Other",17-2199.00,"Engineers, All Other"
+17-3011.00,Architectural and Civil Drafters,17-3011.00,Architectural and Civil Drafters
+17-3011.01,Architectural Drafters,17-3011.01,Architectural Drafters
+17-3011.02,Civil Drafters,17-3011.02,Civil Drafters
+17-3012.00,Electrical and Electronics Drafters,17-3012.00,Electrical and Electronics Drafters
+17-3012.01,Electronic Drafters,17-3012.01,Electronic Drafters
+17-3012.02,Electrical Drafters,17-3012.02,Electrical Drafters
+17-3013.00,Mechanical Drafters,17-3013.00,Mechanical Drafters
+17-3019.99,"Drafters, All Other",17-3019.00,"Drafters, All Other"
+17-3021.00,Aerospace Engineering and Operations Technicians,17-3021.00,Aerospace Engineering and Operations Technicians
+17-3022.00,Civil Engineering Technicians,17-3022.00,Civil Engineering Technicians
+17-3023.00,Electrical and Electronic Engineering Technicians,17-3023.00,Electrical and Electronic Engineering Technicians
+17-3023.01,Electronics Engineering Technicians,17-3023.01,Electronics Engineering Technicians
+17-3023.03,Electrical Engineering Technicians,17-3023.03,Electrical Engineering Technicians
+17-3024.00,Electro-Mechanical Technicians,17-3024.00,Electro-Mechanical Technicians
+17-3025.00,Environmental Engineering Technicians,17-3025.00,Environmental Engineering Technicians
+17-3026.00,Industrial Engineering Technicians,17-3026.00,Industrial Engineering Technicians
+17-3027.00,Mechanical Engineering Technicians,17-3027.00,Mechanical Engineering Technicians
+17-3029.99,"Engineering Technicians, Except Drafters, All Other",17-3029.00,"Engineering Technicians, Except Drafters, All Other"
+17-3031.00,Surveying and Mapping Technicians,17-3031.00,Surveying and Mapping Technicians
+17-3031.01,Surveying Technicians,17-3031.01,Surveying Technicians
+17-3031.02,Mapping Technicians,17-3031.02,Mapping Technicians
+19-1011.00,Animal Scientists,19-1011.00,Animal Scientists
+19-1012.00,Food Scientists and Technologists,19-1012.00,Food Scientists and Technologists
+19-1013.00,Soil and Plant Scientists,19-1013.00,Soil and Plant Scientists
+19-1020.01,Biologists,19-1020.01,Biologists
+19-1021.00,Biochemists and Biophysicists,19-1021.00,Biochemists and Biophysicists
+19-1022.00,Microbiologists,19-1022.00,Microbiologists
+19-1023.00,Zoologists and Wildlife Biologists,19-1023.00,Zoologists and Wildlife Biologists
+19-1029.99,"Biological Scientists, All Other",19-1029.00,"Biological Scientists, All Other"
+19-1031.00,Conservation Scientists,19-1031.00,Conservation Scientists
+19-1031.01,Soil and Water Conservationists,19-1031.01,Soil and Water Conservationists
+19-1031.02,Range Managers,19-1031.02,Range Managers
+19-1031.03,Park Naturalists,19-1031.03,Park Naturalists
+19-1032.00,Foresters,19-1032.00,Foresters
+19-1041.00,Epidemiologists,19-1041.00,Epidemiologists
+19-1042.00,"Medical Scientists, Except Epidemiologists",19-1042.00,"Medical Scientists, Except Epidemiologists"
+19-1099.99,"Life Scientists, All Other",19-1099.00,"Life Scientists, All Other"
+19-2011.00,Astronomers,19-2011.00,Astronomers
+19-2012.00,Physicists,19-2012.00,Physicists
+19-2021.00,Atmospheric and Space Scientists,19-2021.00,Atmospheric and Space Scientists
+19-2031.00,Chemists,19-2031.00,Chemists
+19-2032.00,Materials Scientists,19-2032.00,Materials Scientists
+19-2041.00,"Environmental Scientists and Specialists, Including Health",19-2041.00,"Environmental Scientists and Specialists, Including Health"
+19-2042.00,"Geoscientists, Except Hydrologists and Geographers",19-2042.00,"Geoscientists, Except Hydrologists and Geographers"
+19-2043.00,Hydrologists,19-2043.00,Hydrologists
+19-2099.99,"Physical Scientists, All Other",19-2099.00,"Physical Scientists, All Other"
+19-3011.00,Economists,19-3011.00,Economists
+19-3021.00,Market Research Analysts,19-3021.00,Market Research Analysts
+19-3022.00,Survey Researchers,19-3022.00,Survey Researchers
+19-3031.00,"Clinical, Counseling, and School Psychologists",19-3031.00,"Clinical, Counseling, and School Psychologists"
+19-3031.01,School Psychologists,19-3031.01,School Psychologists
+19-3031.02,Clinical Psychologists,19-3031.02,Clinical Psychologists
+19-3031.03,Counseling Psychologists,19-3031.03,Counseling Psychologists
+19-3032.00,Industrial-Organizational Psychologists,19-3032.00,Industrial-Organizational Psychologists
+19-3039.99,"Psychologists, All Other",19-3039.00,"Psychologists, All Other"
+19-3041.00,Sociologists,19-3041.00,Sociologists
+19-3051.00,Urban and Regional Planners,19-3051.00,Urban and Regional Planners
+19-3091.00,Anthropologists and Archeologists,19-3091.00,Anthropologists and Archeologists
+19-3091.01,Anthropologists,19-3091.01,Anthropologists
+19-3091.02,Archeologists,19-3091.02,Archeologists
+19-3092.00,Geographers,19-3092.00,Geographers
+19-3093.00,Historians,19-3093.00,Historians
+19-3094.00,Political Scientists,19-3094.00,Political Scientists
+19-3099.99,"Social Scientists and Related Workers, All Other",19-3099.00,"Social Scientists and Related Workers, All Other"
+19-4011.00,Agricultural and Food Science Technicians,19-4011.00,Agricultural and Food Science Technicians
+19-4011.01,Agricultural Technicians,19-4011.01,Agricultural Technicians
+19-4011.02,Food Science Technicians,19-4011.02,Food Science Technicians
+19-4021.00,Biological Technicians,19-4021.00,Biological Technicians
+19-4031.00,Chemical Technicians,19-4031.00,Chemical Technicians
+19-4041.00,Geological and Petroleum Technicians,19-4041.00,Geological and Petroleum Technicians
+19-4041.01,Geophysical Data Technicians,19-4041.01,Geophysical Data Technicians
+19-4041.02,Geological Sample Test Technicians,19-4041.02,Geological Sample Test Technicians
+19-4051.00,Nuclear Technicians,19-4051.00,Nuclear Technicians
+19-4051.01,Nuclear Equipment Operation Technicians,19-4051.01,Nuclear Equipment Operation Technicians
+19-4051.02,Nuclear Monitoring Technicians,19-4051.02,Nuclear Monitoring Technicians
+19-4061.00,Social Science Research Assistants,19-4061.00,Social Science Research Assistants
+19-4061.01,City and Regional Planning Aides,19-4061.01,City and Regional Planning Aides
+19-4091.00,"Environmental Science and Protection Technicians, Including Health",19-4091.00,"Environmental Science and Protection Technicians, Including Health"
+19-4092.00,Forensic Science Technicians,19-4092.00,Forensic Science Technicians
+19-4093.00,Forest and Conservation Technicians,19-4093.00,Forest and Conservation Technicians
+19-4099.99,"Life, Physical, and Social Science Technicians, All Other",19-4099.00,"Life, Physical, and Social Science Technicians, All Other"
+21-1011.00,Substance Abuse and Behavioral Disorder Counselors,21-1011.00,Substance Abuse and Behavioral Disorder Counselors
+21-1012.00,"Educational, Vocational, and School Counselors",21-1012.00,"Educational, Vocational, and School Counselors"
+21-1013.00,Marriage and Family Therapists,21-1013.00,Marriage and Family Therapists
+21-1014.00,Mental Health Counselors,21-1014.00,Mental Health Counselors
+21-1015.00,Rehabilitation Counselors,21-1015.00,Rehabilitation Counselors
+21-1019.99,"Counselors, All Other",21-1019.00,"Counselors, All Other"
+21-1021.00,"Child, Family, and School Social Workers",21-1021.00,"Child, Family, and School Social Workers"
+21-1022.00,Medical and Public Health Social Workers,21-1022.00,Medical and Public Health Social Workers
+21-1023.00,Mental Health and Substance Abuse Social Workers,21-1023.00,Mental Health and Substance Abuse Social Workers
+21-1029.99,"Social Workers, All Other",21-1029.00,"Social Workers, All Other"
+21-1091.00,Health Educators,21-1091.00,Health Educators
+21-1092.00,Probation Officers and Correctional Treatment Specialists,21-1092.00,Probation Officers and Correctional Treatment Specialists
+21-1093.00,Social and Human Service Assistants,21-1093.00,Social and Human Service Assistants
+21-1099.99,"Community and Social Service Specialists, All Other",21-1099.00,"Community and Social Service Specialists, All Other"
+21-2011.00,Clergy,21-2011.00,Clergy
+21-2021.00,"Directors, Religious Activities and Education",21-2021.00,"Directors, Religious Activities and Education"
+21-2099.99,"Religious Workers, All Other",21-2099.00,"Religious Workers, All Other"
+23-1011.00,Lawyers,23-1011.00,Lawyers
+23-1021.00,"Administrative Law Judges, Adjudicators, and Hearing Officers",23-1021.00,"Administrative Law Judges, Adjudicators, and Hearing Officers"
+23-1022.00,"Arbitrators, Mediators, and Conciliators",23-1022.00,"Arbitrators, Mediators, and Conciliators"
+23-1023.00,"Judges, Magistrate Judges, and Magistrates",23-1023.00,"Judges, Magistrate Judges, and Magistrates"
+23-2011.00,Paralegals and Legal Assistants,23-2011.00,Paralegals and Legal Assistants
+23-2091.00,Court Reporters,23-2091.00,Court Reporters
+23-2092.00,Law Clerks,23-2092.00,Law Clerks
+23-2093.00,"Title Examiners, Abstractors, and Searchers",23-2093.00,"Title Examiners, Abstractors, and Searchers"
+23-2099.99,"Legal Support Workers, All Other",23-2099.00,"Legal Support Workers, All Other"
+25-1011.00,"Business Teachers, Postsecondary",25-1011.00,"Business Teachers, Postsecondary"
+25-1021.00,"Computer Science Teachers, Postsecondary",25-1021.00,"Computer Science Teachers, Postsecondary"
+25-1022.00,"Mathematical Science Teachers, Postsecondary",25-1022.00,"Mathematical Science Teachers, Postsecondary"
+25-1031.00,"Architecture Teachers, Postsecondary",25-1031.00,"Architecture Teachers, Postsecondary"
+25-1032.00,"Engineering Teachers, Postsecondary",25-1032.00,"Engineering Teachers, Postsecondary"
+25-1041.00,"Agricultural Sciences Teachers, Postsecondary",25-1041.00,"Agricultural Sciences Teachers, Postsecondary"
+25-1042.00,"Biological Science Teachers, Postsecondary",25-1042.00,"Biological Science Teachers, Postsecondary"
+25-1043.00,"Forestry and Conservation Science Teachers, Postsecondary",25-1043.00,"Forestry and Conservation Science Teachers, Postsecondary"
+25-1051.00,"Atmospheric, Earth, Marine, and Space Sciences Teachers, Postsecondary",25-1051.00,"Atmospheric, Earth, Marine, and Space Sciences Teachers, Postsecondary"
+25-1052.00,"Chemistry Teachers, Postsecondary",25-1052.00,"Chemistry Teachers, Postsecondary"
+25-1053.00,"Environmental Science Teachers, Postsecondary",25-1053.00,"Environmental Science Teachers, Postsecondary"
+25-1054.00,"Physics Teachers, Postsecondary",25-1054.00,"Physics Teachers, Postsecondary"
+25-1061.00,"Anthropology and Archeology Teachers, Postsecondary",25-1061.00,"Anthropology and Archeology Teachers, Postsecondary"
+25-1062.00,"Area, Ethnic, and Cultural Studies Teachers, Postsecondary",25-1062.00,"Area, Ethnic, and Cultural Studies Teachers, Postsecondary"
+25-1063.00,"Economics Teachers, Postsecondary",25-1063.00,"Economics Teachers, Postsecondary"
+25-1064.00,"Geography Teachers, Postsecondary",25-1064.00,"Geography Teachers, Postsecondary"
+25-1065.00,"Political Science Teachers, Postsecondary",25-1065.00,"Political Science Teachers, Postsecondary"
+25-1066.00,"Psychology Teachers, Postsecondary",25-1066.00,"Psychology Teachers, Postsecondary"
+25-1067.00,"Sociology Teachers, Postsecondary",25-1067.00,"Sociology Teachers, Postsecondary"
+25-1069.99,"Social Sciences Teachers, Postsecondary, All Other",25-1069.00,"Social Sciences Teachers, Postsecondary, All Other"
+25-1071.00,"Health Specialties Teachers, Postsecondary",25-1071.00,"Health Specialties Teachers, Postsecondary"
+25-1072.00,"Nursing Instructors and Teachers, Postsecondary",25-1072.00,"Nursing Instructors and Teachers, Postsecondary"
+25-1081.00,"Education Teachers, Postsecondary",25-1081.00,"Education Teachers, Postsecondary"
+25-1082.00,"Library Science Teachers, Postsecondary",25-1082.00,"Library Science Teachers, Postsecondary"
+25-1111.00,"Criminal Justice and Law Enforcement Teachers, Postsecondary",25-1111.00,"Criminal Justice and Law Enforcement Teachers, Postsecondary"
+25-1112.00,"Law Teachers, Postsecondary",25-1112.00,"Law Teachers, Postsecondary"
+25-1113.00,"Social Work Teachers, Postsecondary",25-1113.00,"Social Work Teachers, Postsecondary"
+25-1121.00,"Art, Drama, and Music Teachers, Postsecondary",25-1121.00,"Art, Drama, and Music Teachers, Postsecondary"
+25-1122.00,"Communications Teachers, Postsecondary",25-1122.00,"Communications Teachers, Postsecondary"
+25-1123.00,"English Language and Literature Teachers, Postsecondary",25-1123.00,"English Language and Literature Teachers, Postsecondary"
+25-1124.00,"Foreign Language and Literature Teachers, Postsecondary",25-1124.00,"Foreign Language and Literature Teachers, Postsecondary"
+25-1125.00,"History Teachers, Postsecondary",25-1125.00,"History Teachers, Postsecondary"
+25-1126.00,"Philosophy and Religion Teachers, Postsecondary",25-1126.00,"Philosophy and Religion Teachers, Postsecondary"
+25-1191.00,Graduate Teaching Assistants,25-1191.00,Graduate Teaching Assistants
+25-1192.00,"Home Economics Teachers, Postsecondary",25-1192.00,"Home Economics Teachers, Postsecondary"
+25-1193.00,"Recreation and Fitness Studies Teachers, Postsecondary",25-1193.00,"Recreation and Fitness Studies Teachers, Postsecondary"
+25-1194.00,"Vocational Education Teachers, Postsecondary",25-1194.00,"Vocational Education Teachers, Postsecondary"
+25-1199.99,"Postsecondary Teachers, All Other",25-1199.00,"Postsecondary Teachers, All Other"
+25-2011.00,"Preschool Teachers, Except Special Education",25-2011.00,"Preschool Teachers, Except Special Education"
+25-2012.00,"Kindergarten Teachers, Except Special Education",25-2012.00,"Kindergarten Teachers, Except Special Education"
+25-2021.00,"Elementary School Teachers, Except Special Education",25-2021.00,"Elementary School Teachers, Except Special Education"
+25-2022.00,"Middle School Teachers, Except Special and Vocational Education",25-2022.00,"Middle School Teachers, Except Special and Vocational Education"
+25-2023.00,"Vocational Education Teachers, Middle School",25-2023.00,"Vocational Education Teachers, Middle School"
+25-2031.00,"Secondary School Teachers, Except Special and Vocational Education",25-2031.00,"Secondary School Teachers, Except Special and Vocational Education"
+25-2032.00,"Vocational Education Teachers, Secondary School",25-2032.00,"Vocational Education Teachers, Secondary School"
+25-2041.00,"Special Education Teachers, Preschool, Kindergarten, and Elementary School",25-2041.00,"Special Education Teachers, Preschool, Kindergarten, and Elementary School"
+25-2042.00,"Special Education Teachers, Middle School",25-2042.00,"Special Education Teachers, Middle School"
+25-2043.00,"Special Education Teachers, Secondary School",25-2043.00,"Special Education Teachers, Secondary School"
+25-3011.00,"Adult Literacy, Remedial Education, and GED Teachers and Instructors",25-3011.00,"Adult Literacy, Remedial Education, and GED Teachers and Instructors"
+25-3021.00,Self-Enrichment Education Teachers,25-3021.00,Self-Enrichment Education Teachers
+25-3099.99,"Teachers and Instructors, All Other",25-3099.00,"Teachers and Instructors, All Other"
+25-4011.00,Archivists,25-4011.00,Archivists
+25-4012.00,Curators,25-4012.00,Curators
+25-4013.00,Museum Technicians and Conservators,25-4013.00,Museum Technicians and Conservators
+25-4021.00,Librarians,25-4021.00,Librarians
+25-4031.00,Library Technicians,25-4031.00,Library Technicians
+25-9011.00,Audio-Visual Collections Specialists,25-9011.00,Audio-Visual Collections Specialists
+25-9021.00,Farm and Home Management Advisors,25-9021.00,Farm and Home Management Advisors
+25-9031.00,Instructional Coordinators,25-9031.00,Instructional Coordinators
+25-9041.00,Teacher Assistants,25-9041.00,Teacher Assistants
+25-9099.99,"Education, Training, and Library Workers, All Other",25-9099.00,"Education, Training, and Library Workers, All Other"
+27-1011.00,Art Directors,27-1011.00,Art Directors
+27-1012.00,Craft Artists,27-1012.00,Craft Artists
+27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators",27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators"
+27-1014.00,Multi-Media Artists and Animators,27-1014.00,Multi-Media Artists and Animators
+27-1019.99,"Artists and Related Workers, All Other",27-1019.00,"Artists and Related Workers, All Other"
+27-1021.00,Commercial and Industrial Designers,27-1021.00,Commercial and Industrial Designers
+27-1022.00,Fashion Designers,27-1022.00,Fashion Designers
+27-1023.00,Floral Designers,27-1023.00,Floral Designers
+27-1024.00,Graphic Designers,27-1024.00,Graphic Designers
+27-1025.00,Interior Designers,27-1025.00,Interior Designers
+27-1026.00,Merchandise Displayers and Window Trimmers,27-1026.00,Merchandise Displayers and Window Trimmers
+27-1027.00,Set and Exhibit Designers,27-1027.00,Set and Exhibit Designers
+27-1029.99,"Designers, All Other",27-1029.00,"Designers, All Other"
+27-2011.00,Actors,27-2011.00,Actors
+27-2012.00,Producers and Directors,27-2012.00,Producers and Directors
+27-2012.01,Producers,27-2012.01,Producers
+27-2012.02,"Directors- Stage, Motion Pictures, Television, and Radio",27-2012.02,"Directors- Stage, Motion Pictures, Television, and Radio"
+27-2012.03,Program Directors,27-2012.03,Program Directors
+27-2012.04,Talent Directors,27-2012.04,Talent Directors
+27-2012.05,Technical Directors/Managers,27-2012.05,Technical Directors/Managers
+27-2021.00,Athletes and Sports Competitors,27-2021.00,Athletes and Sports Competitors
+27-2022.00,Coaches and Scouts,27-2022.00,Coaches and Scouts
+27-2023.00,"Umpires, Referees, and Other Sports Officials",27-2023.00,"Umpires, Referees, and Other Sports Officials"
+27-2031.00,Dancers,27-2031.00,Dancers
+27-2032.00,Choreographers,27-2032.00,Choreographers
+27-2041.00,Music Directors and Composers,27-2041.00,Music Directors and Composers
+27-2041.01,Music Directors,27-2041.01,Music Directors
+27-2041.04,Music Composers and Arrangers,27-2041.04,Music Composers and Arrangers
+27-2042.00,Musicians and Singers,27-2042.00,Musicians and Singers
+27-2042.01,Singers,27-2042.01,Singers
+27-2042.02,"Musicians, Instrumental",27-2042.02,"Musicians, Instrumental"
+27-2099.99,"Entertainers and Performers, Sports and Related Workers, All Other",27-2099.00,"Entertainers and Performers, Sports and Related Workers, All Other"
+27-3011.00,Radio and Television Announcers,27-3011.00,Radio and Television Announcers
+27-3012.00,Public Address System and Other Announcers,27-3012.00,Public Address System and Other Announcers
+27-3021.00,Broadcast News Analysts,27-3021.00,Broadcast News Analysts
+27-3022.00,Reporters and Correspondents,27-3022.00,Reporters and Correspondents
+27-3031.00,Public Relations Specialists,27-3031.00,Public Relations Specialists
+27-3041.00,Editors,27-3041.00,Editors
+27-3042.00,Technical Writers,27-3042.00,Technical Writers
+27-3043.00,Writers and Authors,27-3043.00,Writers and Authors
+27-3043.04,Copy Writers,27-3043.04,Copy Writers
+27-3043.05,"Poets, Lyricists and Creative Writers",27-3043.05,"Poets, Lyricists and Creative Writers"
+27-3091.00,Interpreters and Translators,27-3091.00,Interpreters and Translators
+27-3099.99,"Media and Communication Workers, All Other",27-3099.00,"Media and Communication Workers, All Other"
+27-4011.00,Audio and Video Equipment Technicians,27-4011.00,Audio and Video Equipment Technicians
+27-4012.00,Broadcast Technicians,27-4012.00,Broadcast Technicians
+27-4013.00,Radio Operators,27-4013.00,Radio Operators
+27-4014.00,Sound Engineering Technicians,27-4014.00,Sound Engineering Technicians
+27-4021.00,Photographers,27-4021.00,Photographers
+27-4031.00,"Camera Operators, Television, Video, and Motion Picture",27-4031.00,"Camera Operators, Television, Video, and Motion Picture"
+27-4032.00,Film and Video Editors,27-4032.00,Film and Video Editors
+27-4099.99,"Media and Communication Equipment Workers, All Other",27-4099.00,"Media and Communication Equipment Workers, All Other"
+29-1011.00,Chiropractors,29-1011.00,Chiropractors
+29-1021.00,"Dentists, General",29-1021.00,"Dentists, General"
+29-1022.00,Oral and Maxillofacial Surgeons,29-1022.00,Oral and Maxillofacial Surgeons
+29-1023.00,Orthodontists,29-1023.00,Orthodontists
+29-1024.00,Prosthodontists,29-1024.00,Prosthodontists
+29-1029.99,"Dentists, All Other Specialists",29-1029.00,"Dentists, All Other Specialists"
+29-1031.00,Dietitians and Nutritionists,29-1031.00,Dietitians and Nutritionists
+29-1041.00,Optometrists,29-1041.00,Optometrists
+29-1051.00,Pharmacists,29-1051.00,Pharmacists
+29-1061.00,Anesthesiologists,29-1061.00,Anesthesiologists
+29-1062.00,Family and General Practitioners,29-1062.00,Family and General Practitioners
+29-1063.00,"Internists, General",29-1063.00,"Internists, General"
+29-1064.00,Obstetricians and Gynecologists,29-1064.00,Obstetricians and Gynecologists
+29-1065.00,"Pediatricians, General",29-1065.00,"Pediatricians, General"
+29-1066.00,Psychiatrists,29-1066.00,Psychiatrists
+29-1067.00,Surgeons,29-1067.00,Surgeons
+29-1069.99,"Physicians and Surgeons, All Other",29-1069.00,"Physicians and Surgeons, All Other"
+29-1071.00,Physician Assistants,29-1071.00,Physician Assistants
+29-1081.00,Podiatrists,29-1081.00,Podiatrists
+29-1111.00,Registered Nurses,29-1111.00,Registered Nurses
+29-1121.00,Audiologists,29-1121.00,Audiologists
+29-1122.00,Occupational Therapists,29-1122.00,Occupational Therapists
+29-1123.00,Physical Therapists,29-1123.00,Physical Therapists
+29-1124.00,Radiation Therapists,29-1124.00,Radiation Therapists
+29-1125.00,Recreational Therapists,29-1125.00,Recreational Therapists
+29-1126.00,Respiratory Therapists,29-1126.00,Respiratory Therapists
+29-1127.00,Speech-Language Pathologists,29-1127.00,Speech-Language Pathologists
+29-1129.99,"Therapists, All Other",29-1129.00,"Therapists, All Other"
+29-1131.00,Veterinarians,29-1131.00,Veterinarians
+29-1199.99,"Health Diagnosing and Treating Practitioners, All Other",29-1199.00,"Health Diagnosing and Treating Practitioners, All Other"
+29-2011.00,Medical and Clinical Laboratory Technologists,29-2011.00,Medical and Clinical Laboratory Technologists
+29-2012.00,Medical and Clinical Laboratory Technicians,29-2012.00,Medical and Clinical Laboratory Technicians
+29-2021.00,Dental Hygienists,29-2021.00,Dental Hygienists
+29-2031.00,Cardiovascular Technologists and Technicians,29-2031.00,Cardiovascular Technologists and Technicians
+29-2032.00,Diagnostic Medical Sonographers,29-2032.00,Diagnostic Medical Sonographers
+29-2033.00,Nuclear Medicine Technologists,29-2033.00,Nuclear Medicine Technologists
+29-2034.00,Radiologic Technologists and Technicians,29-2034.00,Radiologic Technologists and Technicians
+29-2034.01,Radiologic Technologists,29-2034.01,Radiologic Technologists
+29-2034.02,Radiologic Technicians,29-2034.02,Radiologic Technicians
+29-2041.00,Emergency Medical Technicians and Paramedics,29-2041.00,Emergency Medical Technicians and Paramedics
+29-2051.00,Dietetic Technicians,29-2051.00,Dietetic Technicians
+29-2052.00,Pharmacy Technicians,29-2052.00,Pharmacy Technicians
+29-2053.00,Psychiatric Technicians,29-2053.00,Psychiatric Technicians
+29-2054.00,Respiratory Therapy Technicians,29-2054.00,Respiratory Therapy Technicians
+29-2055.00,Surgical Technologists,29-2055.00,Surgical Technologists
+29-2056.00,Veterinary Technologists and Technicians,29-2056.00,Veterinary Technologists and Technicians
+29-2061.00,Licensed Practical and Licensed Vocational Nurses,29-2061.00,Licensed Practical and Licensed Vocational Nurses
+29-2071.00,Medical Records and Health Information Technicians,29-2071.00,Medical Records and Health Information Technicians
+29-2081.00,"Opticians, Dispensing",29-2081.00,"Opticians, Dispensing"
+29-2091.00,Orthotists and Prosthetists,29-2091.00,Orthotists and Prosthetists
+29-2099.99,"Health Technologists and Technicians, All Other",29-2099.00,"Health Technologists and Technicians, All Other"
+29-9011.00,Occupational Health and Safety Specialists,29-9011.00,Occupational Health and Safety Specialists
+29-9012.00,Occupational Health and Safety Technicians,29-9012.00,Occupational Health and Safety Technicians
+29-9091.00,Athletic Trainers,29-9091.00,Athletic Trainers
+29-9099.99,"Healthcare Practitioners and Technical Workers, All Other",29-9099.00,"Healthcare Practitioners and Technical Workers, All Other"
+31-1011.00,Home Health Aides,31-1011.00,Home Health Aides
+31-1012.00,"Nursing Aides, Orderlies, and Attendants",31-1012.00,"Nursing Aides, Orderlies, and Attendants"
+31-1013.00,Psychiatric Aides,31-1013.00,Psychiatric Aides
+31-2011.00,Occupational Therapist Assistants,31-2011.00,Occupational Therapist Assistants
+31-2012.00,Occupational Therapist Aides,31-2012.00,Occupational Therapist Aides
+31-2021.00,Physical Therapist Assistants,31-2021.00,Physical Therapist Assistants
+31-2022.00,Physical Therapist Aides,31-2022.00,Physical Therapist Aides
+31-9011.00,Massage Therapists,31-9011.00,Massage Therapists
+31-9091.00,Dental Assistants,31-9091.00,Dental Assistants
+31-9092.00,Medical Assistants,31-9092.00,Medical Assistants
+31-9093.00,Medical Equipment Preparers,31-9093.00,Medical Equipment Preparers
+31-9094.00,Medical Transcriptionists,31-9094.00,Medical Transcriptionists
+31-9095.00,Pharmacy Aides,31-9095.00,Pharmacy Aides
+31-9096.00,Veterinary Assistants and Laboratory Animal Caretakers,31-9096.00,Veterinary Assistants and Laboratory Animal Caretakers
+31-9099.99,"Healthcare Support Workers, All Other",31-9099.00,"Healthcare Support Workers, All Other"
+33-1011.00,First-Line Supervisors/Managers of Correctional Officers,33-1011.00,First-Line Supervisors/Managers of Correctional Officers
+33-1012.00,First-Line Supervisors/Managers of Police and Detectives,33-1012.00,First-Line Supervisors/Managers of Police and Detectives
+33-1021.00,First-Line Supervisors/Managers of Fire Fighting and Prevention Workers,33-1021.00,First-Line Supervisors/Managers of Fire Fighting and Prevention Workers
+33-1021.01,Municipal Fire Fighting and Prevention Supervisors,33-1021.01,Municipal Fire Fighting and Prevention Supervisors
+33-1021.02,Forest Fire Fighting and Prevention Supervisors,33-1021.02,Forest Fire Fighting and Prevention Supervisors
+33-1099.99,"First-Line Supervisors/Managers, Protective Service Workers, All Other",33-1099.00,"First-Line Supervisors/Managers, Protective Service Workers, All Other"
+33-2011.00,Fire Fighters,33-2011.00,Fire Fighters
+33-2011.01,Municipal Fire Fighters,33-2011.01,Municipal Fire Fighters
+33-2011.02,Forest Fire Fighters,33-2011.02,Forest Fire Fighters
+33-2021.00,Fire Inspectors and Investigators,33-2021.00,Fire Inspectors and Investigators
+33-2021.01,Fire Inspectors,33-2021.01,Fire Inspectors
+33-2021.02,Fire Investigators,33-2021.02,Fire Investigators
+33-2022.00,Forest Fire Inspectors and Prevention Specialists,33-2022.00,Forest Fire Inspectors and Prevention Specialists
+33-3011.00,Bailiffs,33-3011.00,Bailiffs
+33-3012.00,Correctional Officers and Jailers,33-3012.00,Correctional Officers and Jailers
+33-3021.00,Detectives and Criminal Investigators,33-3021.00,Detectives and Criminal Investigators
+33-3021.01,Police Detectives,33-3021.01,Police Detectives
+33-3021.02,Police Identification and Records Officers,33-3021.02,Police Identification and Records Officers
+33-3021.03,Criminal Investigators and Special Agents,33-3021.03,Criminal Investigators and Special Agents
+33-3021.05,Immigration and Customs Inspectors,33-3021.05,Immigration and Customs Inspectors
+33-3031.00,Fish and Game Wardens,33-3031.00,Fish and Game Wardens
+33-3041.00,Parking Enforcement Workers,33-3041.00,Parking Enforcement Workers
+33-3051.00,Police and Sheriff's Patrol Officers,33-3051.00,Police and Sheriff's Patrol Officers
+33-3051.01,Police Patrol Officers,33-3051.01,Police Patrol Officers
+33-3051.03,Sheriffs and Deputy Sheriffs,33-3051.03,Sheriffs and Deputy Sheriffs
+33-3052.00,Transit and Railroad Police,33-3052.00,Transit and Railroad Police
+33-9011.00,Animal Control Workers,33-9011.00,Animal Control Workers
+33-9021.00,Private Detectives and Investigators,33-9021.00,Private Detectives and Investigators
+33-9031.00,Gaming Surveillance Officers and Gaming Investigators,33-9031.00,Gaming Surveillance Officers and Gaming Investigators
+33-9032.00,Security Guards,33-9032.00,Security Guards
+33-9091.00,Crossing Guards,33-9091.00,Crossing Guards
+33-9092.00,"Lifeguards, Ski Patrol, and Other Recreational Protective Service Workers",33-9092.00,"Lifeguards, Ski Patrol, and Other Recreational Protective Service Workers"
+33-9099.01,Transportation Security Screeners,33-9099.01,Transportation Security Officers
+33-9099.99,"Protective Service Workers, All Other",33-9099.00,"Protective Service Workers, All Other"
+35-1011.00,Chefs and Head Cooks,35-1011.00,Chefs and Head Cooks
+35-1012.00,First-Line Supervisors/Managers of Food Preparation and Serving Workers,35-1012.00,First-Line Supervisors/Managers of Food Preparation and Serving Workers
+35-2011.00,"Cooks, Fast Food",35-2011.00,"Cooks, Fast Food"
+35-2012.00,"Cooks, Institution and Cafeteria",35-2012.00,"Cooks, Institution and Cafeteria"
+35-2013.00,"Cooks, Private Household",35-2013.00,"Cooks, Private Household"
+35-2014.00,"Cooks, Restaurant",35-2014.00,"Cooks, Restaurant"
+35-2015.00,"Cooks, Short Order",35-2015.00,"Cooks, Short Order"
+35-2019.99,"Cooks, All Other",35-2019.00,"Cooks, All Other"
+35-2021.00,Food Preparation Workers,35-2021.00,Food Preparation Workers
+35-3011.00,Bartenders,35-3011.00,Bartenders
+35-3021.00,"Combined Food Preparation and Serving Workers, Including Fast Food",35-3021.00,"Combined Food Preparation and Serving Workers, Including Fast Food"
+35-3022.00,"Counter Attendants, Cafeteria, Food Concession, and Coffee Shop",35-3022.00,"Counter Attendants, Cafeteria, Food Concession, and Coffee Shop"
+35-3031.00,Waiters and Waitresses,35-3031.00,Waiters and Waitresses
+35-3041.00,"Food Servers, Nonrestaurant",35-3041.00,"Food Servers, Nonrestaurant"
+35-9011.00,Dining Room and Cafeteria Attendants and Bartender Helpers,35-9011.00,Dining Room and Cafeteria Attendants and Bartender Helpers
+35-9021.00,Dishwashers,35-9021.00,Dishwashers
+35-9031.00,"Hosts and Hostesses, Restaurant, Lounge, and Coffee Shop",35-9031.00,"Hosts and Hostesses, Restaurant, Lounge, and Coffee Shop"
+35-9099.99,"Food Preparation and Serving Related Workers, All Other",35-9099.00,"Food Preparation and Serving Related Workers, All Other"
+37-1011.00,First-Line Supervisors/Managers of Housekeeping and Janitorial Workers,37-1011.00,First-Line Supervisors/Managers of Housekeeping and Janitorial Workers
+37-1012.00,"First-Line Supervisors/Managers of Landscaping, Lawn Service, and Groundskeeping Workers",37-1012.00,"First-Line Supervisors/Managers of Landscaping, Lawn Service, and Groundskeeping Workers"
+37-2011.00,"Janitors and Cleaners, Except Maids and Housekeeping Cleaners",37-2011.00,"Janitors and Cleaners, Except Maids and Housekeeping Cleaners"
+37-2012.00,Maids and Housekeeping Cleaners,37-2012.00,Maids and Housekeeping Cleaners
+37-2019.99,"Building Cleaning Workers, All Other",37-2019.00,"Building Cleaning Workers, All Other"
+37-2021.00,Pest Control Workers,37-2021.00,Pest Control Workers
+37-3011.00,Landscaping and Groundskeeping Workers,37-3011.00,Landscaping and Groundskeeping Workers
+37-3012.00,"Pesticide Handlers, Sprayers, and Applicators, Vegetation",37-3012.00,"Pesticide Handlers, Sprayers, and Applicators, Vegetation"
+37-3013.00,Tree Trimmers and Pruners,37-3013.00,Tree Trimmers and Pruners
+37-3019.99,"Grounds Maintenance Workers, All Other",37-3019.00,"Grounds Maintenance Workers, All Other"
+39-1011.00,Gaming Supervisors,39-1011.00,Gaming Supervisors
+39-1012.00,Slot Key Persons,39-1012.00,Slot Key Persons
+39-1021.00,First-Line Supervisors/Managers of Personal Service Workers,39-1021.00,First-Line Supervisors/Managers of Personal Service Workers
+39-2011.00,Animal Trainers,39-2011.00,Animal Trainers
+39-2021.00,Nonfarm Animal Caretakers,39-2021.00,Nonfarm Animal Caretakers
+39-3011.00,Gaming Dealers,39-3011.00,Gaming Dealers
+39-3012.00,Gaming and Sports Book Writers and Runners,39-3012.00,Gaming and Sports Book Writers and Runners
+39-3019.99,"Gaming Service Workers, All Other",39-3019.00,"Gaming Service Workers, All Other"
+39-3021.00,Motion Picture Projectionists,39-3021.00,Motion Picture Projectionists
+39-3031.00,"Ushers, Lobby Attendants, and Ticket Takers",39-3031.00,"Ushers, Lobby Attendants, and Ticket Takers"
+39-3091.00,Amusement and Recreation Attendants,39-3091.00,Amusement and Recreation Attendants
+39-3092.00,Costume Attendants,39-3092.00,Costume Attendants
+39-3093.00,"Locker Room, Coatroom, and Dressing Room Attendants",39-3093.00,"Locker Room, Coatroom, and Dressing Room Attendants"
+39-3099.99,"Entertainment Attendants and Related Workers, All Other",39-3099.00,"Entertainment Attendants and Related Workers, All Other"
+39-4011.00,Embalmers,39-4011.00,Embalmers
+39-4021.00,Funeral Attendants,39-4021.00,Funeral Attendants
+39-5011.00,Barbers,39-5011.00,Barbers
+39-5012.00,"Hairdressers, Hairstylists, and Cosmetologists",39-5012.00,"Hairdressers, Hairstylists, and Cosmetologists"
+39-5091.00,"Makeup Artists, Theatrical and Performance",39-5091.00,"Makeup Artists, Theatrical and Performance"
+39-5092.00,Manicurists and Pedicurists,39-5092.00,Manicurists and Pedicurists
+39-5093.00,Shampooers,39-5093.00,Shampooers
+39-5094.00,Skin Care Specialists,39-5094.00,Skin Care Specialists
+39-6011.00,Baggage Porters and Bellhops,39-6011.00,Baggage Porters and Bellhops
+39-6012.00,Concierges,39-6012.00,Concierges
+39-6021.00,Tour Guides and Escorts,39-6021.00,Tour Guides and Escorts
+39-6022.00,Travel Guides,39-6022.00,Travel Guides
+39-6031.00,Flight Attendants,39-6031.00,Flight Attendants
+39-6032.00,"Transportation Attendants, Except Flight Attendants and Baggage Porters",39-6032.00,"Transportation Attendants, Except Flight Attendants and Baggage Porters"
+39-9011.00,Child Care Workers,39-9011.00,Child Care Workers
+39-9011.01,Nannies,39-9011.01,Nannies
+39-9021.00,Personal and Home Care Aides,39-9021.00,Personal and Home Care Aides
+39-9031.00,Fitness Trainers and Aerobics Instructors,39-9031.00,Fitness Trainers and Aerobics Instructors
+39-9032.00,Recreation Workers,39-9032.00,Recreation Workers
+39-9041.00,Residential Advisors,39-9041.00,Residential Advisors
+39-9099.99,"Personal Care and Service Workers, All Other",39-9099.00,"Personal Care and Service Workers, All Other"
+41-1011.00,First-Line Supervisors/Managers of Retail Sales Workers,41-1011.00,First-Line Supervisors/Managers of Retail Sales Workers
+41-1012.00,First-Line Supervisors/Managers of Non-Retail Sales Workers,41-1012.00,First-Line Supervisors/Managers of Non-Retail Sales Workers
+41-2011.00,Cashiers,41-2011.00,Cashiers
+41-2012.00,Gaming Change Persons and Booth Cashiers,41-2012.00,Gaming Change Persons and Booth Cashiers
+41-2021.00,Counter and Rental Clerks,41-2021.00,Counter and Rental Clerks
+41-2022.00,Parts Salespersons,41-2022.00,Parts Salespersons
+41-2031.00,Retail Salespersons,41-2031.00,Retail Salespersons
+41-3011.00,Advertising Sales Agents,41-3011.00,Advertising Sales Agents
+41-3021.00,Insurance Sales Agents,41-3021.00,Insurance Sales Agents
+41-3031.00,"Securities, Commodities, and Financial Services Sales Agents",41-3031.00,"Securities, Commodities, and Financial Services Sales Agents"
+41-3031.01,"Sales Agents, Securities and Commodities",41-3031.01,"Sales Agents, Securities and Commodities"
+41-3031.02,"Sales Agents, Financial Services",41-3031.02,"Sales Agents, Financial Services"
+41-3041.00,Travel Agents,41-3041.00,Travel Agents
+41-3099.99,"Sales Representatives, Services, All Other",41-3099.00,"Sales Representatives, Services, All Other"
+41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4012.00,"Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products",41-4012.00,"Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products"
+41-9011.00,Demonstrators and Product Promoters,41-9011.00,Demonstrators and Product Promoters
+41-9012.00,Models,41-9012.00,Models
+41-9021.00,Real Estate Brokers,41-9021.00,Real Estate Brokers
+41-9022.00,Real Estate Sales Agents,41-9022.00,Real Estate Sales Agents
+41-9031.00,Sales Engineers,41-9031.00,Sales Engineers
+41-9041.00,Telemarketers,41-9041.00,Telemarketers
+41-9091.00,"Door-To-Door Sales Workers, News and Street Vendors, and Related Workers",41-9091.00,"Door-To-Door Sales Workers, News and Street Vendors, and Related Workers"
+41-9099.99,"Sales and Related Workers, All Other",41-9099.00,"Sales and Related Workers, All Other"
+43-1011.00,First-Line Supervisors/Managers of Office and Administrative Support Workers,43-1011.00,First-Line Supervisors/Managers of Office and Administrative Support Workers
+43-2011.00,"Switchboard Operators, Including Answering Service",43-2011.00,"Switchboard Operators, Including Answering Service"
+43-2021.00,Telephone Operators,43-2021.00,Telephone Operators
+43-2099.99,"Communications Equipment Operators, All Other",43-2099.00,"Communications Equipment Operators, All Other"
+43-3011.00,Bill and Account Collectors,43-3011.00,Bill and Account Collectors
+43-3021.00,Billing and Posting Clerks and Machine Operators,43-3021.00,Billing and Posting Clerks and Machine Operators
+43-3021.01,Statement Clerks,43-3021.01,Statement Clerks
+43-3021.02,"Billing, Cost, and Rate Clerks",43-3021.02,"Billing, Cost, and Rate Clerks"
+43-3021.03,"Billing, Posting, and Calculating Machine Operators",43-3021.03,"Billing, Posting, and Calculating Machine Operators"
+43-3031.00,"Bookkeeping, Accounting, and Auditing Clerks",43-3031.00,"Bookkeeping, Accounting, and Auditing Clerks"
+43-3041.00,Gaming Cage Workers,43-3041.00,Gaming Cage Workers
+43-3051.00,Payroll and Timekeeping Clerks,43-3051.00,Payroll and Timekeeping Clerks
+43-3061.00,Procurement Clerks,43-3061.00,Procurement Clerks
+43-3071.00,Tellers,43-3071.00,Tellers
+43-4011.00,Brokerage Clerks,43-4011.00,Brokerage Clerks
+43-4021.00,Correspondence Clerks,43-4021.00,Correspondence Clerks
+43-4031.00,"Court, Municipal, and License Clerks",43-4031.00,"Court, Municipal, and License Clerks"
+43-4031.01,Court Clerks,43-4031.01,Court Clerks
+43-4031.02,Municipal Clerks,43-4031.02,Municipal Clerks
+43-4031.03,License Clerks,43-4031.03,License Clerks
+43-4041.00,"Credit Authorizers, Checkers, and Clerks",43-4041.00,"Credit Authorizers, Checkers, and Clerks"
+43-4041.01,Credit Authorizers,43-4041.01,Credit Authorizers
+43-4041.02,Credit Checkers,43-4041.02,Credit Checkers
+43-4051.00,Customer Service Representatives,43-4051.00,Customer Service Representatives
+43-4061.00,"Eligibility Interviewers, Government Programs",43-4061.00,"Eligibility Interviewers, Government Programs"
+43-4071.00,File Clerks,43-4071.00,File Clerks
+43-4081.00,"Hotel, Motel, and Resort Desk Clerks",43-4081.00,"Hotel, Motel, and Resort Desk Clerks"
+43-4111.00,"Interviewers, Except Eligibility and Loan",43-4111.00,"Interviewers, Except Eligibility and Loan"
+43-4121.00,"Library Assistants, Clerical",43-4121.00,"Library Assistants, Clerical"
+43-4131.00,Loan Interviewers and Clerks,43-4131.00,Loan Interviewers and Clerks
+43-4141.00,New Accounts Clerks,43-4141.00,New Accounts Clerks
+43-4151.00,Order Clerks,43-4151.00,Order Clerks
+43-4161.00,"Human Resources Assistants, Except Payroll and Timekeeping",43-4161.00,"Human Resources Assistants, Except Payroll and Timekeeping"
+43-4171.00,Receptionists and Information Clerks,43-4171.00,Receptionists and Information Clerks
+43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks,43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks
+43-4199.99,"Information and Record Clerks, All Other",43-4199.00,"Information and Record Clerks, All Other"
+43-5011.00,Cargo and Freight Agents,43-5011.00,Cargo and Freight Agents
+43-5021.00,Couriers and Messengers,43-5021.00,Couriers and Messengers
+43-5031.00,"Police, Fire, and Ambulance Dispatchers",43-5031.00,"Police, Fire, and Ambulance Dispatchers"
+43-5032.00,"Dispatchers, Except Police, Fire, and Ambulance",43-5032.00,"Dispatchers, Except Police, Fire, and Ambulance"
+43-5041.00,"Meter Readers, Utilities",43-5041.00,"Meter Readers, Utilities"
+43-5051.00,Postal Service Clerks,43-5051.00,Postal Service Clerks
+43-5052.00,Postal Service Mail Carriers,43-5052.00,Postal Service Mail Carriers
+43-5053.00,"Postal Service Mail Sorters, Processors, and Processing Machine Operators",43-5053.00,"Postal Service Mail Sorters, Processors, and Processing Machine Operators"
+43-5061.00,"Production, Planning, and Expediting Clerks",43-5061.00,"Production, Planning, and Expediting Clerks"
+43-5071.00,"Shipping, Receiving, and Traffic Clerks",43-5071.00,"Shipping, Receiving, and Traffic Clerks"
+43-5081.00,Stock Clerks and Order Fillers,43-5081.00,Stock Clerks and Order Fillers
+43-5081.01,"Stock Clerks, Sales Floor",43-5081.01,"Stock Clerks, Sales Floor"
+43-5081.02,Marking Clerks,43-5081.02,Marking Clerks
+43-5081.03,"Stock Clerks- Stockroom, Warehouse, or Storage Yard",43-5081.03,"Stock Clerks- Stockroom, Warehouse, or Storage Yard"
+43-5081.04,"Order Fillers, Wholesale and Retail Sales",43-5081.04,"Order Fillers, Wholesale and Retail Sales"
+43-5111.00,"Weighers, Measurers, Checkers, and Samplers, Recordkeeping",43-5111.00,"Weighers, Measurers, Checkers, and Samplers, Recordkeeping"
+43-6011.00,Executive Secretaries and Administrative Assistants,43-6011.00,Executive Secretaries and Administrative Assistants
+43-6012.00,Legal Secretaries,43-6012.00,Legal Secretaries
+43-6013.00,Medical Secretaries,43-6013.00,Medical Secretaries
+43-6014.00,"Secretaries, Except Legal, Medical, and Executive",43-6014.00,"Secretaries, Except Legal, Medical, and Executive"
+43-9011.00,Computer Operators,43-9011.00,Computer Operators
+43-9021.00,Data Entry Keyers,43-9021.00,Data Entry Keyers
+43-9022.00,Word Processors and Typists,43-9022.00,Word Processors and Typists
+43-9031.00,Desktop Publishers,43-9031.00,Desktop Publishers
+43-9041.00,Insurance Claims and Policy Processing Clerks,43-9041.00,Insurance Claims and Policy Processing Clerks
+43-9041.01,Insurance Claims Clerks,43-9041.01,Insurance Claims Clerks
+43-9041.02,Insurance Policy Processing Clerks,43-9041.02,Insurance Policy Processing Clerks
+43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service",43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service"
+43-9061.00,"Office Clerks, General",43-9061.00,"Office Clerks, General"
+43-9071.00,"Office Machine Operators, Except Computer",43-9071.00,"Office Machine Operators, Except Computer"
+43-9081.00,Proofreaders and Copy Markers,43-9081.00,Proofreaders and Copy Markers
+43-9111.00,Statistical Assistants,43-9111.00,Statistical Assistants
+43-9199.99,"Office and Administrative Support Workers, All Other",43-9199.00,"Office and Administrative Support Workers, All Other"
+45-1011.00,"First-Line Supervisors/Managers of Farming, Fishing, and Forestry Workers",45-1011.00,"First-Line Supervisors/Managers of Farming, Fishing, and Forestry Workers"
+45-1011.05,First-Line Supervisors/Managers of Logging Workers,45-1011.05,First-Line Supervisors/Managers of Logging Workers
+45-1011.06,First-Line Supervisors/Managers of Aquacultural Workers,45-1011.06,First-Line Supervisors/Managers of Aquacultural Workers
+45-1011.07,First-Line Supervisors/Managers of Agricultural Crop and Horticultural Workers,45-1011.07,First-Line Supervisors/Managers of Agricultural Crop and Horticultural Workers
+45-1011.08,First-Line Supervisors/Managers of Animal Husbandry and Animal Care Workers,45-1011.08,First-Line Supervisors/Managers of Animal Husbandry and Animal Care Workers
+45-1012.00,Farm Labor Contractors,45-1012.00,Farm Labor Contractors
+45-2011.00,Agricultural Inspectors,45-2011.00,Agricultural Inspectors
+45-2021.00,Animal Breeders,45-2021.00,Animal Breeders
+45-2041.00,"Graders and Sorters, Agricultural Products",45-2041.00,"Graders and Sorters, Agricultural Products"
+45-2091.00,Agricultural Equipment Operators,45-2091.00,Agricultural Equipment Operators
+45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse",45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse"
+45-2092.01,Nursery Workers,45-2092.01,Nursery Workers
+45-2092.02,"Farmworkers and Laborers, Crop",45-2092.02,"Farmworkers and Laborers, Crop"
+45-2093.00,"Farmworkers, Farm and Ranch Animals",45-2093.00,"Farmworkers, Farm and Ranch Animals"
+45-2099.99,"Agricultural Workers, All Other",45-2099.00,"Agricultural Workers, All Other"
+45-3011.00,Fishers and Related Fishing Workers,45-3011.00,Fishers and Related Fishing Workers
+45-3021.00,Hunters and Trappers,45-3021.00,Hunters and Trappers
+45-4011.00,Forest and Conservation Workers,45-4011.00,Forest and Conservation Workers
+45-4021.00,Fallers,45-4021.00,Fallers
+45-4022.00,Logging Equipment Operators,45-4022.00,Logging Equipment Operators
+45-4023.00,Log Graders and Scalers,45-4023.00,Log Graders and Scalers
+45-4029.99,"Logging Workers, All Other",45-4029.00,"Logging Workers, All Other"
+47-1011.00,First-Line Supervisors/Managers of Construction Trades and Extraction Workers,47-1011.00,First-Line Supervisors/Managers of Construction Trades and Extraction Workers
+47-2011.00,Boilermakers,47-2011.00,Boilermakers
+47-2021.00,Brickmasons and Blockmasons,47-2021.00,Brickmasons and Blockmasons
+47-2022.00,Stonemasons,47-2022.00,Stonemasons
+47-2031.00,Carpenters,47-2031.00,Carpenters
+47-2031.01,Construction Carpenters,47-2031.01,Construction Carpenters
+47-2031.02,Rough Carpenters,47-2031.02,Rough Carpenters
+47-2041.00,Carpet Installers,47-2041.00,Carpet Installers
+47-2042.00,"Floor Layers, Except Carpet, Wood, and Hard Tiles",47-2042.00,"Floor Layers, Except Carpet, Wood, and Hard Tiles"
+47-2043.00,Floor Sanders and Finishers,47-2043.00,Floor Sanders and Finishers
+47-2044.00,Tile and Marble Setters,47-2044.00,Tile and Marble Setters
+47-2051.00,Cement Masons and Concrete Finishers,47-2051.00,Cement Masons and Concrete Finishers
+47-2053.00,Terrazzo Workers and Finishers,47-2053.00,Terrazzo Workers and Finishers
+47-2061.00,Construction Laborers,47-2061.00,Construction Laborers
+47-2071.00,"Paving, Surfacing, and Tamping Equipment Operators",47-2071.00,"Paving, Surfacing, and Tamping Equipment Operators"
+47-2072.00,Pile-Driver Operators,47-2072.00,Pile-Driver Operators
+47-2073.00,Operating Engineers and Other Construction Equipment Operators,47-2073.00,Operating Engineers and Other Construction Equipment Operators
+47-2081.00,Drywall and Ceiling Tile Installers,47-2081.00,Drywall and Ceiling Tile Installers
+47-2082.00,Tapers,47-2082.00,Tapers
+47-2111.00,Electricians,47-2111.00,Electricians
+47-2121.00,Glaziers,47-2121.00,Glaziers
+47-2131.00,"Insulation Workers, Floor, Ceiling, and Wall",47-2131.00,"Insulation Workers, Floor, Ceiling, and Wall"
+47-2132.00,"Insulation Workers, Mechanical",47-2132.00,"Insulation Workers, Mechanical"
+47-2141.00,"Painters, Construction and Maintenance",47-2141.00,"Painters, Construction and Maintenance"
+47-2142.00,Paperhangers,47-2142.00,Paperhangers
+47-2151.00,Pipelayers,47-2151.00,Pipelayers
+47-2152.00,"Plumbers, Pipefitters, and Steamfitters",47-2152.00,"Plumbers, Pipefitters, and Steamfitters"
+47-2152.01,Pipe Fitters and Steamfitters,47-2152.01,Pipe Fitters and Steamfitters
+47-2152.02,Plumbers,47-2152.02,Plumbers
+47-2161.00,Plasterers and Stucco Masons,47-2161.00,Plasterers and Stucco Masons
+47-2171.00,Reinforcing Iron and Rebar Workers,47-2171.00,Reinforcing Iron and Rebar Workers
+47-2181.00,Roofers,47-2181.00,Roofers
+47-2211.00,Sheet Metal Workers,47-2211.00,Sheet Metal Workers
+47-2221.00,Structural Iron and Steel Workers,47-2221.00,Structural Iron and Steel Workers
+47-3011.00,"Helpers--Brickmasons, Blockmasons, Stonemasons, and Tile and Marble Setters",47-3011.00,"Helpers--Brickmasons, Blockmasons, Stonemasons, and Tile and Marble Setters"
+47-3012.00,Helpers--Carpenters,47-3012.00,Helpers--Carpenters
+47-3013.00,Helpers--Electricians,47-3013.00,Helpers--Electricians
+47-3014.00,"Helpers--Painters, Paperhangers, Plasterers, and Stucco Masons",47-3014.00,"Helpers--Painters, Paperhangers, Plasterers, and Stucco Masons"
+47-3015.00,"Helpers--Pipelayers, Plumbers, Pipefitters, and Steamfitters",47-3015.00,"Helpers--Pipelayers, Plumbers, Pipefitters, and Steamfitters"
+47-3016.00,Helpers--Roofers,47-3016.00,Helpers--Roofers
+47-3019.99,"Helpers, Construction Trades, All Other",47-3019.00,"Helpers, Construction Trades, All Other"
+47-4011.00,Construction and Building Inspectors,47-4011.00,Construction and Building Inspectors
+47-4021.00,Elevator Installers and Repairers,47-4021.00,Elevator Installers and Repairers
+47-4031.00,Fence Erectors,47-4031.00,Fence Erectors
+47-4041.00,Hazardous Materials Removal Workers,47-4041.00,Hazardous Materials Removal Workers
+47-4051.00,Highway Maintenance Workers,47-4051.00,Highway Maintenance Workers
+47-4061.00,Rail-Track Laying and Maintenance Equipment Operators,47-4061.00,Rail-Track Laying and Maintenance Equipment Operators
+47-4071.00,Septic Tank Servicers and Sewer Pipe Cleaners,47-4071.00,Septic Tank Servicers and Sewer Pipe Cleaners
+47-4091.00,Segmental Pavers,47-4091.00,Segmental Pavers
+47-4099.99,"Construction and Related Workers, All Other",47-4099.00,"Construction and Related Workers, All Other"
+47-5011.00,"Derrick Operators, Oil and Gas",47-5011.00,"Derrick Operators, Oil and Gas"
+47-5012.00,"Rotary Drill Operators, Oil and Gas",47-5012.00,"Rotary Drill Operators, Oil and Gas"
+47-5013.00,"Service Unit Operators, Oil, Gas, and Mining",47-5013.00,"Service Unit Operators, Oil, Gas, and Mining"
+47-5021.00,"Earth Drillers, Except Oil and Gas",47-5021.00,"Earth Drillers, Except Oil and Gas"
+47-5031.00,"Explosives Workers, Ordnance Handling Experts, and Blasters",47-5031.00,"Explosives Workers, Ordnance Handling Experts, and Blasters"
+47-5041.00,Continuous Mining Machine Operators,47-5041.00,Continuous Mining Machine Operators
+47-5042.00,Mine Cutting and Channeling Machine Operators,47-5042.00,Mine Cutting and Channeling Machine Operators
+47-5049.99,"Mining Machine Operators, All Other",47-5049.00,"Mining Machine Operators, All Other"
+47-5051.00,"Rock Splitters, Quarry",47-5051.00,"Rock Splitters, Quarry"
+47-5061.00,"Roof Bolters, Mining",47-5061.00,"Roof Bolters, Mining"
+47-5071.00,"Roustabouts, Oil and Gas",47-5071.00,"Roustabouts, Oil and Gas"
+47-5081.00,Helpers--Extraction Workers,47-5081.00,Helpers--Extraction Workers
+47-5099.99,"Extraction Workers, All Other",47-5099.00,"Extraction Workers, All Other"
+49-1011.00,"First-Line Supervisors/Managers of Mechanics, Installers, and Repairers",49-1011.00,"First-Line Supervisors/Managers of Mechanics, Installers, and Repairers"
+49-2011.00,"Computer, Automated Teller, and Office Machine Repairers",49-2011.00,"Computer, Automated Teller, and Office Machine Repairers"
+49-2021.00,Radio Mechanics,49-2021.00,Radio Mechanics
+49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers",49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers"
+49-2091.00,Avionics Technicians,49-2091.00,Avionics Technicians
+49-2092.00,"Electric Motor, Power Tool, and Related Repairers",49-2092.00,"Electric Motor, Power Tool, and Related Repairers"
+49-2093.00,"Electrical and Electronics Installers and Repairers, Transportation Equipment",49-2093.00,"Electrical and Electronics Installers and Repairers, Transportation Equipment"
+49-2094.00,"Electrical and Electronics Repairers, Commercial and Industrial Equipment",49-2094.00,"Electrical and Electronics Repairers, Commercial and Industrial Equipment"
+49-2095.00,"Electrical and Electronics Repairers, Powerhouse, Substation, and Relay",49-2095.00,"Electrical and Electronics Repairers, Powerhouse, Substation, and Relay"
+49-2096.00,"Electronic Equipment Installers and Repairers, Motor Vehicles",49-2096.00,"Electronic Equipment Installers and Repairers, Motor Vehicles"
+49-2097.00,Electronic Home Entertainment Equipment Installers and Repairers,49-2097.00,Electronic Home Entertainment Equipment Installers and Repairers
+49-2098.00,Security and Fire Alarm Systems Installers,49-2098.00,Security and Fire Alarm Systems Installers
+49-3011.00,Aircraft Mechanics and Service Technicians,49-3011.00,Aircraft Mechanics and Service Technicians
+49-3021.00,Automotive Body and Related Repairers,49-3021.00,Automotive Body and Related Repairers
+49-3022.00,Automotive Glass Installers and Repairers,49-3022.00,Automotive Glass Installers and Repairers
+49-3023.00,Automotive Service Technicians and Mechanics,49-3023.00,Automotive Service Technicians and Mechanics
+49-3023.01,Automotive Master Mechanics,49-3023.01,Automotive Master Mechanics
+49-3023.02,Automotive Specialty Technicians,49-3023.02,Automotive Specialty Technicians
+49-3031.00,Bus and Truck Mechanics and Diesel Engine Specialists,49-3031.00,Bus and Truck Mechanics and Diesel Engine Specialists
+49-3041.00,Farm Equipment Mechanics,49-3041.00,Farm Equipment Mechanics
+49-3042.00,"Mobile Heavy Equipment Mechanics, Except Engines",49-3042.00,"Mobile Heavy Equipment Mechanics, Except Engines"
+49-3043.00,Rail Car Repairers,49-3043.00,Rail Car Repairers
+49-3051.00,Motorboat Mechanics,49-3051.00,Motorboat Mechanics
+49-3052.00,Motorcycle Mechanics,49-3052.00,Motorcycle Mechanics
+49-3053.00,Outdoor Power Equipment and Other Small Engine Mechanics,49-3053.00,Outdoor Power Equipment and Other Small Engine Mechanics
+49-3091.00,Bicycle Repairers,49-3091.00,Bicycle Repairers
+49-3092.00,Recreational Vehicle Service Technicians,49-3092.00,Recreational Vehicle Service Technicians
+49-3093.00,Tire Repairers and Changers,49-3093.00,Tire Repairers and Changers
+49-9011.00,Mechanical Door Repairers,49-9011.00,Mechanical Door Repairers
+49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door",49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door"
+49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers",49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers"
+49-9021.01,Heating and Air Conditioning Mechanics and Installers,49-9021.01,Heating and Air Conditioning Mechanics and Installers
+49-9021.02,Refrigeration Mechanics and Installers,49-9021.02,Refrigeration Mechanics and Installers
+49-9031.00,Home Appliance Repairers,49-9031.00,Home Appliance Repairers
+49-9041.00,Industrial Machinery Mechanics,49-9041.00,Industrial Machinery Mechanics
+49-9042.00,"Maintenance and Repair Workers, General",49-9042.00,"Maintenance and Repair Workers, General"
+49-9043.00,"Maintenance Workers, Machinery",49-9043.00,"Maintenance Workers, Machinery"
+49-9044.00,Millwrights,49-9044.00,Millwrights
+49-9045.00,"Refractory Materials Repairers, Except Brickmasons",49-9045.00,"Refractory Materials Repairers, Except Brickmasons"
+49-9051.00,Electrical Power-Line Installers and Repairers,49-9051.00,Electrical Power-Line Installers and Repairers
+49-9052.00,Telecommunications Line Installers and Repairers,49-9052.00,Telecommunications Line Installers and Repairers
+49-9061.00,Camera and Photographic Equipment Repairers,49-9061.00,Camera and Photographic Equipment Repairers
+49-9062.00,Medical Equipment Repairers,49-9062.00,Medical Equipment Repairers
+49-9063.00,Musical Instrument Repairers and Tuners,49-9063.00,Musical Instrument Repairers and Tuners
+49-9064.00,Watch Repairers,49-9064.00,Watch Repairers
+49-9069.99,"Precision Instrument and Equipment Repairers, All Other",49-9069.00,"Precision Instrument and Equipment Repairers, All Other"
+49-9091.00,"Coin, Vending, and Amusement Machine Servicers and Repairers",49-9091.00,"Coin, Vending, and Amusement Machine Servicers and Repairers"
+49-9092.00,Commercial Divers,49-9092.00,Commercial Divers
+49-9093.00,"Fabric Menders, Except Garment",49-9093.00,"Fabric Menders, Except Garment"
+49-9094.00,Locksmiths and Safe Repairers,49-9094.00,Locksmiths and Safe Repairers
+49-9095.00,Manufactured Building and Mobile Home Installers,49-9095.00,Manufactured Building and Mobile Home Installers
+49-9096.00,Riggers,49-9096.00,Riggers
+49-9097.00,Signal and Track Switch Repairers,49-9097.00,Signal and Track Switch Repairers
+49-9098.00,"Helpers--Installation, Maintenance, and Repair Workers",49-9098.00,"Helpers--Installation, Maintenance, and Repair Workers"
+49-9099.99,"Installation, Maintenance, and Repair Workers, All Other",49-9099.00,"Installation, Maintenance, and Repair Workers, All Other"
+51-1011.00,First-Line Supervisors/Managers of Production and Operating Workers,51-1011.00,First-Line Supervisors/Managers of Production and Operating Workers
+51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers",51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers"
+51-2021.00,"Coil Winders, Tapers, and Finishers",51-2021.00,"Coil Winders, Tapers, and Finishers"
+51-2022.00,Electrical and Electronic Equipment Assemblers,51-2022.00,Electrical and Electronic Equipment Assemblers
+51-2023.00,Electromechanical Equipment Assemblers,51-2023.00,Electromechanical Equipment Assemblers
+51-2031.00,Engine and Other Machine Assemblers,51-2031.00,Engine and Other Machine Assemblers
+51-2041.00,Structural Metal Fabricators and Fitters,51-2041.00,Structural Metal Fabricators and Fitters
+51-2091.00,Fiberglass Laminators and Fabricators,51-2091.00,Fiberglass Laminators and Fabricators
+51-2092.00,Team Assemblers,51-2092.00,Team Assemblers
+51-2093.00,"Timing Device Assemblers, Adjusters, and Calibrators",51-2093.00,"Timing Device Assemblers, Adjusters, and Calibrators"
+51-2099.99,"Assemblers and Fabricators, All Other",51-2099.00,"Assemblers and Fabricators, All Other"
+51-3011.00,Bakers,51-3011.00,Bakers
+51-3021.00,Butchers and Meat Cutters,51-3021.00,Butchers and Meat Cutters
+51-3022.00,"Meat, Poultry, and Fish Cutters and Trimmers",51-3022.00,"Meat, Poultry, and Fish Cutters and Trimmers"
+51-3023.00,Slaughterers and Meat Packers,51-3023.00,Slaughterers and Meat Packers
+51-3091.00,"Food and Tobacco Roasting, Baking, and Drying Machine Operators and Tenders",51-3091.00,"Food and Tobacco Roasting, Baking, and Drying Machine Operators and Tenders"
+51-3092.00,Food Batchmakers,51-3092.00,Food Batchmakers
+51-3093.00,Food Cooking Machine Operators and Tenders,51-3093.00,Food Cooking Machine Operators and Tenders
+51-4011.00,"Computer-Controlled Machine Tool Operators, Metal and Plastic",51-4011.00,"Computer-Controlled Machine Tool Operators, Metal and Plastic"
+51-4012.00,Numerical Tool and Process Control Programmers,51-4012.00,Numerical Tool and Process Control Programmers
+51-4021.00,"Extruding and Drawing Machine Setters, Operators, and Tenders, Metal and Plastic",51-4021.00,"Extruding and Drawing Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4022.00,"Forging Machine Setters, Operators, and Tenders, Metal and Plastic",51-4022.00,"Forging Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4023.00,"Rolling Machine Setters, Operators, and Tenders, Metal and Plastic",51-4023.00,"Rolling Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic",51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4032.00,"Drilling and Boring Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4032.00,"Drilling and Boring Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4034.00,"Lathe and Turning Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4034.00,"Lathe and Turning Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4035.00,"Milling and Planing Machine Setters, Operators, and Tenders, Metal and Plastic",51-4035.00,"Milling and Planing Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4041.00,Machinists,51-4041.00,Machinists
+51-4051.00,Metal-Refining Furnace Operators and Tenders,51-4051.00,Metal-Refining Furnace Operators and Tenders
+51-4052.00,"Pourers and Casters, Metal",51-4052.00,"Pourers and Casters, Metal"
+51-4061.00,"Model Makers, Metal and Plastic",51-4061.00,"Model Makers, Metal and Plastic"
+51-4062.00,"Patternmakers, Metal and Plastic",51-4062.00,"Patternmakers, Metal and Plastic"
+51-4071.00,Foundry Mold and Coremakers,51-4071.00,Foundry Mold and Coremakers
+51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic",51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4111.00,Tool and Die Makers,51-4111.00,Tool and Die Makers
+51-4121.00,"Welders, Cutters, Solderers, and Brazers",51-4121.00,"Welders, Cutters, Solderers, and Brazers"
+51-4121.06,"Welders, Cutters, and Welder Fitters",51-4121.06,"Welders, Cutters, and Welder Fitters"
+51-4121.07,Solderers and Brazers,51-4121.07,Solderers and Brazers
+51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders",51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders"
+51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic",51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic"
+51-4192.00,"Lay-Out Workers, Metal and Plastic",51-4192.00,"Lay-Out Workers, Metal and Plastic"
+51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic",51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4194.00,"Tool Grinders, Filers, and Sharpeners",51-4194.00,"Tool Grinders, Filers, and Sharpeners"
+51-4199.99,"Metal Workers and Plastic Workers, All Other",51-4199.00,"Metal Workers and Plastic Workers, All Other"
+51-5011.00,Bindery Workers,51-5011.00,Bindery Workers
+51-5012.00,Bookbinders,51-5012.00,Bookbinders
+51-5021.00,Job Printers,51-5021.00,Job Printers
+51-5022.00,Prepress Technicians and Workers,51-5022.00,Prepress Technicians and Workers
+51-5023.00,Printing Machine Operators,51-5023.00,Printing Machine Operators
+51-6011.00,Laundry and Dry-Cleaning Workers,51-6011.00,Laundry and Dry-Cleaning Workers
+51-6021.00,"Pressers, Textile, Garment, and Related Materials",51-6021.00,"Pressers, Textile, Garment, and Related Materials"
+51-6031.00,Sewing Machine Operators,51-6031.00,Sewing Machine Operators
+51-6041.00,Shoe and Leather Workers and Repairers,51-6041.00,Shoe and Leather Workers and Repairers
+51-6042.00,Shoe Machine Operators and Tenders,51-6042.00,Shoe Machine Operators and Tenders
+51-6051.00,"Sewers, Hand",51-6051.00,"Sewers, Hand"
+51-6052.00,"Tailors, Dressmakers, and Custom Sewers",51-6052.00,"Tailors, Dressmakers, and Custom Sewers"
+51-6061.00,Textile Bleaching and Dyeing Machine Operators and Tenders,51-6061.00,Textile Bleaching and Dyeing Machine Operators and Tenders
+51-6062.00,"Textile Cutting Machine Setters, Operators, and Tenders",51-6062.00,"Textile Cutting Machine Setters, Operators, and Tenders"
+51-6063.00,"Textile Knitting and Weaving Machine Setters, Operators, and Tenders",51-6063.00,"Textile Knitting and Weaving Machine Setters, Operators, and Tenders"
+51-6064.00,"Textile Winding, Twisting, and Drawing Out Machine Setters, Operators, and Tenders",51-6064.00,"Textile Winding, Twisting, and Drawing Out Machine Setters, Operators, and Tenders"
+51-6091.00,"Extruding and Forming Machine Setters, Operators, and Tenders, Synthetic and Glass Fibers",51-6091.00,"Extruding and Forming Machine Setters, Operators, and Tenders, Synthetic and Glass Fibers"
+51-6092.00,Fabric and Apparel Patternmakers,51-6092.00,Fabric and Apparel Patternmakers
+51-6093.00,Upholsterers,51-6093.00,Upholsterers
+51-6099.99,"Textile, Apparel, and Furnishings Workers, All Other",51-6099.00,"Textile, Apparel, and Furnishings Workers, All Other"
+51-7011.00,Cabinetmakers and Bench Carpenters,51-7011.00,Cabinetmakers and Bench Carpenters
+51-7021.00,Furniture Finishers,51-7021.00,Furniture Finishers
+51-7031.00,"Model Makers, Wood",51-7031.00,"Model Makers, Wood"
+51-7032.00,"Patternmakers, Wood",51-7032.00,"Patternmakers, Wood"
+51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood",51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood"
+51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing",51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing"
+51-7099.99,"Woodworkers, All Other",51-7099.00,"Woodworkers, All Other"
+51-8011.00,Nuclear Power Reactor Operators,51-8011.00,Nuclear Power Reactor Operators
+51-8012.00,Power Distributors and Dispatchers,51-8012.00,Power Distributors and Dispatchers
+51-8013.00,Power Plant Operators,51-8013.00,Power Plant Operators
+51-8021.00,Stationary Engineers and Boiler Operators,51-8021.00,Stationary Engineers and Boiler Operators
+51-8031.00,Water and Liquid Waste Treatment Plant and System Operators,51-8031.00,Water and Liquid Waste Treatment Plant and System Operators
+51-8091.00,Chemical Plant and System Operators,51-8091.00,Chemical Plant and System Operators
+51-8092.00,Gas Plant Operators,51-8092.00,Gas Plant Operators
+51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers",51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers"
+51-8099.99,"Plant and System Operators, All Other",51-8099.00,"Plant and System Operators, All Other"
+51-9011.00,Chemical Equipment Operators and Tenders,51-9011.00,Chemical Equipment Operators and Tenders
+51-9012.00,"Separating, Filtering, Clarifying, Precipitating, and Still Machine Setters, Operators, and Tenders",51-9012.00,"Separating, Filtering, Clarifying, Precipitating, and Still Machine Setters, Operators, and Tenders"
+51-9021.00,"Crushing, Grinding, and Polishing Machine Setters, Operators, and Tenders",51-9021.00,"Crushing, Grinding, and Polishing Machine Setters, Operators, and Tenders"
+51-9022.00,"Grinding and Polishing Workers, Hand",51-9022.00,"Grinding and Polishing Workers, Hand"
+51-9023.00,"Mixing and Blending Machine Setters, Operators, and Tenders",51-9023.00,"Mixing and Blending Machine Setters, Operators, and Tenders"
+51-9031.00,"Cutters and Trimmers, Hand",51-9031.00,"Cutters and Trimmers, Hand"
+51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders",51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders"
+51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders",51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders"
+51-9051.00,"Furnace, Kiln, Oven, Drier, and Kettle Operators and Tenders",51-9051.00,"Furnace, Kiln, Oven, Drier, and Kettle Operators and Tenders"
+51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers",51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers"
+51-9071.00,Jewelers and Precious Stone and Metal Workers,51-9071.00,Jewelers and Precious Stone and Metal Workers
+51-9071.01,Jewelers,51-9071.01,Jewelers
+51-9071.06,Gem and Diamond Workers,51-9071.06,Gem and Diamond Workers
+51-9071.07,Precious Metal Workers,51-9071.07,Precious Metal Workers
+51-9081.00,Dental Laboratory Technicians,51-9081.00,Dental Laboratory Technicians
+51-9082.00,Medical Appliance Technicians,51-9082.00,Medical Appliance Technicians
+51-9083.00,Ophthalmic Laboratory Technicians,51-9083.00,Ophthalmic Laboratory Technicians
+51-9111.00,Packaging and Filling Machine Operators and Tenders,51-9111.00,Packaging and Filling Machine Operators and Tenders
+51-9121.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders",51-9121.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders"
+51-9122.00,"Painters, Transportation Equipment",51-9122.00,"Painters, Transportation Equipment"
+51-9123.00,"Painting, Coating, and Decorating Workers",51-9123.00,"Painting, Coating, and Decorating Workers"
+51-9131.00,Photographic Process Workers,51-9131.00,Photographic Process Workers
+51-9132.00,Photographic Processing Machine Operators,51-9132.00,Photographic Processing Machine Operators
+51-9141.00,Semiconductor Processors,51-9141.00,Semiconductor Processors
+51-9191.00,Cementing and Gluing Machine Operators and Tenders,51-9191.00,Cementing and Gluing Machine Operators and Tenders
+51-9192.00,"Cleaning, Washing, and Metal Pickling Equipment Operators and Tenders",51-9192.00,"Cleaning, Washing, and Metal Pickling Equipment Operators and Tenders"
+51-9193.00,Cooling and Freezing Equipment Operators and Tenders,51-9193.00,Cooling and Freezing Equipment Operators and Tenders
+51-9194.00,Etchers and Engravers,51-9194.00,Etchers and Engravers
+51-9195.00,"Molders, Shapers, and Casters, Except Metal and Plastic",51-9195.00,"Molders, Shapers, and Casters, Except Metal and Plastic"
+51-9195.03,"Stone Cutters and Carvers, Manufacturing",51-9195.03,"Stone Cutters and Carvers, Manufacturing"
+51-9195.04,"Glass Blowers, Molders, Benders, and Finishers",51-9195.04,"Glass Blowers, Molders, Benders, and Finishers"
+51-9195.05,"Potters, Manufacturing",51-9195.05,"Potters, Manufacturing"
+51-9195.07,Molding and Casting Workers,51-9195.07,Molding and Casting Workers
+51-9196.00,"Paper Goods Machine Setters, Operators, and Tenders",51-9196.00,"Paper Goods Machine Setters, Operators, and Tenders"
+51-9197.00,Tire Builders,51-9197.00,Tire Builders
+51-9198.00,Helpers--Production Workers,51-9198.00,Helpers--Production Workers
+51-9199.99,"Production Workers, All Other",51-9199.00,"Production Workers, All Other"
+53-1011.00,Aircraft Cargo Handling Supervisors,53-1011.00,Aircraft Cargo Handling Supervisors
+53-1021.00,"First-Line Supervisors/Managers of Helpers, Laborers, and Material Movers, Hand",53-1021.00,"First-Line Supervisors/Managers of Helpers, Laborers, and Material Movers, Hand"
+53-1031.00,First-Line Supervisors/Managers of Transportation and Material-Moving Machine and Vehicle Operators,53-1031.00,First-Line Supervisors/Managers of Transportation and Material-Moving Machine and Vehicle Operators
+53-2011.00,"Airline Pilots, Copilots, and Flight Engineers",53-2011.00,"Airline Pilots, Copilots, and Flight Engineers"
+53-2012.00,Commercial Pilots,53-2012.00,Commercial Pilots
+53-2021.00,Air Traffic Controllers,53-2021.00,Air Traffic Controllers
+53-2022.00,Airfield Operations Specialists,53-2022.00,Airfield Operations Specialists
+53-3011.00,"Ambulance Drivers and Attendants, Except Emergency Medical Technicians",53-3011.00,"Ambulance Drivers and Attendants, Except Emergency Medical Technicians"
+53-3021.00,"Bus Drivers, Transit and Intercity",53-3021.00,"Bus Drivers, Transit and Intercity"
+53-3022.00,"Bus Drivers, School",53-3022.00,"Bus Drivers, School"
+53-3031.00,Driver/Sales Workers,53-3031.00,Driver/Sales Workers
+53-3032.00,"Truck Drivers, Heavy and Tractor-Trailer",53-3032.00,"Truck Drivers, Heavy and Tractor-Trailer"
+53-3033.00,"Truck Drivers, Light or Delivery Services",53-3033.00,"Truck Drivers, Light or Delivery Services"
+53-3041.00,Taxi Drivers and Chauffeurs,53-3041.00,Taxi Drivers and Chauffeurs
+53-3099.99,"Motor Vehicle Operators, All Other",53-3099.00,"Motor Vehicle Operators, All Other"
+53-4011.00,Locomotive Engineers,53-4011.00,Locomotive Engineers
+53-4012.00,Locomotive Firers,53-4012.00,Locomotive Firers
+53-4013.00,"Rail Yard Engineers, Dinkey Operators, and Hostlers",53-4013.00,"Rail Yard Engineers, Dinkey Operators, and Hostlers"
+53-4021.00,"Railroad Brake, Signal, and Switch Operators",53-4021.00,"Railroad Brake, Signal, and Switch Operators"
+53-4031.00,Railroad Conductors and Yardmasters,53-4031.00,Railroad Conductors and Yardmasters
+53-4041.00,Subway and Streetcar Operators,53-4041.00,Subway and Streetcar Operators
+53-4099.99,"Rail Transportation Workers, All Other",53-4099.00,"Rail Transportation Workers, All Other"
+53-5011.00,Sailors and Marine Oilers,53-5011.00,Sailors and Marine Oilers
+53-5021.00,"Captains, Mates, and Pilots of Water Vessels",53-5021.00,"Captains, Mates, and Pilots of Water Vessels"
+53-5021.01,Ship and Boat Captains,53-5021.01,Ship and Boat Captains
+53-5021.02,"Mates- Ship, Boat, and Barge",53-5021.02,"Mates- Ship, Boat, and Barge"
+53-5021.03,"Pilots, Ship",53-5021.03,"Pilots, Ship"
+53-5022.00,Motorboat Operators,53-5022.00,Motorboat Operators
+53-5031.00,Ship Engineers,53-5031.00,Ship Engineers
+53-6011.00,Bridge and Lock Tenders,53-6011.00,Bridge and Lock Tenders
+53-6021.00,Parking Lot Attendants,53-6021.00,Parking Lot Attendants
+53-6031.00,Service Station Attendants,53-6031.00,Service Station Attendants
+53-6041.00,Traffic Technicians,53-6041.00,Traffic Technicians
+53-6051.00,Transportation Inspectors,53-6051.00,Transportation Inspectors
+53-6051.01,Aviation Inspectors,53-6051.01,Aviation Inspectors
+53-6051.07,"Transportation Vehicle, Equipment and Systems Inspectors, Except Aviation",53-6051.07,"Transportation Vehicle, Equipment and Systems Inspectors, Except Aviation"
+53-6051.08,Freight and Cargo Inspectors,53-6051.08,Freight and Cargo Inspectors
+53-6099.99,"Transportation Workers, All Other",53-6099.00,"Transportation Workers, All Other"
+53-7011.00,Conveyor Operators and Tenders,53-7011.00,Conveyor Operators and Tenders
+53-7021.00,Crane and Tower Operators,53-7021.00,Crane and Tower Operators
+53-7031.00,Dredge Operators,53-7031.00,Dredge Operators
+53-7032.00,Excavating and Loading Machine and Dragline Operators,53-7032.00,Excavating and Loading Machine and Dragline Operators
+53-7033.00,"Loading Machine Operators, Underground Mining",53-7033.00,"Loading Machine Operators, Underground Mining"
+53-7041.00,Hoist and Winch Operators,53-7041.00,Hoist and Winch Operators
+53-7051.00,Industrial Truck and Tractor Operators,53-7051.00,Industrial Truck and Tractor Operators
+53-7061.00,Cleaners of Vehicles and Equipment,53-7061.00,Cleaners of Vehicles and Equipment
+53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand",53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand"
+53-7063.00,Machine Feeders and Offbearers,53-7063.00,Machine Feeders and Offbearers
+53-7064.00,"Packers and Packagers, Hand",53-7064.00,"Packers and Packagers, Hand"
+53-7071.00,Gas Compressor and Gas Pumping Station Operators,53-7071.00,Gas Compressor and Gas Pumping Station Operators
+53-7072.00,"Pump Operators, Except Wellhead Pumpers",53-7072.00,"Pump Operators, Except Wellhead Pumpers"
+53-7073.00,Wellhead Pumpers,53-7073.00,Wellhead Pumpers
+53-7081.00,Refuse and Recyclable Material Collectors,53-7081.00,Refuse and Recyclable Material Collectors
+53-7111.00,Shuttle Car Operators,53-7111.00,Shuttle Car Operators
+53-7121.00,"Tank Car, Truck, and Ship Loaders",53-7121.00,"Tank Car, Truck, and Ship Loaders"
+53-7199.99,"Material Moving Workers, All Other",53-7199.00,"Material Moving Workers, All Other"
+55-1011.00,Air Crew Officers,55-1011.00,Air Crew Officers
+55-1012.00,Aircraft Launch and Recovery Officers,55-1012.00,Aircraft Launch and Recovery Officers
+55-1013.00,Armored Assault Vehicle Officers,55-1013.00,Armored Assault Vehicle Officers
+55-1014.00,Artillery and Missile Officers,55-1014.00,Artillery and Missile Officers
+55-1015.00,Command and Control Center Officers,55-1015.00,Command and Control Center Officers
+55-1016.00,Infantry Officers,55-1016.00,Infantry Officers
+55-1017.00,Special Forces Officers,55-1017.00,Special Forces Officers
+55-1019.99,"Military Officer Special and Tactical Operations Leaders/Managers, All Other",55-1019.00,"Military Officer Special and Tactical Operations Leaders/Managers, All Other"
+55-2011.00,First-Line Supervisors/Managers of Air Crew Members,55-2011.00,First-Line Supervisors/Managers of Air Crew Members
+55-2012.00,First-Line Supervisors/Managers of Weapons Specialists/Crew Members,55-2012.00,First-Line Supervisors/Managers of Weapons Specialists/Crew Members
+55-2013.00,First-Line Supervisors/Managers of All Other Tactical Operations Specialists,55-2013.00,First-Line Supervisors/Managers of All Other Tactical Operations Specialists
+55-3011.00,Air Crew Members,55-3011.00,Air Crew Members
+55-3012.00,Aircraft Launch and Recovery Specialists,55-3012.00,Aircraft Launch and Recovery Specialists
+55-3013.00,Armored Assault Vehicle Crew Members,55-3013.00,Armored Assault Vehicle Crew Members
+55-3014.00,Artillery and Missile Crew Members,55-3014.00,Artillery and Missile Crew Members
+55-3015.00,Command and Control Center Specialists,55-3015.00,Command and Control Center Specialists
+55-3016.00,Infantry,55-3016.00,Infantry
+55-3017.00,Radar and Sonar Technicians,55-3017.00,Radar and Sonar Technicians
+55-3018.00,Special Forces,55-3018.00,Special Forces
+55-3019.99,"Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members, All Other",55-3019.00,"Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members, All Other"

--- a/lib/tasks/files/2009_to_2010_Crosswalk.csv
+++ b/lib/tasks/files/2009_to_2010_Crosswalk.csv
@@ -1,0 +1,1111 @@
+O*NET-SOC 2009 Code,O*NET-SOC 2009 Title,O*NET-SOC 2010 Code,O*NET-SOC 2010 Title
+11-1011.00,Chief Executives,11-1011.00,Chief Executives
+11-1011.03,Chief Sustainability Officers,11-1011.03,Chief Sustainability Officers
+11-1021.00,General and Operations Managers,11-1021.00,General and Operations Managers
+11-1031.00,Legislators,11-1031.00,Legislators
+11-2011.00,Advertising and Promotions Managers,11-2011.00,Advertising and Promotions Managers
+11-2011.01,Green Marketers,11-2011.01,Green Marketers
+11-2021.00,Marketing Managers,11-2021.00,Marketing Managers
+11-2022.00,Sales Managers,11-2022.00,Sales Managers
+11-2031.00,Public Relations Managers,11-2031.00,Public Relations and Fundraising Managers
+11-3011.00,Administrative Services Managers,11-3011.00,Administrative Services Managers
+11-3021.00,Computer and Information Systems Managers,11-3021.00,Computer and Information Systems Managers
+11-3031.00,Financial Managers,11-3031.00,Financial Managers
+11-3031.01,Treasurers and Controllers,11-3031.01,Treasurers and Controllers
+11-3031.02,"Financial Managers, Branch or Department",11-3031.02,"Financial Managers, Branch or Department"
+11-3040.00,Human Resources Managers,11-3121.00,Human Resources Managers
+11-3041.00,Compensation and Benefits Managers,11-3111.00,Compensation and Benefits Managers
+11-3042.00,Training and Development Managers,11-3131.00,Training and Development Managers
+11-3049.00,"Human Resources Managers, All Other",11-3121.00,Human Resources Managers
+11-3051.00,Industrial Production Managers,11-3051.00,Industrial Production Managers
+11-3051.01,Quality Control Systems Managers,11-3051.01,Quality Control Systems Managers
+11-3051.02,Geothermal Production Managers,11-3051.02,Geothermal Production Managers
+11-3051.03,Biofuels Production Managers,11-3051.03,Biofuels Production Managers
+11-3051.04,Biomass Production Managers,11-3051.04,Biomass Power Plant Managers
+11-3051.05,Methane/Landfill Gas Collection System Operators,11-3051.05,Methane/Landfill Gas Collection System Operators
+11-3051.06,Hydroelectric Production Managers,11-3051.06,Hydroelectric Production Managers
+11-3061.00,Purchasing Managers,11-3061.00,Purchasing Managers
+11-3071.00,"Transportation, Storage, and Distribution Managers",11-3071.00,"Transportation, Storage, and Distribution Managers"
+11-3071.01,Transportation Managers,11-3071.01,Transportation Managers
+11-3071.02,Storage and Distribution Managers,11-3071.02,Storage and Distribution Managers
+11-9011.00,"Farm, Ranch, and Other Agricultural Managers",11-9013.00,"Farmers, Ranchers, and Other Agricultural Managers"
+11-9011.01,Nursery and Greenhouse Managers,11-9013.01,Nursery and Greenhouse Managers
+11-9011.02,Crop and Livestock Managers,11-9013.02,Farm and Ranch Managers
+11-9011.03,Aquacultural Managers,11-9013.03,Aquacultural Managers
+11-9012.00,Farmers and Ranchers,11-9013.02,Farm and Ranch Managers
+11-9021.00,Construction Managers,11-9021.00,Construction Managers
+11-9031.00,"Education Administrators, Preschool and Child Care Center/Program",11-9031.00,"Education Administrators, Preschool and Childcare Center/Program"
+11-9032.00,"Education Administrators, Elementary and Secondary School",11-9032.00,"Education Administrators, Elementary and Secondary School"
+11-9033.00,"Education Administrators, Postsecondary",11-9033.00,"Education Administrators, Postsecondary"
+11-9039.00,"Education Administrators, All Other",11-9039.00,"Education Administrators, All Other"
+11-9039.01,Distance Learning Coordinators,11-9039.01,Distance Learning Coordinators
+11-9039.02,Fitness and Wellness Coordinators,11-9039.02,Fitness and Wellness Coordinators
+11-9041.00,Engineering Managers,11-9041.00,Architectural and Engineering Managers
+11-9041.01,Biofuels/Biodiesel Technology and Product Development Managers,11-9041.01,Biofuels/Biodiesel Technology and Product Development Managers
+11-9051.00,Food Service Managers,11-9051.00,Food Service Managers
+11-9061.00,Funeral Directors,39-4031.00,"Morticians, Undertakers, and Funeral Directors"
+11-9071.00,Gaming Managers,11-9071.00,Gaming Managers
+11-9081.00,Lodging Managers,11-9081.00,Lodging Managers
+11-9111.00,Medical and Health Services Managers,11-9111.00,Medical and Health Services Managers
+11-9111.01,Clinical Nurse Specialists,29-1141.04,Clinical Nurse Specialists
+11-9121.00,Natural Sciences Managers,11-9121.00,Natural Sciences Managers
+11-9121.01,Clinical Research Coordinators,11-9121.01,Clinical Research Coordinators
+11-9121.02,Water Resource Specialists,11-9121.02,Water Resource Specialists
+11-9131.00,Postmasters and Mail Superintendents,11-9131.00,Postmasters and Mail Superintendents
+11-9141.00,"Property, Real Estate, and Community Association Managers",11-9141.00,"Property, Real Estate, and Community Association Managers"
+11-9151.00,Social and Community Service Managers,11-9151.00,Social and Community Service Managers
+11-9199.00,"Managers, All Other",11-9199.00,"Managers, All Other"
+11-9199.01,Regulatory Affairs Managers,11-9199.01,Regulatory Affairs Managers
+11-9199.02,Compliance Managers,11-9199.02,Compliance Managers
+11-9199.03,Investment Fund Managers,11-9199.03,Investment Fund Managers
+11-9199.04,Supply Chain Managers,11-9199.04,Supply Chain Managers
+11-9199.05,Online Merchants,13-1199.06,Online Merchants
+11-9199.06,Logistics Managers,11-3071.03,Logistics Managers
+11-9199.07,Security Managers,11-9199.07,Security Managers
+11-9199.08,Loss Prevention Managers,11-9199.08,Loss Prevention Managers
+11-9199.09,Wind Energy Operations Managers,11-9199.09,Wind Energy Operations Managers
+11-9199.10,Wind Energy Project Managers,11-9199.10,Wind Energy Project Managers
+11-9199.11,Brownfield Redevelopment Specialists and Site Managers,11-9199.11,Brownfield Redevelopment Specialists and Site Managers
+13-1011.00,"Agents and Business Managers of Artists, Performers, and Athletes",13-1011.00,"Agents and Business Managers of Artists, Performers, and Athletes"
+13-1021.00,"Purchasing Agents and Buyers, Farm Products",13-1021.00,"Buyers and Purchasing Agents, Farm Products"
+13-1022.00,"Wholesale and Retail Buyers, Except Farm Products",13-1022.00,"Wholesale and Retail Buyers, Except Farm Products"
+13-1023.00,"Purchasing Agents, Except Wholesale, Retail, and Farm Products",13-1023.00,"Purchasing Agents, Except Wholesale, Retail, and Farm Products"
+13-1031.00,"Claims Adjusters, Examiners, and Investigators",13-1031.00,"Claims Adjusters, Examiners, and Investigators"
+13-1031.01,"Claims Examiners, Property and Casualty Insurance",13-1031.01,"Claims Examiners, Property and Casualty Insurance"
+13-1031.02,"Insurance Adjusters, Examiners, and Investigators",13-1031.02,"Insurance Adjusters, Examiners, and Investigators"
+13-1032.00,"Insurance Appraisers, Auto Damage",13-1032.00,"Insurance Appraisers, Auto Damage"
+13-1041.00,"Compliance Officers, Except Agriculture, Construction, Health and Safety, and Transportation",13-1041.00,Compliance Officers
+13-1041.01,Environmental Compliance Inspectors,13-1041.01,Environmental Compliance Inspectors
+13-1041.02,Licensing Examiners and Inspectors,13-1041.02,Licensing Examiners and Inspectors
+13-1041.03,Equal Opportunity Representatives and Officers,13-1041.03,Equal Opportunity Representatives and Officers
+13-1041.04,Government Property Inspectors and Investigators,13-1041.04,Government Property Inspectors and Investigators
+13-1041.06,Coroners,13-1041.06,Coroners
+13-1041.07,Regulatory Affairs Specialists,13-1041.07,Regulatory Affairs Specialists
+13-1051.00,Cost Estimators,13-1051.00,Cost Estimators
+13-1061.00,Emergency Management Specialists,11-9161.00,Emergency Management Directors
+13-1071.00,"Employment, Recruitment, and Placement Specialists",13-1071.00,Human Resources Specialists
+13-1071.01,Employment Interviewers,13-1071.00,Human Resources Specialists
+13-1071.02,Personnel Recruiters,13-1071.00,Human Resources Specialists
+13-1072.00,"Compensation, Benefits, and Job Analysis Specialists",13-1141.00,"Compensation, Benefits, and Job Analysis Specialists"
+13-1073.00,Training and Development Specialists,13-1151.00,Training and Development Specialists
+13-1079.00,"Human Resources, Training, and Labor Relations Specialists, All Other",13-1071.00,Human Resources Specialists
+13-1079.00,"Human Resources, Training, and Labor Relations Specialists, All Other",13-1075.00,Labor Relations Specialists
+13-1081.00,Logisticians,13-1081.00,Logisticians
+13-1081.01,Logistics Engineers,13-1081.01,Logistics Engineers
+13-1081.02,Logistics Analysts,13-1081.02,Logistics Analysts
+13-1111.00,Management Analysts,13-1111.00,Management Analysts
+13-1121.00,Meeting and Convention Planners,13-1121.00,"Meeting, Convention, and Event Planners"
+13-1199.00,"Business Operations Specialists, All Other",13-1199.00,"Business Operations Specialists, All Other"
+13-1199.01,Energy Auditors,13-1199.01,Energy Auditors
+13-1199.02,Security Management Specialists,13-1199.02,Security Management Specialists
+13-1199.03,Customs Brokers,13-1199.03,Customs Brokers
+13-1199.04,Business Continuity Planners,13-1199.04,Business Continuity Planners
+13-1199.05,Sustainability Specialists,13-1199.05,Sustainability Specialists
+13-2011.00,Accountants and Auditors,13-2011.00,Accountants and Auditors
+13-2011.01,Accountants,13-2011.01,Accountants
+13-2011.02,Auditors,13-2011.02,Auditors
+13-2021.00,Appraisers and Assessors of Real Estate,13-2021.00,Appraisers and Assessors of Real Estate
+13-2021.01,Assessors,13-2021.01,Assessors
+13-2021.02,"Appraisers, Real Estate",13-2021.02,"Appraisers, Real Estate"
+13-2031.00,Budget Analysts,13-2031.00,Budget Analysts
+13-2041.00,Credit Analysts,13-2041.00,Credit Analysts
+13-2051.00,Financial Analysts,13-2051.00,Financial Analysts
+13-2052.00,Personal Financial Advisors,13-2052.00,Personal Financial Advisors
+13-2053.00,Insurance Underwriters,13-2053.00,Insurance Underwriters
+13-2061.00,Financial Examiners,13-2061.00,Financial Examiners
+13-2071.00,Loan Counselors,13-2071.01,Loan Counselors
+13-2072.00,Loan Officers,13-2072.00,Loan Officers
+13-2081.00,"Tax Examiners, Collectors, and Revenue Agents",13-2081.00,"Tax Examiners and Collectors, and Revenue Agents"
+13-2082.00,Tax Preparers,13-2082.00,Tax Preparers
+13-2099.00,"Financial Specialists, All Other",13-2099.00,"Financial Specialists, All Other"
+13-2099.01,Financial Quantitative Analysts,13-2099.01,Financial Quantitative Analysts
+13-2099.02,Risk Management Specialists,13-2099.02,Risk Management Specialists
+13-2099.03,Investment Underwriters,13-2099.03,Investment Underwriters
+13-2099.04,"Fraud Examiners, Investigators and Analysts",13-2099.04,"Fraud Examiners, Investigators and Analysts"
+15-1011.00,"Computer and Information Scientists, Research",15-1111.00,Computer and Information Research Scientists
+15-1021.00,Computer Programmers,15-1131.00,Computer Programmers
+15-1031.00,"Computer Software Engineers, Applications",15-1132.00,"Software Developers, Applications"
+15-1032.00,"Computer Software Engineers, Systems Software",15-1133.00,"Software Developers, Systems Software"
+15-1041.00,Computer Support Specialists,15-1151.00,Computer User Support Specialists
+15-1051.00,Computer Systems Analysts,15-1121.00,Computer Systems Analysts
+15-1051.01,Informatics Nurse Specialists,15-1121.01,Informatics Nurse Specialists
+15-1061.00,Database Administrators,15-1141.00,Database Administrators
+15-1071.00,Network and Computer Systems Administrators,15-1142.00,Network and Computer Systems Administrators
+15-1071.01,Computer Security Specialists,15-1122.00,Information Security Analysts
+15-1081.00,Network Systems and Data Communications Analysts,15-1143.00,Computer Network Architects
+15-1081.00,Network Systems and Data Communications Analysts,15-1152.00,Computer Network Support Specialists
+15-1081.01,Telecommunications Specialists,15-1143.01,Telecommunications Engineering Specialists
+15-1099.00,"Computer Specialists, All Other",15-1199.00,"Computer Occupations, All Other"
+15-1099.01,Software Quality Assurance Engineers and Testers,15-1199.01,Software Quality Assurance Engineers and Testers
+15-1099.02,Computer Systems Engineers/Architects,15-1199.02,Computer Systems Engineers/Architects
+15-1099.03,Network Designers,15-1143.00,Computer Network Architects
+15-1099.04,Web Developers,15-1134.00,Web Developers
+15-1099.05,Web Administrators,15-1199.03,Web Administrators
+15-1099.06,Geospatial Information Scientists and Technologists,15-1199.04,Geospatial Information Scientists and Technologists
+15-1099.07,Geographic Information Systems Technicians,15-1199.05,Geographic Information Systems Technicians
+15-1099.08,Database Architects,15-1199.06,Database Architects
+15-1099.09,Data Warehousing Specialists,15-1199.07,Data Warehousing Specialists
+15-1099.10,Business Intelligence Analysts,15-1199.08,Business Intelligence Analysts
+15-1099.11,Information Technology Project Managers,15-1199.09,Information Technology Project Managers
+15-1099.12,Electronic Commerce Specialists,15-1199.10,Search Marketing Strategists
+15-1099.13,Video Game Designers,15-1199.11,Video Game Designers
+15-1099.14,Document Management Specialists,15-1199.12,Document Management Specialists
+15-2011.00,Actuaries,15-2011.00,Actuaries
+15-2021.00,Mathematicians,15-2021.00,Mathematicians
+15-2031.00,Operations Research Analysts,15-2031.00,Operations Research Analysts
+15-2041.00,Statisticians,15-2041.00,Statisticians
+15-2041.01,Biostatisticians,15-2041.01,Biostatisticians
+15-2041.02,Clinical Data Managers,15-2041.02,Clinical Data Managers
+15-2091.00,Mathematical Technicians,15-2091.00,Mathematical Technicians
+15-2099.00,"Mathematical Science Occupations, All Other",15-2099.00,"Mathematical Science Occupations, All Other"
+17-1011.00,"Architects, Except Landscape and Naval",17-1011.00,"Architects, Except Landscape and Naval"
+17-1012.00,Landscape Architects,17-1012.00,Landscape Architects
+17-1021.00,Cartographers and Photogrammetrists,17-1021.00,Cartographers and Photogrammetrists
+17-1022.00,Surveyors,17-1022.00,Surveyors
+17-1022.01,Geodetic Surveyors,17-1022.01,Geodetic Surveyors
+17-2011.00,Aerospace Engineers,17-2011.00,Aerospace Engineers
+17-2021.00,Agricultural Engineers,17-2021.00,Agricultural Engineers
+17-2031.00,Biomedical Engineers,17-2031.00,Biomedical Engineers
+17-2041.00,Chemical Engineers,17-2041.00,Chemical Engineers
+17-2051.00,Civil Engineers,17-2051.00,Civil Engineers
+17-2051.01,Transportation Engineers,17-2051.01,Transportation Engineers
+17-2051.02,Water/Wastewater Engineers,17-2081.01,Water/Wastewater Engineers
+17-2061.00,Computer Hardware Engineers,17-2061.00,Computer Hardware Engineers
+17-2071.00,Electrical Engineers,17-2071.00,Electrical Engineers
+17-2072.00,"Electronics Engineers, Except Computer",17-2072.00,"Electronics Engineers, Except Computer"
+17-2072.01,Radio Frequency Identification Device Specialists,17-2072.01,Radio Frequency Identification Device Specialists
+17-2081.00,Environmental Engineers,17-2081.00,Environmental Engineers
+17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors",17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors"
+17-2111.01,Industrial Safety and Health Engineers,17-2111.01,Industrial Safety and Health Engineers
+17-2111.02,Fire-Prevention and Protection Engineers,17-2111.02,Fire-Prevention and Protection Engineers
+17-2111.03,Product Safety Engineers,17-2111.03,Product Safety Engineers
+17-2112.00,Industrial Engineers,17-2112.00,Industrial Engineers
+17-2112.01,Human Factors Engineers and Ergonomists,17-2112.01,Human Factors Engineers and Ergonomists
+17-2121.00,Marine Engineers and Naval Architects,17-2121.00,Marine Engineers and Naval Architects
+17-2121.01,Marine Engineers,17-2121.01,Marine Engineers
+17-2121.02,Marine Architects,17-2121.02,Marine Architects
+17-2131.00,Materials Engineers,17-2131.00,Materials Engineers
+17-2141.00,Mechanical Engineers,17-2141.00,Mechanical Engineers
+17-2141.01,Fuel Cell Engineers,17-2141.01,Fuel Cell Engineers
+17-2141.02,Automotive Engineers,17-2141.02,Automotive Engineers
+17-2151.00,"Mining and Geological Engineers, Including Mining Safety Engineers",17-2151.00,"Mining and Geological Engineers, Including Mining Safety Engineers"
+17-2161.00,Nuclear Engineers,17-2161.00,Nuclear Engineers
+17-2171.00,Petroleum Engineers,17-2171.00,Petroleum Engineers
+17-2199.00,"Engineers, All Other",17-2199.00,"Engineers, All Other"
+17-2199.01,Biochemical Engineers,17-2199.01,Biochemical Engineers
+17-2199.02,Validation Engineers,17-2199.02,Validation Engineers
+17-2199.03,Energy Engineers,17-2199.03,Energy Engineers
+17-2199.04,Manufacturing Engineers,17-2199.04,Manufacturing Engineers
+17-2199.05,Mechatronics Engineers,17-2199.05,Mechatronics Engineers
+17-2199.06,Microsystems Engineers,17-2199.06,Microsystems Engineers
+17-2199.07,Photonics Engineers,17-2199.07,Photonics Engineers
+17-2199.08,Robotics Engineers,17-2199.08,Robotics Engineers
+17-2199.09,Nanosystems Engineers,17-2199.09,Nanosystems Engineers
+17-2199.10,Wind Energy Engineers,17-2199.10,Wind Energy Engineers
+17-2199.11,Solar Energy Systems Engineers,17-2199.11,Solar Energy Systems Engineers
+17-3011.00,Architectural and Civil Drafters,17-3011.00,Architectural and Civil Drafters
+17-3011.01,Architectural Drafters,17-3011.01,Architectural Drafters
+17-3011.02,Civil Drafters,17-3011.02,Civil Drafters
+17-3012.00,Electrical and Electronics Drafters,17-3012.00,Electrical and Electronics Drafters
+17-3012.01,Electronic Drafters,17-3012.01,Electronic Drafters
+17-3012.02,Electrical Drafters,17-3012.02,Electrical Drafters
+17-3013.00,Mechanical Drafters,17-3013.00,Mechanical Drafters
+17-3019.00,"Drafters, All Other",17-3019.00,"Drafters, All Other"
+17-3021.00,Aerospace Engineering and Operations Technicians,17-3021.00,Aerospace Engineering and Operations Technicians
+17-3022.00,Civil Engineering Technicians,17-3022.00,Civil Engineering Technicians
+17-3023.00,Electrical and Electronic Engineering Technicians,17-3023.00,Electrical and Electronic Engineering Technicians
+17-3023.01,Electronics Engineering Technicians,17-3023.01,Electronics Engineering Technicians
+17-3023.03,Electrical Engineering Technicians,17-3023.03,Electrical Engineering Technicians
+17-3024.00,Electro-Mechanical Technicians,17-3024.00,Electro-Mechanical Technicians
+17-3024.01,Robotics Technicians,17-3024.01,Robotics Technicians
+17-3025.00,Environmental Engineering Technicians,17-3025.00,Environmental Engineering Technicians
+17-3026.00,Industrial Engineering Technicians,17-3026.00,Industrial Engineering Technicians
+17-3027.00,Mechanical Engineering Technicians,17-3027.00,Mechanical Engineering Technicians
+17-3027.01,Automotive Engineering Technicians,17-3027.01,Automotive Engineering Technicians
+17-3029.00,"Engineering Technicians, Except Drafters, All Other",17-3029.00,"Engineering Technicians, Except Drafters, All Other"
+17-3029.01,Non-Destructive Testing Specialists,17-3029.01,Non-Destructive Testing Specialists
+17-3029.02,Electrical Engineering Technologists,17-3029.02,Electrical Engineering Technologists
+17-3029.03,Electromechanical Engineering Technologists,17-3029.03,Electromechanical Engineering Technologists
+17-3029.04,Electronics Engineering Technologists,17-3029.04,Electronics Engineering Technologists
+17-3029.05,Industrial Engineering Technologists,17-3029.05,Industrial Engineering Technologists
+17-3029.06,Manufacturing Engineering Technologists,17-3029.06,Manufacturing Engineering Technologists
+17-3029.07,Mechanical Engineering Technologists,17-3029.07,Mechanical Engineering Technologists
+17-3029.08,Photonics Technicians,17-3029.08,Photonics Technicians
+17-3029.09,Manufacturing Production Technicians,17-3029.09,Manufacturing Production Technicians
+17-3029.10,Fuel Cell Technicians,17-3029.10,Fuel Cell Technicians
+17-3029.11,Nanotechnology Engineering Technologists,17-3029.11,Nanotechnology Engineering Technologists
+17-3029.12,Nanotechnology Engineering Technicians,17-3029.12,Nanotechnology Engineering Technicians
+17-3031.00,Surveying and Mapping Technicians,17-3031.00,Surveying and Mapping Technicians
+17-3031.01,Surveying Technicians,17-3031.01,Surveying Technicians
+17-3031.02,Mapping Technicians,17-3031.02,Mapping Technicians
+19-1011.00,Animal Scientists,19-1011.00,Animal Scientists
+19-1012.00,Food Scientists and Technologists,19-1012.00,Food Scientists and Technologists
+19-1013.00,Soil and Plant Scientists,19-1013.00,Soil and Plant Scientists
+19-1020.01,Biologists,19-1020.01,Biologists
+19-1021.00,Biochemists and Biophysicists,19-1021.00,Biochemists and Biophysicists
+19-1022.00,Microbiologists,19-1022.00,Microbiologists
+19-1023.00,Zoologists and Wildlife Biologists,19-1023.00,Zoologists and Wildlife Biologists
+19-1029.00,"Biological Scientists, All Other",19-1029.00,"Biological Scientists, All Other"
+19-1029.01,Bioinformatics Scientists,19-1029.01,Bioinformatics Scientists
+19-1029.02,Molecular and Cellular Biologists,19-1029.02,Molecular and Cellular Biologists
+19-1029.03,Geneticists,19-1029.03,Geneticists
+19-1031.00,Conservation Scientists,19-1031.00,Conservation Scientists
+19-1031.01,Soil and Water Conservationists,19-1031.01,Soil and Water Conservationists
+19-1031.02,Range Managers,19-1031.02,Range Managers
+19-1031.03,Park Naturalists,19-1031.03,Park Naturalists
+19-1032.00,Foresters,19-1032.00,Foresters
+19-1041.00,Epidemiologists,19-1041.00,Epidemiologists
+19-1042.00,"Medical Scientists, Except Epidemiologists",19-1042.00,"Medical Scientists, Except Epidemiologists"
+19-1099.00,"Life Scientists, All Other",19-1099.00,"Life Scientists, All Other"
+19-2011.00,Astronomers,19-2011.00,Astronomers
+19-2012.00,Physicists,19-2012.00,Physicists
+19-2021.00,Atmospheric and Space Scientists,19-2021.00,Atmospheric and Space Scientists
+19-2031.00,Chemists,19-2031.00,Chemists
+19-2032.00,Materials Scientists,19-2032.00,Materials Scientists
+19-2041.00,"Environmental Scientists and Specialists, Including Health",19-2041.00,"Environmental Scientists and Specialists, Including Health"
+19-2041.01,Climate Change Analysts,19-2041.01,Climate Change Analysts
+19-2041.02,Environmental Restoration Planners,19-2041.02,Environmental Restoration Planners
+19-2041.03,Industrial Ecologists,19-2041.03,Industrial Ecologists
+19-2042.00,"Geoscientists, Except Hydrologists and Geographers",19-2042.00,"Geoscientists, Except Hydrologists and Geographers"
+19-2043.00,Hydrologists,19-2043.00,Hydrologists
+19-2099.00,"Physical Scientists, All Other",19-2099.00,"Physical Scientists, All Other"
+19-2099.01,Remote Sensing Scientists and Technologists,19-2099.01,Remote Sensing Scientists and Technologists
+19-3011.00,Economists,19-3011.00,Economists
+19-3011.01,Environmental Economists,19-3011.01,Environmental Economists
+19-3021.00,Market Research Analysts,13-1161.00,Market Research Analysts and Marketing Specialists
+19-3022.00,Survey Researchers,19-3022.00,Survey Researchers
+19-3031.00,"Clinical, Counseling, and School Psychologists",19-3031.00,"Clinical, Counseling, and School Psychologists"
+19-3031.01,School Psychologists,19-3031.01,School Psychologists
+19-3031.02,Clinical Psychologists,19-3031.02,Clinical Psychologists
+19-3031.03,Counseling Psychologists,19-3031.03,Counseling Psychologists
+19-3032.00,Industrial-Organizational Psychologists,19-3032.00,Industrial-Organizational Psychologists
+19-3039.00,"Psychologists, All Other",19-3039.00,"Psychologists, All Other"
+19-3039.01,Neuropsychologists and Clinical Neuropsychologists,19-3039.01,Neuropsychologists and Clinical Neuropsychologists
+19-3041.00,Sociologists,19-3041.00,Sociologists
+19-3051.00,Urban and Regional Planners,19-3051.00,Urban and Regional Planners
+19-3091.00,Anthropologists and Archeologists,19-3091.00,Anthropologists and Archeologists
+19-3091.01,Anthropologists,19-3091.01,Anthropologists
+19-3091.02,Archeologists,19-3091.02,Archeologists
+19-3092.00,Geographers,19-3092.00,Geographers
+19-3093.00,Historians,19-3093.00,Historians
+19-3094.00,Political Scientists,19-3094.00,Political Scientists
+19-3099.00,"Social Scientists and Related Workers, All Other",19-3099.00,"Social Scientists and Related Workers, All Other"
+19-3099.01,Transportation Planners,19-3099.01,Transportation Planners
+19-4011.00,Agricultural and Food Science Technicians,19-4011.00,Agricultural and Food Science Technicians
+19-4011.01,Agricultural Technicians,19-4011.01,Agricultural Technicians
+19-4011.02,Food Science Technicians,19-4011.02,Food Science Technicians
+19-4021.00,Biological Technicians,19-4021.00,Biological Technicians
+19-4031.00,Chemical Technicians,19-4031.00,Chemical Technicians
+19-4041.00,Geological and Petroleum Technicians,19-4041.00,Geological and Petroleum Technicians
+19-4041.01,Geophysical Data Technicians,19-4041.01,Geophysical Data Technicians
+19-4041.02,Geological Sample Test Technicians,19-4041.02,Geological Sample Test Technicians
+19-4051.00,Nuclear Technicians,19-4051.00,Nuclear Technicians
+19-4051.01,Nuclear Equipment Operation Technicians,19-4051.01,Nuclear Equipment Operation Technicians
+19-4051.02,Nuclear Monitoring Technicians,19-4051.02,Nuclear Monitoring Technicians
+19-4061.00,Social Science Research Assistants,19-4061.00,Social Science Research Assistants
+19-4061.01,City and Regional Planning Aides,19-4061.01,City and Regional Planning Aides
+19-4091.00,"Environmental Science and Protection Technicians, Including Health",19-4091.00,"Environmental Science and Protection Technicians, Including Health"
+19-4092.00,Forensic Science Technicians,19-4092.00,Forensic Science Technicians
+19-4093.00,Forest and Conservation Technicians,19-4093.00,Forest and Conservation Technicians
+19-4099.00,"Life, Physical, and Social Science Technicians, All Other",19-4099.00,"Life, Physical, and Social Science Technicians, All Other"
+19-4099.01,Quality Control Analysts,19-4099.01,Quality Control Analysts
+19-4099.02,Precision Agriculture Technicians,19-4099.02,Precision Agriculture Technicians
+19-4099.03,Remote Sensing Technicians,19-4099.03,Remote Sensing Technicians
+21-1011.00,Substance Abuse and Behavioral Disorder Counselors,21-1011.00,Substance Abuse and Behavioral Disorder Counselors
+21-1012.00,"Educational, Vocational, and School Counselors",21-1012.00,"Educational, Guidance, School, and Vocational Counselors"
+21-1013.00,Marriage and Family Therapists,21-1013.00,Marriage and Family Therapists
+21-1014.00,Mental Health Counselors,21-1014.00,Mental Health Counselors
+21-1015.00,Rehabilitation Counselors,21-1015.00,Rehabilitation Counselors
+21-1019.00,"Counselors, All Other",21-1019.00,"Counselors, All Other"
+21-1021.00,"Child, Family, and School Social Workers",21-1021.00,"Child, Family, and School Social Workers"
+21-1022.00,Medical and Public Health Social Workers,21-1022.00,Healthcare Social Workers
+21-1023.00,Mental Health and Substance Abuse Social Workers,21-1023.00,Mental Health and Substance Abuse Social Workers
+21-1029.00,"Social Workers, All Other",21-1029.00,"Social Workers, All Other"
+21-1091.00,Health Educators,21-1091.00,Health Educators
+21-1092.00,Probation Officers and Correctional Treatment Specialists,21-1092.00,Probation Officers and Correctional Treatment Specialists
+21-1093.00,Social and Human Service Assistants,21-1093.00,Social and Human Service Assistants
+21-1099.00,"Community and Social Service Specialists, All Other",21-1099.00,"Community and Social Service Specialists, All Other"
+21-2011.00,Clergy,21-2011.00,Clergy
+21-2021.00,"Directors, Religious Activities and Education",21-2021.00,"Directors, Religious Activities and Education"
+21-2099.00,"Religious Workers, All Other",21-2099.00,"Religious Workers, All Other"
+23-1011.00,Lawyers,23-1011.00,Lawyers
+23-1021.00,"Administrative Law Judges, Adjudicators, and Hearing Officers",23-1021.00,"Administrative Law Judges, Adjudicators, and Hearing Officers"
+23-1022.00,"Arbitrators, Mediators, and Conciliators",23-1022.00,"Arbitrators, Mediators, and Conciliators"
+23-1023.00,"Judges, Magistrate Judges, and Magistrates",23-1023.00,"Judges, Magistrate Judges, and Magistrates"
+23-2011.00,Paralegals and Legal Assistants,23-2011.00,Paralegals and Legal Assistants
+23-2091.00,Court Reporters,23-2091.00,Court Reporters
+23-2092.00,Law Clerks,23-1012.00,Judicial Law Clerks
+23-2092.00,Law Clerks,23-2011.00,Paralegals and Legal Assistants
+23-2093.00,"Title Examiners, Abstractors, and Searchers",23-2093.00,"Title Examiners, Abstractors, and Searchers"
+23-2099.00,"Legal Support Workers, All Other",23-2099.00,"Legal Support Workers, All Other"
+25-1011.00,"Business Teachers, Postsecondary",25-1011.00,"Business Teachers, Postsecondary"
+25-1021.00,"Computer Science Teachers, Postsecondary",25-1021.00,"Computer Science Teachers, Postsecondary"
+25-1022.00,"Mathematical Science Teachers, Postsecondary",25-1022.00,"Mathematical Science Teachers, Postsecondary"
+25-1031.00,"Architecture Teachers, Postsecondary",25-1031.00,"Architecture Teachers, Postsecondary"
+25-1032.00,"Engineering Teachers, Postsecondary",25-1032.00,"Engineering Teachers, Postsecondary"
+25-1041.00,"Agricultural Sciences Teachers, Postsecondary",25-1041.00,"Agricultural Sciences Teachers, Postsecondary"
+25-1042.00,"Biological Science Teachers, Postsecondary",25-1042.00,"Biological Science Teachers, Postsecondary"
+25-1043.00,"Forestry and Conservation Science Teachers, Postsecondary",25-1043.00,"Forestry and Conservation Science Teachers, Postsecondary"
+25-1051.00,"Atmospheric, Earth, Marine, and Space Sciences Teachers, Postsecondary",25-1051.00,"Atmospheric, Earth, Marine, and Space Sciences Teachers, Postsecondary"
+25-1052.00,"Chemistry Teachers, Postsecondary",25-1052.00,"Chemistry Teachers, Postsecondary"
+25-1053.00,"Environmental Science Teachers, Postsecondary",25-1053.00,"Environmental Science Teachers, Postsecondary"
+25-1054.00,"Physics Teachers, Postsecondary",25-1054.00,"Physics Teachers, Postsecondary"
+25-1061.00,"Anthropology and Archeology Teachers, Postsecondary",25-1061.00,"Anthropology and Archeology Teachers, Postsecondary"
+25-1062.00,"Area, Ethnic, and Cultural Studies Teachers, Postsecondary",25-1062.00,"Area, Ethnic, and Cultural Studies Teachers, Postsecondary"
+25-1063.00,"Economics Teachers, Postsecondary",25-1063.00,"Economics Teachers, Postsecondary"
+25-1064.00,"Geography Teachers, Postsecondary",25-1064.00,"Geography Teachers, Postsecondary"
+25-1065.00,"Political Science Teachers, Postsecondary",25-1065.00,"Political Science Teachers, Postsecondary"
+25-1066.00,"Psychology Teachers, Postsecondary",25-1066.00,"Psychology Teachers, Postsecondary"
+25-1067.00,"Sociology Teachers, Postsecondary",25-1067.00,"Sociology Teachers, Postsecondary"
+25-1069.00,"Social Sciences Teachers, Postsecondary, All Other",25-1069.00,"Social Sciences Teachers, Postsecondary, All Other"
+25-1071.00,"Health Specialties Teachers, Postsecondary",25-1071.00,"Health Specialties Teachers, Postsecondary"
+25-1072.00,"Nursing Instructors and Teachers, Postsecondary",25-1072.00,"Nursing Instructors and Teachers, Postsecondary"
+25-1081.00,"Education Teachers, Postsecondary",25-1081.00,"Education Teachers, Postsecondary"
+25-1082.00,"Library Science Teachers, Postsecondary",25-1082.00,"Library Science Teachers, Postsecondary"
+25-1111.00,"Criminal Justice and Law Enforcement Teachers, Postsecondary",25-1111.00,"Criminal Justice and Law Enforcement Teachers, Postsecondary"
+25-1112.00,"Law Teachers, Postsecondary",25-1112.00,"Law Teachers, Postsecondary"
+25-1113.00,"Social Work Teachers, Postsecondary",25-1113.00,"Social Work Teachers, Postsecondary"
+25-1121.00,"Art, Drama, and Music Teachers, Postsecondary",25-1121.00,"Art, Drama, and Music Teachers, Postsecondary"
+25-1122.00,"Communications Teachers, Postsecondary",25-1122.00,"Communications Teachers, Postsecondary"
+25-1123.00,"English Language and Literature Teachers, Postsecondary",25-1123.00,"English Language and Literature Teachers, Postsecondary"
+25-1124.00,"Foreign Language and Literature Teachers, Postsecondary",25-1124.00,"Foreign Language and Literature Teachers, Postsecondary"
+25-1125.00,"History Teachers, Postsecondary",25-1125.00,"History Teachers, Postsecondary"
+25-1126.00,"Philosophy and Religion Teachers, Postsecondary",25-1126.00,"Philosophy and Religion Teachers, Postsecondary"
+25-1191.00,Graduate Teaching Assistants,25-1191.00,Graduate Teaching Assistants
+25-1192.00,"Home Economics Teachers, Postsecondary",25-1192.00,"Home Economics Teachers, Postsecondary"
+25-1193.00,"Recreation and Fitness Studies Teachers, Postsecondary",25-1193.00,"Recreation and Fitness Studies Teachers, Postsecondary"
+25-1194.00,"Vocational Education Teachers, Postsecondary",25-1194.00,"Vocational Education Teachers, Postsecondary"
+25-1199.00,"Postsecondary Teachers, All Other",25-1199.00,"Postsecondary Teachers, All Other"
+25-2011.00,"Preschool Teachers, Except Special Education",25-2011.00,"Preschool Teachers, Except Special Education"
+25-2012.00,"Kindergarten Teachers, Except Special Education",25-2012.00,"Kindergarten Teachers, Except Special Education"
+25-2021.00,"Elementary School Teachers, Except Special Education",25-2021.00,"Elementary School Teachers, Except Special Education"
+25-2022.00,"Middle School Teachers, Except Special and Vocational Education",25-2022.00,"Middle School Teachers, Except Special and Career/Technical Education"
+25-2023.00,"Vocational Education Teachers, Middle School",25-2023.00,"Career/Technical Education Teachers, Middle School"
+25-2031.00,"Secondary School Teachers, Except Special and Vocational Education",25-2031.00,"Secondary School Teachers, Except Special and Career/Technical Education"
+25-2032.00,"Vocational Education Teachers, Secondary School",25-2032.00,"Career/Technical Education Teachers, Secondary School"
+25-2041.00,"Special Education Teachers, Preschool, Kindergarten, and Elementary School",25-2051.00,"Special Education Teachers, Preschool"
+25-2041.00,"Special Education Teachers, Preschool, Kindergarten, and Elementary School",25-2052.00,"Special Education Teachers, Kindergarten and Elementary School"
+25-2042.00,"Special Education Teachers, Middle School",25-2053.00,"Special Education Teachers, Middle School"
+25-2043.00,"Special Education Teachers, Secondary School",25-2054.00,"Special Education Teachers, Secondary School"
+25-3011.00,"Adult Literacy, Remedial Education, and GED Teachers and Instructors",25-3011.00,Adult Basic and Secondary Education and Literacy Teachers and Instructors
+25-3021.00,Self-Enrichment Education Teachers,25-3021.00,Self-Enrichment Education Teachers
+25-3099.00,"Teachers and Instructors, All Other",25-3099.00,"Teachers and Instructors, All Other"
+25-3099.01,Adaptive Physical Education Specialists,25-2059.01,Adapted Physical Education Specialists
+25-3099.02,Tutors,25-3099.02,Tutors
+25-4011.00,Archivists,25-4011.00,Archivists
+25-4012.00,Curators,25-4012.00,Curators
+25-4013.00,Museum Technicians and Conservators,25-4013.00,Museum Technicians and Conservators
+25-4021.00,Librarians,25-4021.00,Librarians
+25-4031.00,Library Technicians,25-4031.00,Library Technicians
+25-9011.00,Audio-Visual Collections Specialists,25-9011.00,Audio-Visual and Multimedia Collections Specialists
+25-9021.00,Farm and Home Management Advisors,25-9021.00,Farm and Home Management Advisors
+25-9031.00,Instructional Coordinators,25-9031.00,Instructional Coordinators
+25-9031.01,Instructional Designers and Technologists,25-9031.01,Instructional Designers and Technologists
+25-9041.00,Teacher Assistants,25-9041.00,Teacher Assistants
+25-9099.00,"Education, Training, and Library Workers, All Other",25-9099.00,"Education, Training, and Library Workers, All Other"
+27-1011.00,Art Directors,27-1011.00,Art Directors
+27-1012.00,Craft Artists,27-1012.00,Craft Artists
+27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators",27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators"
+27-1014.00,Multi-Media Artists and Animators,27-1014.00,Multimedia Artists and Animators
+27-1019.00,"Artists and Related Workers, All Other",27-1019.00,"Artists and Related Workers, All Other"
+27-1021.00,Commercial and Industrial Designers,27-1021.00,Commercial and Industrial Designers
+27-1022.00,Fashion Designers,27-1022.00,Fashion Designers
+27-1023.00,Floral Designers,27-1023.00,Floral Designers
+27-1024.00,Graphic Designers,27-1024.00,Graphic Designers
+27-1025.00,Interior Designers,27-1025.00,Interior Designers
+27-1026.00,Merchandise Displayers and Window Trimmers,27-1026.00,Merchandise Displayers and Window Trimmers
+27-1027.00,Set and Exhibit Designers,27-1027.00,Set and Exhibit Designers
+27-1029.00,"Designers, All Other",27-1029.00,"Designers, All Other"
+27-2011.00,Actors,27-2011.00,Actors
+27-2012.00,Producers and Directors,27-2012.00,Producers and Directors
+27-2012.01,Producers,27-2012.01,Producers
+27-2012.02,"Directors- Stage, Motion Pictures, Television, and Radio",27-2012.02,"Directors- Stage, Motion Pictures, Television, and Radio"
+27-2012.03,Program Directors,27-2012.03,Program Directors
+27-2012.04,Talent Directors,27-2012.04,Talent Directors
+27-2012.05,Technical Directors/Managers,27-2012.05,Technical Directors/Managers
+27-2021.00,Athletes and Sports Competitors,27-2021.00,Athletes and Sports Competitors
+27-2022.00,Coaches and Scouts,27-2022.00,Coaches and Scouts
+27-2023.00,"Umpires, Referees, and Other Sports Officials",27-2023.00,"Umpires, Referees, and Other Sports Officials"
+27-2031.00,Dancers,27-2031.00,Dancers
+27-2032.00,Choreographers,27-2032.00,Choreographers
+27-2041.00,Music Directors and Composers,27-2041.00,Music Directors and Composers
+27-2041.01,Music Directors,27-2041.01,Music Directors
+27-2041.04,Music Composers and Arrangers,27-2041.04,Music Composers and Arrangers
+27-2042.00,Musicians and Singers,27-2042.00,Musicians and Singers
+27-2042.01,Singers,27-2042.01,Singers
+27-2042.02,"Musicians, Instrumental",27-2042.02,"Musicians, Instrumental"
+27-2099.00,"Entertainers and Performers, Sports and Related Workers, All Other",27-2099.00,"Entertainers and Performers, Sports and Related Workers, All Other"
+27-3011.00,Radio and Television Announcers,27-3011.00,Radio and Television Announcers
+27-3012.00,Public Address System and Other Announcers,27-3012.00,Public Address System and Other Announcers
+27-3021.00,Broadcast News Analysts,27-3021.00,Broadcast News Analysts
+27-3022.00,Reporters and Correspondents,27-3022.00,Reporters and Correspondents
+27-3031.00,Public Relations Specialists,27-3031.00,Public Relations Specialists
+27-3041.00,Editors,27-3041.00,Editors
+27-3042.00,Technical Writers,27-3042.00,Technical Writers
+27-3043.00,Writers and Authors,27-3043.00,Writers and Authors
+27-3043.04,Copy Writers,27-3043.04,Copy Writers
+27-3043.05,"Poets, Lyricists and Creative Writers",27-3043.05,"Poets, Lyricists and Creative Writers"
+27-3091.00,Interpreters and Translators,27-3091.00,Interpreters and Translators
+27-3099.00,"Media and Communication Workers, All Other",27-3099.00,"Media and Communication Workers, All Other"
+27-4011.00,Audio and Video Equipment Technicians,27-4011.00,Audio and Video Equipment Technicians
+27-4012.00,Broadcast Technicians,27-4012.00,Broadcast Technicians
+27-4013.00,Radio Operators,27-4013.00,Radio Operators
+27-4014.00,Sound Engineering Technicians,27-4014.00,Sound Engineering Technicians
+27-4021.00,Photographers,27-4021.00,Photographers
+27-4031.00,"Camera Operators, Television, Video, and Motion Picture",27-4031.00,"Camera Operators, Television, Video, and Motion Picture"
+27-4032.00,Film and Video Editors,27-4032.00,Film and Video Editors
+27-4099.00,"Media and Communication Equipment Workers, All Other",27-4099.00,"Media and Communication Equipment Workers, All Other"
+29-1011.00,Chiropractors,29-1011.00,Chiropractors
+29-1021.00,"Dentists, General",29-1021.00,"Dentists, General"
+29-1022.00,Oral and Maxillofacial Surgeons,29-1022.00,Oral and Maxillofacial Surgeons
+29-1023.00,Orthodontists,29-1023.00,Orthodontists
+29-1024.00,Prosthodontists,29-1024.00,Prosthodontists
+29-1029.00,"Dentists, All Other Specialists",29-1029.00,"Dentists, All Other Specialists"
+29-1031.00,Dietitians and Nutritionists,29-1031.00,Dietitians and Nutritionists
+29-1041.00,Optometrists,29-1041.00,Optometrists
+29-1051.00,Pharmacists,29-1051.00,Pharmacists
+29-1061.00,Anesthesiologists,29-1061.00,Anesthesiologists
+29-1062.00,Family and General Practitioners,29-1062.00,Family and General Practitioners
+29-1063.00,"Internists, General",29-1063.00,"Internists, General"
+29-1064.00,Obstetricians and Gynecologists,29-1064.00,Obstetricians and Gynecologists
+29-1065.00,"Pediatricians, General",29-1065.00,"Pediatricians, General"
+29-1066.00,Psychiatrists,29-1066.00,Psychiatrists
+29-1067.00,Surgeons,29-1067.00,Surgeons
+29-1069.00,"Physicians and Surgeons, All Other",29-1069.00,"Physicians and Surgeons, All Other"
+29-1069.01,Allergists and Immunologists,29-1069.01,Allergists and Immunologists
+29-1069.02,Dermatologists,29-1069.02,Dermatologists
+29-1069.03,Hospitalists,29-1069.03,Hospitalists
+29-1069.04,Neurologists,29-1069.04,Neurologists
+29-1069.05,Nuclear Medicine Physicians,29-1069.05,Nuclear Medicine Physicians
+29-1069.06,Ophthalmologists,29-1069.06,Ophthalmologists
+29-1069.07,Pathologists,29-1069.07,Pathologists
+29-1069.08,Physical Medicine and Rehabilitation Physicians,29-1069.08,Physical Medicine and Rehabilitation Physicians
+29-1069.09,Preventive Medicine Physicians,29-1069.09,Preventive Medicine Physicians
+29-1069.10,Radiologists,29-1069.10,Radiologists
+29-1069.11,Sports Medicine Physicians,29-1069.11,Sports Medicine Physicians
+29-1069.12,Urologists,29-1069.12,Urologists
+29-1071.00,Physician Assistants,29-1071.00,Physician Assistants
+29-1071.01,Anesthesiologist Assistants,29-1071.01,Anesthesiologist Assistants
+29-1081.00,Podiatrists,29-1081.00,Podiatrists
+29-1111.00,Registered Nurses,29-1141.00,Registered Nurses
+29-1111.01,Acute Care Nurses,29-1141.01,Acute Care Nurses
+29-1111.02,Advanced Practice Psychiatric Nurses,29-1141.02,Advanced Practice Psychiatric Nurses
+29-1111.03,Critical Care Nurses,29-1141.03,Critical Care Nurses
+29-1121.00,Audiologists,29-1181.00,Audiologists
+29-1122.00,Occupational Therapists,29-1122.00,Occupational Therapists
+29-1122.01,"Low Vision Therapists, Orientation and Mobility Specialists, and Vision Rehabilitation Therapists",29-1122.01,"Low Vision Therapists, Orientation and Mobility Specialists, and Vision Rehabilitation Therapists"
+29-1123.00,Physical Therapists,29-1123.00,Physical Therapists
+29-1124.00,Radiation Therapists,29-1124.00,Radiation Therapists
+29-1125.00,Recreational Therapists,29-1125.00,Recreational Therapists
+29-1126.00,Respiratory Therapists,29-1126.00,Respiratory Therapists
+29-1127.00,Speech-Language Pathologists,29-1127.00,Speech-Language Pathologists
+29-1129.00,"Therapists, All Other",29-1129.00,"Therapists, All Other"
+29-1131.00,Veterinarians,29-1131.00,Veterinarians
+29-1199.00,"Health Diagnosing and Treating Practitioners, All Other",29-1199.00,"Health Diagnosing and Treating Practitioners, All Other"
+29-1199.01,Acupuncturists,29-1199.01,Acupuncturists
+29-1199.02,Nurse Anesthetists,29-1151.00,Nurse Anesthetists
+29-1199.03,Nurse Practitioners,29-1171.00,Nurse Practitioners
+29-1199.04,Naturopathic Physicians,29-1199.04,Naturopathic Physicians
+29-1199.05,Orthoptists,29-1199.05,Orthoptists
+29-2011.00,Medical and Clinical Laboratory Technologists,29-2011.00,Medical and Clinical Laboratory Technologists
+29-2011.01,Cytogenetic Technologists,29-2011.01,Cytogenetic Technologists
+29-2011.02,Cytotechnologists,29-2011.02,Cytotechnologists
+29-2011.03,Histotechnologists and Histologic Technicians,29-2011.03,Histotechnologists and Histologic Technicians
+29-2012.00,Medical and Clinical Laboratory Technicians,29-2012.00,Medical and Clinical Laboratory Technicians
+29-2021.00,Dental Hygienists,29-2021.00,Dental Hygienists
+29-2031.00,Cardiovascular Technologists and Technicians,29-2031.00,Cardiovascular Technologists and Technicians
+29-2032.00,Diagnostic Medical Sonographers,29-2032.00,Diagnostic Medical Sonographers
+29-2033.00,Nuclear Medicine Technologists,29-2033.00,Nuclear Medicine Technologists
+29-2034.00,Radiologic Technologists and Technicians,29-2034.00,Radiologic Technologists
+29-2034.00,Radiologic Technologists and Technicians,29-2099.06,Radiologic Technicians
+29-2034.01,Radiologic Technologists,29-2034.00,Radiologic Technologists
+29-2034.02,Radiologic Technicians,29-2099.06,Radiologic Technicians
+29-2041.00,Emergency Medical Technicians and Paramedics,29-2041.00,Emergency Medical Technicians and Paramedics
+29-2051.00,Dietetic Technicians,29-2051.00,Dietetic Technicians
+29-2052.00,Pharmacy Technicians,29-2052.00,Pharmacy Technicians
+29-2053.00,Psychiatric Technicians,29-2053.00,Psychiatric Technicians
+29-2054.00,Respiratory Therapy Technicians,29-2054.00,Respiratory Therapy Technicians
+29-2055.00,Surgical Technologists,29-2055.00,Surgical Technologists
+29-2056.00,Veterinary Technologists and Technicians,29-2056.00,Veterinary Technologists and Technicians
+29-2061.00,Licensed Practical and Licensed Vocational Nurses,29-2061.00,Licensed Practical and Licensed Vocational Nurses
+29-2071.00,Medical Records and Health Information Technicians,29-2071.00,Medical Records and Health Information Technicians
+29-2081.00,"Opticians, Dispensing",29-2081.00,"Opticians, Dispensing"
+29-2091.00,Orthotists and Prosthetists,29-2091.00,Orthotists and Prosthetists
+29-2099.00,"Health Technologists and Technicians, All Other",29-2099.00,"Health Technologists and Technicians, All Other"
+29-2099.01,Electroneurodiagnostic Technologists,29-2099.01,Neurodiagnostic Technologists
+29-2099.02,Hearing Aid Specialists,29-2092.00,Hearing Aid Specialists
+29-2099.03,Ophthalmic Medical Technologists and Technicians,29-2057.00,Ophthalmic Medical Technicians
+29-2099.03,Ophthalmic Medical Technologists and Technicians,29-2099.05,Ophthalmic Medical Technologists
+29-2099.04,Nurse Midwives,29-1161.00,Nurse Midwives
+29-9011.00,Occupational Health and Safety Specialists,29-9011.00,Occupational Health and Safety Specialists
+29-9012.00,Occupational Health and Safety Technicians,29-9012.00,Occupational Health and Safety Technicians
+29-9091.00,Athletic Trainers,29-9091.00,Athletic Trainers
+29-9099.00,"Healthcare Practitioners and Technical Workers, All Other",29-9099.00,"Healthcare Practitioners and Technical Workers, All Other"
+29-9099.01,Midwives,29-9099.01,Midwives
+29-9099.02,Genetic Counselors,29-9092.00,Genetic Counselors
+31-1011.00,Home Health Aides,31-1011.00,Home Health Aides
+31-1012.00,"Nursing Aides, Orderlies, and Attendants",31-1014.00,Nursing Assistants
+31-1012.00,"Nursing Aides, Orderlies, and Attendants",31-1015.00,Orderlies
+31-1013.00,Psychiatric Aides,31-1013.00,Psychiatric Aides
+31-2011.00,Occupational Therapist Assistants,31-2011.00,Occupational Therapy Assistants
+31-2012.00,Occupational Therapist Aides,31-2012.00,Occupational Therapy Aides
+31-2021.00,Physical Therapist Assistants,31-2021.00,Physical Therapist Assistants
+31-2022.00,Physical Therapist Aides,31-2022.00,Physical Therapist Aides
+31-9011.00,Massage Therapists,31-9011.00,Massage Therapists
+31-9091.00,Dental Assistants,31-9091.00,Dental Assistants
+31-9092.00,Medical Assistants,31-9092.00,Medical Assistants
+31-9093.00,Medical Equipment Preparers,31-9093.00,Medical Equipment Preparers
+31-9093.01,Endoscopy Technicians,31-9099.02,Endoscopy Technicians
+31-9094.00,Medical Transcriptionists,31-9094.00,Medical Transcriptionists
+31-9095.00,Pharmacy Aides,31-9095.00,Pharmacy Aides
+31-9096.00,Veterinary Assistants and Laboratory Animal Caretakers,31-9096.00,Veterinary Assistants and Laboratory Animal Caretakers
+31-9099.00,"Healthcare Support Workers, All Other",31-9099.00,"Healthcare Support Workers, All Other"
+31-9099.01,Speech-Language Pathology Assistants,31-9099.01,Speech-Language Pathology Assistants
+33-1011.00,First-Line Supervisors/Managers of Correctional Officers,33-1011.00,First-Line Supervisors of Correctional Officers
+33-1012.00,First-Line Supervisors/Managers of Police and Detectives,33-1012.00,First-Line Supervisors of Police and Detectives
+33-1021.00,First-Line Supervisors/Managers of Fire Fighting and Prevention Workers,33-1021.00,First-Line Supervisors of Fire Fighting and Prevention Workers
+33-1021.01,Municipal Fire Fighting and Prevention Supervisors,33-1021.01,Municipal Fire Fighting and Prevention Supervisors
+33-1021.02,Forest Fire Fighting and Prevention Supervisors,33-1021.02,Forest Fire Fighting and Prevention Supervisors
+33-1099.00,"First-Line Supervisors/Managers, Protective Service Workers, All Other",33-1099.00,"First-Line Supervisors of Protective Service Workers, All Other"
+33-2011.00,Fire Fighters,33-2011.00,Firefighters
+33-2011.01,Municipal Fire Fighters,33-2011.01,Municipal Firefighters
+33-2011.02,Forest Fire Fighters,33-2011.02,Forest Firefighters
+33-2021.00,Fire Inspectors and Investigators,33-2021.00,Fire Inspectors and Investigators
+33-2021.01,Fire Inspectors,33-2021.01,Fire Inspectors
+33-2021.02,Fire Investigators,33-2021.02,Fire Investigators
+33-2022.00,Forest Fire Inspectors and Prevention Specialists,33-2022.00,Forest Fire Inspectors and Prevention Specialists
+33-3011.00,Bailiffs,33-3011.00,Bailiffs
+33-3012.00,Correctional Officers and Jailers,33-3012.00,Correctional Officers and Jailers
+33-3021.00,Detectives and Criminal Investigators,33-3021.00,Detectives and Criminal Investigators
+33-3021.01,Police Detectives,33-3021.01,Police Detectives
+33-3021.02,Police Identification and Records Officers,33-3021.02,Police Identification and Records Officers
+33-3021.03,Criminal Investigators and Special Agents,33-3021.03,Criminal Investigators and Special Agents
+33-3021.05,Immigration and Customs Inspectors,33-3021.05,Immigration and Customs Inspectors
+33-3021.06,Intelligence Analysts,33-3021.06,Intelligence Analysts
+33-3031.00,Fish and Game Wardens,33-3031.00,Fish and Game Wardens
+33-3041.00,Parking Enforcement Workers,33-3041.00,Parking Enforcement Workers
+33-3051.00,Police and Sheriff's Patrol Officers,33-3051.00,Police and Sheriff's Patrol Officers
+33-3051.01,Police Patrol Officers,33-3051.01,Police Patrol Officers
+33-3051.03,Sheriffs and Deputy Sheriffs,33-3051.03,Sheriffs and Deputy Sheriffs
+33-3052.00,Transit and Railroad Police,33-3052.00,Transit and Railroad Police
+33-9011.00,Animal Control Workers,33-9011.00,Animal Control Workers
+33-9021.00,Private Detectives and Investigators,33-9021.00,Private Detectives and Investigators
+33-9031.00,Gaming Surveillance Officers and Gaming Investigators,33-9031.00,Gaming Surveillance Officers and Gaming Investigators
+33-9032.00,Security Guards,33-9032.00,Security Guards
+33-9091.00,Crossing Guards,33-9091.00,Crossing Guards
+33-9092.00,"Lifeguards, Ski Patrol, and Other Recreational Protective Service Workers",33-9092.00,"Lifeguards, Ski Patrol, and Other Recreational Protective Service Workers"
+33-9099.00,"Protective Service Workers, All Other",33-9099.00,"Protective Service Workers, All Other"
+33-9099.01,Transportation Security Officers,33-9093.00,Transportation Security Screeners
+33-9099.02,Loss Prevention Specialists,33-9099.02,Retail Loss Prevention Specialists
+35-1011.00,Chefs and Head Cooks,35-1011.00,Chefs and Head Cooks
+35-1012.00,First-Line Supervisors/Managers of Food Preparation and Serving Workers,35-1012.00,First-Line Supervisors of Food Preparation and Serving Workers
+35-2011.00,"Cooks, Fast Food",35-2011.00,"Cooks, Fast Food"
+35-2012.00,"Cooks, Institution and Cafeteria",35-2012.00,"Cooks, Institution and Cafeteria"
+35-2013.00,"Cooks, Private Household",35-2013.00,"Cooks, Private Household"
+35-2014.00,"Cooks, Restaurant",35-2014.00,"Cooks, Restaurant"
+35-2015.00,"Cooks, Short Order",35-2015.00,"Cooks, Short Order"
+35-2019.00,"Cooks, All Other",35-2019.00,"Cooks, All Other"
+35-2021.00,Food Preparation Workers,35-2021.00,Food Preparation Workers
+35-3011.00,Bartenders,35-3011.00,Bartenders
+35-3021.00,"Combined Food Preparation and Serving Workers, Including Fast Food",35-3021.00,"Combined Food Preparation and Serving Workers, Including Fast Food"
+35-3022.00,"Counter Attendants, Cafeteria, Food Concession, and Coffee Shop",35-3022.00,"Counter Attendants, Cafeteria, Food Concession, and Coffee Shop"
+35-3022.01,Baristas,35-3022.01,Baristas
+35-3031.00,Waiters and Waitresses,35-3031.00,Waiters and Waitresses
+35-3041.00,"Food Servers, Nonrestaurant",35-3041.00,"Food Servers, Nonrestaurant"
+35-9011.00,Dining Room and Cafeteria Attendants and Bartender Helpers,35-9011.00,Dining Room and Cafeteria Attendants and Bartender Helpers
+35-9021.00,Dishwashers,35-9021.00,Dishwashers
+35-9031.00,"Hosts and Hostesses, Restaurant, Lounge, and Coffee Shop",35-9031.00,"Hosts and Hostesses, Restaurant, Lounge, and Coffee Shop"
+35-9099.00,"Food Preparation and Serving Related Workers, All Other",35-9099.00,"Food Preparation and Serving Related Workers, All Other"
+37-1011.00,First-Line Supervisors/Managers of Housekeeping and Janitorial Workers,37-1011.00,First-Line Supervisors of Housekeeping and Janitorial Workers
+37-1012.00,"First-Line Supervisors/Managers of Landscaping, Lawn Service, and Groundskeeping Workers",37-1012.00,"First-Line Supervisors of Landscaping, Lawn Service, and Groundskeeping Workers"
+37-2011.00,"Janitors and Cleaners, Except Maids and Housekeeping Cleaners",37-2011.00,"Janitors and Cleaners, Except Maids and Housekeeping Cleaners"
+37-2012.00,Maids and Housekeeping Cleaners,37-2012.00,Maids and Housekeeping Cleaners
+37-2019.00,"Building Cleaning Workers, All Other",37-2019.00,"Building Cleaning Workers, All Other"
+37-2021.00,Pest Control Workers,37-2021.00,Pest Control Workers
+37-3011.00,Landscaping and Groundskeeping Workers,37-3011.00,Landscaping and Groundskeeping Workers
+37-3012.00,"Pesticide Handlers, Sprayers, and Applicators, Vegetation",37-3012.00,"Pesticide Handlers, Sprayers, and Applicators, Vegetation"
+37-3013.00,Tree Trimmers and Pruners,37-3013.00,Tree Trimmers and Pruners
+37-3019.00,"Grounds Maintenance Workers, All Other",37-3019.00,"Grounds Maintenance Workers, All Other"
+39-1011.00,Gaming Supervisors,39-1011.00,Gaming Supervisors
+39-1012.00,Slot Key Persons,39-1012.00,Slot Supervisors
+39-1021.00,First-Line Supervisors/Managers of Personal Service Workers,39-1021.00,First-Line Supervisors of Personal Service Workers
+39-1021.01,Spa Managers,39-1021.01,Spa Managers
+39-2011.00,Animal Trainers,39-2011.00,Animal Trainers
+39-2021.00,Nonfarm Animal Caretakers,39-2021.00,Nonfarm Animal Caretakers
+39-3011.00,Gaming Dealers,39-3011.00,Gaming Dealers
+39-3012.00,Gaming and Sports Book Writers and Runners,39-3012.00,Gaming and Sports Book Writers and Runners
+39-3019.00,"Gaming Service Workers, All Other",39-3019.00,"Gaming Service Workers, All Other"
+39-3021.00,Motion Picture Projectionists,39-3021.00,Motion Picture Projectionists
+39-3031.00,"Ushers, Lobby Attendants, and Ticket Takers",39-3031.00,"Ushers, Lobby Attendants, and Ticket Takers"
+39-3091.00,Amusement and Recreation Attendants,39-3091.00,Amusement and Recreation Attendants
+39-3092.00,Costume Attendants,39-3092.00,Costume Attendants
+39-3093.00,"Locker Room, Coatroom, and Dressing Room Attendants",39-3093.00,"Locker Room, Coatroom, and Dressing Room Attendants"
+39-3099.00,"Entertainment Attendants and Related Workers, All Other",39-3099.00,"Entertainment Attendants and Related Workers, All Other"
+39-4011.00,Embalmers,39-4011.00,Embalmers
+39-4021.00,Funeral Attendants,39-4021.00,Funeral Attendants
+39-5011.00,Barbers,39-5011.00,Barbers
+39-5012.00,"Hairdressers, Hairstylists, and Cosmetologists",39-5012.00,"Hairdressers, Hairstylists, and Cosmetologists"
+39-5091.00,"Makeup Artists, Theatrical and Performance",39-5091.00,"Makeup Artists, Theatrical and Performance"
+39-5092.00,Manicurists and Pedicurists,39-5092.00,Manicurists and Pedicurists
+39-5093.00,Shampooers,39-5093.00,Shampooers
+39-5094.00,Skin Care Specialists,39-5094.00,Skincare Specialists
+39-6011.00,Baggage Porters and Bellhops,39-6011.00,Baggage Porters and Bellhops
+39-6012.00,Concierges,39-6012.00,Concierges
+39-6021.00,Tour Guides and Escorts,39-7011.00,Tour Guides and Escorts
+39-6022.00,Travel Guides,39-7012.00,Travel Guides
+39-6031.00,Flight Attendants,53-2031.00,Flight Attendants
+39-6032.00,"Transportation Attendants, Except Flight Attendants and Baggage Porters",53-6061.00,"Transportation Attendants, Except Flight Attendants"
+39-9011.00,Child Care Workers,39-9011.00,Childcare Workers
+39-9011.01,Nannies,39-9011.01,Nannies
+39-9021.00,Personal and Home Care Aides,39-9021.00,Personal Care Aides
+39-9031.00,Fitness Trainers and Aerobics Instructors,39-9031.00,Fitness Trainers and Aerobics Instructors
+39-9032.00,Recreation Workers,39-9032.00,Recreation Workers
+39-9041.00,Residential Advisors,39-9041.00,Residential Advisors
+39-9099.00,"Personal Care and Service Workers, All Other",39-9099.00,"Personal Care and Service Workers, All Other"
+41-1011.00,First-Line Supervisors/Managers of Retail Sales Workers,41-1011.00,First-Line Supervisors of Retail Sales Workers
+41-1012.00,First-Line Supervisors/Managers of Non-Retail Sales Workers,41-1012.00,First-Line Supervisors of Non-Retail Sales Workers
+41-2011.00,Cashiers,41-2011.00,Cashiers
+41-2012.00,Gaming Change Persons and Booth Cashiers,41-2012.00,Gaming Change Persons and Booth Cashiers
+41-2021.00,Counter and Rental Clerks,41-2021.00,Counter and Rental Clerks
+41-2022.00,Parts Salespersons,41-2022.00,Parts Salespersons
+41-2031.00,Retail Salespersons,41-2031.00,Retail Salespersons
+41-3011.00,Advertising Sales Agents,41-3011.00,Advertising Sales Agents
+41-3021.00,Insurance Sales Agents,41-3021.00,Insurance Sales Agents
+41-3031.00,"Securities, Commodities, and Financial Services Sales Agents",41-3031.00,"Securities, Commodities, and Financial Services Sales Agents"
+41-3031.01,"Sales Agents, Securities and Commodities",41-3031.01,"Sales Agents, Securities and Commodities"
+41-3031.02,"Sales Agents, Financial Services",41-3031.02,"Sales Agents, Financial Services"
+41-3031.03,Securities and Commodities Traders,41-3031.03,Securities and Commodities Traders
+41-3041.00,Travel Agents,41-3041.00,Travel Agents
+41-3099.00,"Sales Representatives, Services, All Other",41-3099.00,"Sales Representatives, Services, All Other"
+41-3099.01,Energy Brokers,41-3099.01,Energy Brokers
+41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4011.07,Solar Sales Representatives and Assessors,41-4011.07,Solar Sales Representatives and Assessors
+41-4012.00,"Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products",41-4012.00,"Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products"
+41-9011.00,Demonstrators and Product Promoters,41-9011.00,Demonstrators and Product Promoters
+41-9012.00,Models,41-9012.00,Models
+41-9021.00,Real Estate Brokers,41-9021.00,Real Estate Brokers
+41-9022.00,Real Estate Sales Agents,41-9022.00,Real Estate Sales Agents
+41-9031.00,Sales Engineers,41-9031.00,Sales Engineers
+41-9041.00,Telemarketers,41-9041.00,Telemarketers
+41-9091.00,"Door-To-Door Sales Workers, News and Street Vendors, and Related Workers",41-9091.00,"Door-To-Door Sales Workers, News and Street Vendors, and Related Workers"
+41-9099.00,"Sales and Related Workers, All Other",41-9099.00,"Sales and Related Workers, All Other"
+43-1011.00,First-Line Supervisors/Managers of Office and Administrative Support Workers,43-1011.00,First-Line Supervisors of Office and Administrative Support Workers
+43-2011.00,"Switchboard Operators, Including Answering Service",43-2011.00,"Switchboard Operators, Including Answering Service"
+43-2021.00,Telephone Operators,43-2021.00,Telephone Operators
+43-2099.00,"Communications Equipment Operators, All Other",43-2099.00,"Communications Equipment Operators, All Other"
+43-3011.00,Bill and Account Collectors,43-3011.00,Bill and Account Collectors
+43-3021.00,Billing and Posting Clerks and Machine Operators,43-3021.00,Billing and Posting Clerks
+43-3021.01,Statement Clerks,43-3021.01,Statement Clerks
+43-3021.02,"Billing, Cost, and Rate Clerks",43-3021.02,"Billing, Cost, and Rate Clerks"
+43-3021.03,"Billing, Posting, and Calculating Machine Operators",43-3021.00,Billing and Posting Clerks
+43-3031.00,"Bookkeeping, Accounting, and Auditing Clerks",43-3031.00,"Bookkeeping, Accounting, and Auditing Clerks"
+43-3041.00,Gaming Cage Workers,43-3041.00,Gaming Cage Workers
+43-3051.00,Payroll and Timekeeping Clerks,43-3051.00,Payroll and Timekeeping Clerks
+43-3061.00,Procurement Clerks,43-3061.00,Procurement Clerks
+43-3071.00,Tellers,43-3071.00,Tellers
+43-4011.00,Brokerage Clerks,43-4011.00,Brokerage Clerks
+43-4021.00,Correspondence Clerks,43-4021.00,Correspondence Clerks
+43-4031.00,"Court, Municipal, and License Clerks",43-4031.00,"Court, Municipal, and License Clerks"
+43-4031.01,Court Clerks,43-4031.01,Court Clerks
+43-4031.02,Municipal Clerks,43-4031.02,Municipal Clerks
+43-4031.03,License Clerks,43-4031.03,License Clerks
+43-4041.00,"Credit Authorizers, Checkers, and Clerks",43-4041.00,"Credit Authorizers, Checkers, and Clerks"
+43-4041.01,Credit Authorizers,43-4041.01,Credit Authorizers
+43-4041.02,Credit Checkers,43-4041.02,Credit Checkers
+43-4051.00,Customer Service Representatives,43-4051.00,Customer Service Representatives
+43-4051.03,Patient Representatives,43-4051.03,Patient Representatives
+43-4061.00,"Eligibility Interviewers, Government Programs",43-4061.00,"Eligibility Interviewers, Government Programs"
+43-4071.00,File Clerks,43-4071.00,File Clerks
+43-4081.00,"Hotel, Motel, and Resort Desk Clerks",43-4081.00,"Hotel, Motel, and Resort Desk Clerks"
+43-4111.00,"Interviewers, Except Eligibility and Loan",43-4111.00,"Interviewers, Except Eligibility and Loan"
+43-4121.00,"Library Assistants, Clerical",43-4121.00,"Library Assistants, Clerical"
+43-4131.00,Loan Interviewers and Clerks,43-4131.00,Loan Interviewers and Clerks
+43-4141.00,New Accounts Clerks,43-4141.00,New Accounts Clerks
+43-4151.00,Order Clerks,43-4151.00,Order Clerks
+43-4161.00,"Human Resources Assistants, Except Payroll and Timekeeping",43-4161.00,"Human Resources Assistants, Except Payroll and Timekeeping"
+43-4171.00,Receptionists and Information Clerks,43-4171.00,Receptionists and Information Clerks
+43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks,43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks
+43-4199.00,"Information and Record Clerks, All Other",43-4199.00,"Information and Record Clerks, All Other"
+43-5011.00,Cargo and Freight Agents,43-5011.00,Cargo and Freight Agents
+43-5011.01,Freight Forwarders,43-5011.01,Freight Forwarders
+43-5021.00,Couriers and Messengers,43-5021.00,Couriers and Messengers
+43-5031.00,"Police, Fire, and Ambulance Dispatchers",43-5031.00,"Police, Fire, and Ambulance Dispatchers"
+43-5032.00,"Dispatchers, Except Police, Fire, and Ambulance",43-5032.00,"Dispatchers, Except Police, Fire, and Ambulance"
+43-5041.00,"Meter Readers, Utilities",43-5041.00,"Meter Readers, Utilities"
+43-5051.00,Postal Service Clerks,43-5051.00,Postal Service Clerks
+43-5052.00,Postal Service Mail Carriers,43-5052.00,Postal Service Mail Carriers
+43-5053.00,"Postal Service Mail Sorters, Processors, and Processing Machine Operators",43-5053.00,"Postal Service Mail Sorters, Processors, and Processing Machine Operators"
+43-5061.00,"Production, Planning, and Expediting Clerks",43-5061.00,"Production, Planning, and Expediting Clerks"
+43-5071.00,"Shipping, Receiving, and Traffic Clerks",43-5071.00,"Shipping, Receiving, and Traffic Clerks"
+43-5081.00,Stock Clerks and Order Fillers,43-5081.00,Stock Clerks and Order Fillers
+43-5081.01,"Stock Clerks, Sales Floor",43-5081.01,"Stock Clerks, Sales Floor"
+43-5081.02,Marking Clerks,43-5081.02,Marking Clerks
+43-5081.03,"Stock Clerks- Stockroom, Warehouse, or Storage Yard",43-5081.03,"Stock Clerks- Stockroom, Warehouse, or Storage Yard"
+43-5081.04,"Order Fillers, Wholesale and Retail Sales",43-5081.04,"Order Fillers, Wholesale and Retail Sales"
+43-5111.00,"Weighers, Measurers, Checkers, and Samplers, Recordkeeping",43-5111.00,"Weighers, Measurers, Checkers, and Samplers, Recordkeeping"
+43-6011.00,Executive Secretaries and Administrative Assistants,43-6011.00,Executive Secretaries and Executive Administrative Assistants
+43-6012.00,Legal Secretaries,43-6012.00,Legal Secretaries
+43-6013.00,Medical Secretaries,43-6013.00,Medical Secretaries
+43-6014.00,"Secretaries, Except Legal, Medical, and Executive",43-6014.00,"Secretaries and Administrative Assistants, Except Legal, Medical, and Executive"
+43-9011.00,Computer Operators,43-9011.00,Computer Operators
+43-9021.00,Data Entry Keyers,43-9021.00,Data Entry Keyers
+43-9022.00,Word Processors and Typists,43-9022.00,Word Processors and Typists
+43-9031.00,Desktop Publishers,43-9031.00,Desktop Publishers
+43-9041.00,Insurance Claims and Policy Processing Clerks,43-9041.00,Insurance Claims and Policy Processing Clerks
+43-9041.01,Insurance Claims Clerks,43-9041.01,Insurance Claims Clerks
+43-9041.02,Insurance Policy Processing Clerks,43-9041.02,Insurance Policy Processing Clerks
+43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service",43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service"
+43-9061.00,"Office Clerks, General",43-9061.00,"Office Clerks, General"
+43-9071.00,"Office Machine Operators, Except Computer",43-9071.00,"Office Machine Operators, Except Computer"
+43-9081.00,Proofreaders and Copy Markers,43-9081.00,Proofreaders and Copy Markers
+43-9111.00,Statistical Assistants,43-9111.00,Statistical Assistants
+43-9111.01,Bioinformatics Technicians,43-9111.01,Bioinformatics Technicians
+43-9199.00,"Office and Administrative Support Workers, All Other",43-9199.00,"Office and Administrative Support Workers, All Other"
+45-1011.00,"First-Line Supervisors/Managers of Farming, Fishing, and Forestry Workers",45-1011.00,"First-Line Supervisors of Farming, Fishing, and Forestry Workers"
+45-1011.05,First-Line Supervisors/Managers of Logging Workers,45-1011.05,First-Line Supervisors of Logging Workers
+45-1011.06,First-Line Supervisors/Managers of Aquacultural Workers,45-1011.06,First-Line Supervisors of Aquacultural Workers
+45-1011.07,First-Line Supervisors/Managers of Agricultural Crop and Horticultural Workers,45-1011.07,First-Line Supervisors of Agricultural Crop and Horticultural Workers
+45-1011.08,First-Line Supervisors/Managers of Animal Husbandry and Animal Care Workers,45-1011.08,First-Line Supervisors of Animal Husbandry and Animal Care Workers
+45-1012.00,Farm Labor Contractors,13-1074.00,Farm Labor Contractors
+45-2011.00,Agricultural Inspectors,45-2011.00,Agricultural Inspectors
+45-2021.00,Animal Breeders,45-2021.00,Animal Breeders
+45-2041.00,"Graders and Sorters, Agricultural Products",45-2041.00,"Graders and Sorters, Agricultural Products"
+45-2091.00,Agricultural Equipment Operators,45-2091.00,Agricultural Equipment Operators
+45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse",45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse"
+45-2092.01,Nursery Workers,45-2092.01,Nursery Workers
+45-2092.02,"Farmworkers and Laborers, Crop",45-2092.02,"Farmworkers and Laborers, Crop"
+45-2093.00,"Farmworkers, Farm and Ranch Animals",45-2093.00,"Farmworkers, Farm, Ranch, and Aquacultural Animals"
+45-2099.00,"Agricultural Workers, All Other",45-2099.00,"Agricultural Workers, All Other"
+45-3011.00,Fishers and Related Fishing Workers,45-3011.00,Fishers and Related Fishing Workers
+45-3021.00,Hunters and Trappers,45-3021.00,Hunters and Trappers
+45-4011.00,Forest and Conservation Workers,45-4011.00,Forest and Conservation Workers
+45-4021.00,Fallers,45-4021.00,Fallers
+45-4022.00,Logging Equipment Operators,45-4022.00,Logging Equipment Operators
+45-4023.00,Log Graders and Scalers,45-4023.00,Log Graders and Scalers
+45-4029.00,"Logging Workers, All Other",45-4029.00,"Logging Workers, All Other"
+47-1011.00,First-Line Supervisors/Managers of Construction Trades and Extraction Workers,47-1011.00,First-Line Supervisors of Construction Trades and Extraction Workers
+47-1011.03,Solar Energy Installation Managers,47-1011.03,Solar Energy Installation Managers
+47-2011.00,Boilermakers,47-2011.00,Boilermakers
+47-2021.00,Brickmasons and Blockmasons,47-2021.00,Brickmasons and Blockmasons
+47-2022.00,Stonemasons,47-2022.00,Stonemasons
+47-2031.00,Carpenters,47-2031.00,Carpenters
+47-2031.01,Construction Carpenters,47-2031.01,Construction Carpenters
+47-2031.02,Rough Carpenters,47-2031.02,Rough Carpenters
+47-2041.00,Carpet Installers,47-2041.00,Carpet Installers
+47-2042.00,"Floor Layers, Except Carpet, Wood, and Hard Tiles",47-2042.00,"Floor Layers, Except Carpet, Wood, and Hard Tiles"
+47-2043.00,Floor Sanders and Finishers,47-2043.00,Floor Sanders and Finishers
+47-2044.00,Tile and Marble Setters,47-2044.00,Tile and Marble Setters
+47-2051.00,Cement Masons and Concrete Finishers,47-2051.00,Cement Masons and Concrete Finishers
+47-2053.00,Terrazzo Workers and Finishers,47-2053.00,Terrazzo Workers and Finishers
+47-2061.00,Construction Laborers,47-2061.00,Construction Laborers
+47-2071.00,"Paving, Surfacing, and Tamping Equipment Operators",47-2071.00,"Paving, Surfacing, and Tamping Equipment Operators"
+47-2072.00,Pile-Driver Operators,47-2072.00,Pile-Driver Operators
+47-2073.00,Operating Engineers and Other Construction Equipment Operators,47-2073.00,Operating Engineers and Other Construction Equipment Operators
+47-2081.00,Drywall and Ceiling Tile Installers,47-2081.00,Drywall and Ceiling Tile Installers
+47-2082.00,Tapers,47-2082.00,Tapers
+47-2111.00,Electricians,47-2111.00,Electricians
+47-2121.00,Glaziers,47-2121.00,Glaziers
+47-2131.00,"Insulation Workers, Floor, Ceiling, and Wall",47-2131.00,"Insulation Workers, Floor, Ceiling, and Wall"
+47-2132.00,"Insulation Workers, Mechanical",47-2132.00,"Insulation Workers, Mechanical"
+47-2141.00,"Painters, Construction and Maintenance",47-2141.00,"Painters, Construction and Maintenance"
+47-2142.00,Paperhangers,47-2142.00,Paperhangers
+47-2151.00,Pipelayers,47-2151.00,Pipelayers
+47-2152.00,"Plumbers, Pipefitters, and Steamfitters",47-2152.00,"Plumbers, Pipefitters, and Steamfitters"
+47-2152.01,Pipe Fitters and Steamfitters,47-2152.01,Pipe Fitters and Steamfitters
+47-2152.02,Plumbers,47-2152.02,Plumbers
+47-2161.00,Plasterers and Stucco Masons,47-2161.00,Plasterers and Stucco Masons
+47-2171.00,Reinforcing Iron and Rebar Workers,47-2171.00,Reinforcing Iron and Rebar Workers
+47-2181.00,Roofers,47-2181.00,Roofers
+47-2211.00,Sheet Metal Workers,47-2211.00,Sheet Metal Workers
+47-2221.00,Structural Iron and Steel Workers,47-2221.00,Structural Iron and Steel Workers
+47-3011.00,"Helpers--Brickmasons, Blockmasons, Stonemasons, and Tile and Marble Setters",47-3011.00,"Helpers--Brickmasons, Blockmasons, Stonemasons, and Tile and Marble Setters"
+47-3012.00,Helpers--Carpenters,47-3012.00,Helpers--Carpenters
+47-3013.00,Helpers--Electricians,47-3013.00,Helpers--Electricians
+47-3014.00,"Helpers--Painters, Paperhangers, Plasterers, and Stucco Masons",47-3014.00,"Helpers--Painters, Paperhangers, Plasterers, and Stucco Masons"
+47-3015.00,"Helpers--Pipelayers, Plumbers, Pipefitters, and Steamfitters",47-3015.00,"Helpers--Pipelayers, Plumbers, Pipefitters, and Steamfitters"
+47-3016.00,Helpers--Roofers,47-3016.00,Helpers--Roofers
+47-3019.00,"Helpers, Construction Trades, All Other",47-3019.00,"Helpers, Construction Trades, All Other"
+47-4011.00,Construction and Building Inspectors,47-4011.00,Construction and Building Inspectors
+47-4021.00,Elevator Installers and Repairers,47-4021.00,Elevator Installers and Repairers
+47-4031.00,Fence Erectors,47-4031.00,Fence Erectors
+47-4041.00,Hazardous Materials Removal Workers,47-4041.00,Hazardous Materials Removal Workers
+47-4051.00,Highway Maintenance Workers,47-4051.00,Highway Maintenance Workers
+47-4061.00,Rail-Track Laying and Maintenance Equipment Operators,47-4061.00,Rail-Track Laying and Maintenance Equipment Operators
+47-4071.00,Septic Tank Servicers and Sewer Pipe Cleaners,47-4071.00,Septic Tank Servicers and Sewer Pipe Cleaners
+47-4091.00,Segmental Pavers,47-4091.00,Segmental Pavers
+47-4099.00,"Construction and Related Workers, All Other",47-4099.00,"Construction and Related Workers, All Other"
+47-4099.01,Solar Photovoltaic Installers,47-2231.00,Solar Photovoltaic Installers
+47-4099.02,Solar Thermal Installers and Technicians,47-4099.02,Solar Thermal Installers and Technicians
+47-4099.03,Weatherization Installers and Technicians,47-4099.03,Weatherization Installers and Technicians
+47-5011.00,"Derrick Operators, Oil and Gas",47-5011.00,"Derrick Operators, Oil and Gas"
+47-5012.00,"Rotary Drill Operators, Oil and Gas",47-5012.00,"Rotary Drill Operators, Oil and Gas"
+47-5013.00,"Service Unit Operators, Oil, Gas, and Mining",47-5013.00,"Service Unit Operators, Oil, Gas, and Mining"
+47-5021.00,"Earth Drillers, Except Oil and Gas",47-5021.00,"Earth Drillers, Except Oil and Gas"
+47-5031.00,"Explosives Workers, Ordnance Handling Experts, and Blasters",47-5031.00,"Explosives Workers, Ordnance Handling Experts, and Blasters"
+47-5041.00,Continuous Mining Machine Operators,47-5041.00,Continuous Mining Machine Operators
+47-5042.00,Mine Cutting and Channeling Machine Operators,47-5042.00,Mine Cutting and Channeling Machine Operators
+47-5049.00,"Mining Machine Operators, All Other",47-5049.00,"Mining Machine Operators, All Other"
+47-5051.00,"Rock Splitters, Quarry",47-5051.00,"Rock Splitters, Quarry"
+47-5061.00,"Roof Bolters, Mining",47-5061.00,"Roof Bolters, Mining"
+47-5071.00,"Roustabouts, Oil and Gas",47-5071.00,"Roustabouts, Oil and Gas"
+47-5081.00,Helpers--Extraction Workers,47-5081.00,Helpers--Extraction Workers
+47-5099.00,"Extraction Workers, All Other",47-5099.00,"Extraction Workers, All Other"
+49-1011.00,"First-Line Supervisors/Managers of Mechanics, Installers, and Repairers",49-1011.00,"First-Line Supervisors of Mechanics, Installers, and Repairers"
+49-2011.00,"Computer, Automated Teller, and Office Machine Repairers",49-2011.00,"Computer, Automated Teller, and Office Machine Repairers"
+49-2021.00,Radio Mechanics,49-2021.01,Radio Mechanics
+49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers",49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers"
+49-2091.00,Avionics Technicians,49-2091.00,Avionics Technicians
+49-2092.00,"Electric Motor, Power Tool, and Related Repairers",49-2092.00,"Electric Motor, Power Tool, and Related Repairers"
+49-2093.00,"Electrical and Electronics Installers and Repairers, Transportation Equipment",49-2093.00,"Electrical and Electronics Installers and Repairers, Transportation Equipment"
+49-2094.00,"Electrical and Electronics Repairers, Commercial and Industrial Equipment",49-2094.00,"Electrical and Electronics Repairers, Commercial and Industrial Equipment"
+49-2095.00,"Electrical and Electronics Repairers, Powerhouse, Substation, and Relay",49-2095.00,"Electrical and Electronics Repairers, Powerhouse, Substation, and Relay"
+49-2096.00,"Electronic Equipment Installers and Repairers, Motor Vehicles",49-2096.00,"Electronic Equipment Installers and Repairers, Motor Vehicles"
+49-2097.00,Electronic Home Entertainment Equipment Installers and Repairers,49-2097.00,Electronic Home Entertainment Equipment Installers and Repairers
+49-2098.00,Security and Fire Alarm Systems Installers,49-2098.00,Security and Fire Alarm Systems Installers
+49-3011.00,Aircraft Mechanics and Service Technicians,49-3011.00,Aircraft Mechanics and Service Technicians
+49-3021.00,Automotive Body and Related Repairers,49-3021.00,Automotive Body and Related Repairers
+49-3022.00,Automotive Glass Installers and Repairers,49-3022.00,Automotive Glass Installers and Repairers
+49-3023.00,Automotive Service Technicians and Mechanics,49-3023.00,Automotive Service Technicians and Mechanics
+49-3023.01,Automotive Master Mechanics,49-3023.01,Automotive Master Mechanics
+49-3023.02,Automotive Specialty Technicians,49-3023.02,Automotive Specialty Technicians
+49-3031.00,Bus and Truck Mechanics and Diesel Engine Specialists,49-3031.00,Bus and Truck Mechanics and Diesel Engine Specialists
+49-3041.00,Farm Equipment Mechanics,49-3041.00,Farm Equipment Mechanics and Service Technicians
+49-3042.00,"Mobile Heavy Equipment Mechanics, Except Engines",49-3042.00,"Mobile Heavy Equipment Mechanics, Except Engines"
+49-3043.00,Rail Car Repairers,49-3043.00,Rail Car Repairers
+49-3051.00,Motorboat Mechanics,49-3051.00,Motorboat Mechanics and Service Technicians
+49-3052.00,Motorcycle Mechanics,49-3052.00,Motorcycle Mechanics
+49-3053.00,Outdoor Power Equipment and Other Small Engine Mechanics,49-3053.00,Outdoor Power Equipment and Other Small Engine Mechanics
+49-3091.00,Bicycle Repairers,49-3091.00,Bicycle Repairers
+49-3092.00,Recreational Vehicle Service Technicians,49-3092.00,Recreational Vehicle Service Technicians
+49-3093.00,Tire Repairers and Changers,49-3093.00,Tire Repairers and Changers
+49-9011.00,Mechanical Door Repairers,49-9011.00,Mechanical Door Repairers
+49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door",49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door"
+49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers",49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers"
+49-9021.01,Heating and Air Conditioning Mechanics and Installers,49-9021.01,Heating and Air Conditioning Mechanics and Installers
+49-9021.02,Refrigeration Mechanics and Installers,49-9021.02,Refrigeration Mechanics and Installers
+49-9031.00,Home Appliance Repairers,49-9031.00,Home Appliance Repairers
+49-9041.00,Industrial Machinery Mechanics,49-9041.00,Industrial Machinery Mechanics
+49-9042.00,"Maintenance and Repair Workers, General",49-9071.00,"Maintenance and Repair Workers, General"
+49-9043.00,"Maintenance Workers, Machinery",49-9043.00,"Maintenance Workers, Machinery"
+49-9044.00,Millwrights,49-9044.00,Millwrights
+49-9045.00,"Refractory Materials Repairers, Except Brickmasons",49-9045.00,"Refractory Materials Repairers, Except Brickmasons"
+49-9051.00,Electrical Power-Line Installers and Repairers,49-9051.00,Electrical Power-Line Installers and Repairers
+49-9052.00,Telecommunications Line Installers and Repairers,49-9052.00,Telecommunications Line Installers and Repairers
+49-9061.00,Camera and Photographic Equipment Repairers,49-9061.00,Camera and Photographic Equipment Repairers
+49-9062.00,Medical Equipment Repairers,49-9062.00,Medical Equipment Repairers
+49-9063.00,Musical Instrument Repairers and Tuners,49-9063.00,Musical Instrument Repairers and Tuners
+49-9064.00,Watch Repairers,49-9064.00,Watch Repairers
+49-9069.00,"Precision Instrument and Equipment Repairers, All Other",49-9069.00,"Precision Instrument and Equipment Repairers, All Other"
+49-9091.00,"Coin, Vending, and Amusement Machine Servicers and Repairers",49-9091.00,"Coin, Vending, and Amusement Machine Servicers and Repairers"
+49-9092.00,Commercial Divers,49-9092.00,Commercial Divers
+49-9093.00,"Fabric Menders, Except Garment",49-9093.00,"Fabric Menders, Except Garment"
+49-9094.00,Locksmiths and Safe Repairers,49-9094.00,Locksmiths and Safe Repairers
+49-9095.00,Manufactured Building and Mobile Home Installers,49-9095.00,Manufactured Building and Mobile Home Installers
+49-9096.00,Riggers,49-9096.00,Riggers
+49-9097.00,Signal and Track Switch Repairers,49-9097.00,Signal and Track Switch Repairers
+49-9098.00,"Helpers--Installation, Maintenance, and Repair Workers",49-9098.00,"Helpers--Installation, Maintenance, and Repair Workers"
+49-9099.00,"Installation, Maintenance, and Repair Workers, All Other",49-9099.00,"Installation, Maintenance, and Repair Workers, All Other"
+49-9099.01,Geothermal Technicians,49-9099.01,Geothermal Technicians
+49-9099.02,Wind Turbine Service Technicians,49-9081.00,Wind Turbine Service Technicians
+51-1011.00,First-Line Supervisors/Managers of Production and Operating Workers,51-1011.00,First-Line Supervisors of Production and Operating Workers
+51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers",51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers"
+51-2021.00,"Coil Winders, Tapers, and Finishers",51-2021.00,"Coil Winders, Tapers, and Finishers"
+51-2022.00,Electrical and Electronic Equipment Assemblers,51-2022.00,Electrical and Electronic Equipment Assemblers
+51-2023.00,Electromechanical Equipment Assemblers,51-2023.00,Electromechanical Equipment Assemblers
+51-2031.00,Engine and Other Machine Assemblers,51-2031.00,Engine and Other Machine Assemblers
+51-2041.00,Structural Metal Fabricators and Fitters,51-2041.00,Structural Metal Fabricators and Fitters
+51-2091.00,Fiberglass Laminators and Fabricators,51-2091.00,Fiberglass Laminators and Fabricators
+51-2092.00,Team Assemblers,51-2092.00,Team Assemblers
+51-2093.00,"Timing Device Assemblers, Adjusters, and Calibrators",51-2093.00,Timing Device Assemblers and Adjusters
+51-2099.00,"Assemblers and Fabricators, All Other",51-2099.00,"Assemblers and Fabricators, All Other"
+51-3011.00,Bakers,51-3011.00,Bakers
+51-3021.00,Butchers and Meat Cutters,51-3021.00,Butchers and Meat Cutters
+51-3022.00,"Meat, Poultry, and Fish Cutters and Trimmers",51-3022.00,"Meat, Poultry, and Fish Cutters and Trimmers"
+51-3023.00,Slaughterers and Meat Packers,51-3023.00,Slaughterers and Meat Packers
+51-3091.00,"Food and Tobacco Roasting, Baking, and Drying Machine Operators and Tenders",51-3091.00,"Food and Tobacco Roasting, Baking, and Drying Machine Operators and Tenders"
+51-3092.00,Food Batchmakers,51-3092.00,Food Batchmakers
+51-3093.00,Food Cooking Machine Operators and Tenders,51-3093.00,Food Cooking Machine Operators and Tenders
+51-4011.00,"Computer-Controlled Machine Tool Operators, Metal and Plastic",51-4011.00,"Computer-Controlled Machine Tool Operators, Metal and Plastic"
+51-4012.00,Numerical Tool and Process Control Programmers,51-4012.00,"Computer Numerically Controlled Machine Tool Programmers, Metal and Plastic"
+51-4021.00,"Extruding and Drawing Machine Setters, Operators, and Tenders, Metal and Plastic",51-4021.00,"Extruding and Drawing Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4022.00,"Forging Machine Setters, Operators, and Tenders, Metal and Plastic",51-4022.00,"Forging Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4023.00,"Rolling Machine Setters, Operators, and Tenders, Metal and Plastic",51-4023.00,"Rolling Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic",51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4032.00,"Drilling and Boring Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4032.00,"Drilling and Boring Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4034.00,"Lathe and Turning Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4034.00,"Lathe and Turning Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4035.00,"Milling and Planing Machine Setters, Operators, and Tenders, Metal and Plastic",51-4035.00,"Milling and Planing Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4041.00,Machinists,51-4041.00,Machinists
+51-4051.00,Metal-Refining Furnace Operators and Tenders,51-4051.00,Metal-Refining Furnace Operators and Tenders
+51-4052.00,"Pourers and Casters, Metal",51-4052.00,"Pourers and Casters, Metal"
+51-4061.00,"Model Makers, Metal and Plastic",51-4061.00,"Model Makers, Metal and Plastic"
+51-4062.00,"Patternmakers, Metal and Plastic",51-4062.00,"Patternmakers, Metal and Plastic"
+51-4071.00,Foundry Mold and Coremakers,51-4071.00,Foundry Mold and Coremakers
+51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic",51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4111.00,Tool and Die Makers,51-4111.00,Tool and Die Makers
+51-4121.00,"Welders, Cutters, Solderers, and Brazers",51-4121.00,"Welders, Cutters, Solderers, and Brazers"
+51-4121.06,"Welders, Cutters, and Welder Fitters",51-4121.06,"Welders, Cutters, and Welder Fitters"
+51-4121.07,Solderers and Brazers,51-4121.07,Solderers and Brazers
+51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders",51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders"
+51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic",51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic"
+51-4192.00,"Lay-Out Workers, Metal and Plastic",51-4192.00,"Layout Workers, Metal and Plastic"
+51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic",51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4194.00,"Tool Grinders, Filers, and Sharpeners",51-4194.00,"Tool Grinders, Filers, and Sharpeners"
+51-4199.00,"Metal Workers and Plastic Workers, All Other",51-4199.00,"Metal Workers and Plastic Workers, All Other"
+51-5011.00,Bindery Workers,51-5113.00,Print Binding and Finishing Workers
+51-5012.00,Bookbinders,51-5113.00,Print Binding and Finishing Workers
+51-5021.00,Job Printers,51-5112.00,Printing Press Operators
+51-5021.00,Job Printers,51-5113.00,Print Binding and Finishing Workers
+51-5022.00,Prepress Technicians and Workers,51-5111.00,Prepress Technicians and Workers
+51-5023.00,Printing Machine Operators,51-5112.00,Printing Press Operators
+51-6011.00,Laundry and Dry-Cleaning Workers,51-6011.00,Laundry and Dry-Cleaning Workers
+51-6021.00,"Pressers, Textile, Garment, and Related Materials",51-6021.00,"Pressers, Textile, Garment, and Related Materials"
+51-6031.00,Sewing Machine Operators,51-6031.00,Sewing Machine Operators
+51-6041.00,Shoe and Leather Workers and Repairers,51-6041.00,Shoe and Leather Workers and Repairers
+51-6042.00,Shoe Machine Operators and Tenders,51-6042.00,Shoe Machine Operators and Tenders
+51-6051.00,"Sewers, Hand",51-6051.00,"Sewers, Hand"
+51-6052.00,"Tailors, Dressmakers, and Custom Sewers",51-6052.00,"Tailors, Dressmakers, and Custom Sewers"
+51-6061.00,Textile Bleaching and Dyeing Machine Operators and Tenders,51-6061.00,Textile Bleaching and Dyeing Machine Operators and Tenders
+51-6062.00,"Textile Cutting Machine Setters, Operators, and Tenders",51-6062.00,"Textile Cutting Machine Setters, Operators, and Tenders"
+51-6063.00,"Textile Knitting and Weaving Machine Setters, Operators, and Tenders",51-6063.00,"Textile Knitting and Weaving Machine Setters, Operators, and Tenders"
+51-6064.00,"Textile Winding, Twisting, and Drawing Out Machine Setters, Operators, and Tenders",51-6064.00,"Textile Winding, Twisting, and Drawing Out Machine Setters, Operators, and Tenders"
+51-6091.00,"Extruding and Forming Machine Setters, Operators, and Tenders, Synthetic and Glass Fibers",51-6091.00,"Extruding and Forming Machine Setters, Operators, and Tenders, Synthetic and Glass Fibers"
+51-6092.00,Fabric and Apparel Patternmakers,51-6092.00,Fabric and Apparel Patternmakers
+51-6093.00,Upholsterers,51-6093.00,Upholsterers
+51-6099.00,"Textile, Apparel, and Furnishings Workers, All Other",51-6099.00,"Textile, Apparel, and Furnishings Workers, All Other"
+51-7011.00,Cabinetmakers and Bench Carpenters,51-7011.00,Cabinetmakers and Bench Carpenters
+51-7021.00,Furniture Finishers,51-7021.00,Furniture Finishers
+51-7031.00,"Model Makers, Wood",51-7031.00,"Model Makers, Wood"
+51-7032.00,"Patternmakers, Wood",51-7032.00,"Patternmakers, Wood"
+51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood",51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood"
+51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing",51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing"
+51-7099.00,"Woodworkers, All Other",51-7099.00,"Woodworkers, All Other"
+51-8011.00,Nuclear Power Reactor Operators,51-8011.00,Nuclear Power Reactor Operators
+51-8012.00,Power Distributors and Dispatchers,51-8012.00,Power Distributors and Dispatchers
+51-8013.00,Power Plant Operators,51-8013.00,Power Plant Operators
+51-8021.00,Stationary Engineers and Boiler Operators,51-8021.00,Stationary Engineers and Boiler Operators
+51-8031.00,Water and Liquid Waste Treatment Plant and System Operators,51-8031.00,Water and Wastewater Treatment Plant and System Operators
+51-8091.00,Chemical Plant and System Operators,51-8091.00,Chemical Plant and System Operators
+51-8092.00,Gas Plant Operators,51-8092.00,Gas Plant Operators
+51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers",51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers"
+51-8099.00,"Plant and System Operators, All Other",51-8099.00,"Plant and System Operators, All Other"
+51-8099.01,Biofuels Processing Technicians,51-8099.01,Biofuels Processing Technicians
+51-8099.02,Methane/Landfill Gas Generation System Technicians,51-8099.02,Methane/Landfill Gas Generation System Technicians
+51-8099.03,Biomass Plant Technicians,51-8099.03,Biomass Plant Technicians
+51-8099.04,Hydroelectric Plant Technicians,51-8099.04,Hydroelectric Plant Technicians
+51-9011.00,Chemical Equipment Operators and Tenders,51-9011.00,Chemical Equipment Operators and Tenders
+51-9012.00,"Separating, Filtering, Clarifying, Precipitating, and Still Machine Setters, Operators, and Tenders",51-9012.00,"Separating, Filtering, Clarifying, Precipitating, and Still Machine Setters, Operators, and Tenders"
+51-9021.00,"Crushing, Grinding, and Polishing Machine Setters, Operators, and Tenders",51-9021.00,"Crushing, Grinding, and Polishing Machine Setters, Operators, and Tenders"
+51-9022.00,"Grinding and Polishing Workers, Hand",51-9022.00,"Grinding and Polishing Workers, Hand"
+51-9023.00,"Mixing and Blending Machine Setters, Operators, and Tenders",51-9023.00,"Mixing and Blending Machine Setters, Operators, and Tenders"
+51-9031.00,"Cutters and Trimmers, Hand",51-9031.00,"Cutters and Trimmers, Hand"
+51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders",51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders"
+51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders",51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders"
+51-9051.00,"Furnace, Kiln, Oven, Drier, and Kettle Operators and Tenders",51-9051.00,"Furnace, Kiln, Oven, Drier, and Kettle Operators and Tenders"
+51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers",51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers"
+51-9071.00,Jewelers and Precious Stone and Metal Workers,51-9071.00,Jewelers and Precious Stone and Metal Workers
+51-9071.01,Jewelers,51-9071.01,Jewelers
+51-9071.06,Gem and Diamond Workers,51-9071.06,Gem and Diamond Workers
+51-9071.07,Precious Metal Workers,51-9071.07,Precious Metal Workers
+51-9081.00,Dental Laboratory Technicians,51-9081.00,Dental Laboratory Technicians
+51-9082.00,Medical Appliance Technicians,51-9082.00,Medical Appliance Technicians
+51-9083.00,Ophthalmic Laboratory Technicians,51-9083.00,Ophthalmic Laboratory Technicians
+51-9111.00,Packaging and Filling Machine Operators and Tenders,51-9111.00,Packaging and Filling Machine Operators and Tenders
+51-9121.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders",51-9121.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders"
+51-9122.00,"Painters, Transportation Equipment",51-9122.00,"Painters, Transportation Equipment"
+51-9123.00,"Painting, Coating, and Decorating Workers",51-9123.00,"Painting, Coating, and Decorating Workers"
+51-9131.00,Photographic Process Workers,51-9151.00,Photographic Process Workers and Processing Machine Operators
+51-9132.00,Photographic Processing Machine Operators,51-9151.00,Photographic Process Workers and Processing Machine Operators
+51-9141.00,Semiconductor Processors,51-9141.00,Semiconductor Processors
+51-9191.00,Cementing and Gluing Machine Operators and Tenders,51-9191.00,Adhesive Bonding Machine Operators and Tenders
+51-9192.00,"Cleaning, Washing, and Metal Pickling Equipment Operators and Tenders",51-9192.00,"Cleaning, Washing, and Metal Pickling Equipment Operators and Tenders"
+51-9193.00,Cooling and Freezing Equipment Operators and Tenders,51-9193.00,Cooling and Freezing Equipment Operators and Tenders
+51-9194.00,Etchers and Engravers,51-9194.00,Etchers and Engravers
+51-9195.00,"Molders, Shapers, and Casters, Except Metal and Plastic",51-9195.00,"Molders, Shapers, and Casters, Except Metal and Plastic"
+51-9195.03,"Stone Cutters and Carvers, Manufacturing",51-9195.03,"Stone Cutters and Carvers, Manufacturing"
+51-9195.04,"Glass Blowers, Molders, Benders, and Finishers",51-9195.04,"Glass Blowers, Molders, Benders, and Finishers"
+51-9195.05,"Potters, Manufacturing",51-9195.05,"Potters, Manufacturing"
+51-9195.07,Molding and Casting Workers,51-9195.07,Molding and Casting Workers
+51-9196.00,"Paper Goods Machine Setters, Operators, and Tenders",51-9196.00,"Paper Goods Machine Setters, Operators, and Tenders"
+51-9197.00,Tire Builders,51-9197.00,Tire Builders
+51-9198.00,Helpers--Production Workers,51-9198.00,Helpers--Production Workers
+51-9199.00,"Production Workers, All Other",51-9199.00,"Production Workers, All Other"
+51-9199.01,Recycling and Reclamation Workers,51-9199.01,Recycling and Reclamation Workers
+53-1011.00,Aircraft Cargo Handling Supervisors,53-1011.00,Aircraft Cargo Handling Supervisors
+53-1021.00,"First-Line Supervisors/Managers of Helpers, Laborers, and Material Movers, Hand",53-1021.00,"First-Line Supervisors of Helpers, Laborers, and Material Movers, Hand"
+53-1021.01,Recycling Coordinators,53-1021.01,Recycling Coordinators
+53-1031.00,First-Line Supervisors/Managers of Transportation and Material-Moving Machine and Vehicle Operators,53-1031.00,First-Line Supervisors of Transportation and Material-Moving Machine and Vehicle Operators
+53-2011.00,"Airline Pilots, Copilots, and Flight Engineers",53-2011.00,"Airline Pilots, Copilots, and Flight Engineers"
+53-2012.00,Commercial Pilots,53-2012.00,Commercial Pilots
+53-2021.00,Air Traffic Controllers,53-2021.00,Air Traffic Controllers
+53-2022.00,Airfield Operations Specialists,53-2022.00,Airfield Operations Specialists
+53-3011.00,"Ambulance Drivers and Attendants, Except Emergency Medical Technicians",53-3011.00,"Ambulance Drivers and Attendants, Except Emergency Medical Technicians"
+53-3021.00,"Bus Drivers, Transit and Intercity",53-3021.00,"Bus Drivers, Transit and Intercity"
+53-3022.00,"Bus Drivers, School",53-3022.00,"Bus Drivers, School or Special Client"
+53-3031.00,Driver/Sales Workers,53-3031.00,Driver/Sales Workers
+53-3032.00,"Truck Drivers, Heavy and Tractor-Trailer",53-3032.00,Heavy and Tractor-Trailer Truck Drivers
+53-3033.00,"Truck Drivers, Light or Delivery Services",53-3033.00,Light Truck or Delivery Services Drivers
+53-3041.00,Taxi Drivers and Chauffeurs,53-3041.00,Taxi Drivers and Chauffeurs
+53-3099.00,"Motor Vehicle Operators, All Other",53-3099.00,"Motor Vehicle Operators, All Other"
+53-4011.00,Locomotive Engineers,53-4011.00,Locomotive Engineers
+53-4012.00,Locomotive Firers,53-4012.00,Locomotive Firers
+53-4013.00,"Rail Yard Engineers, Dinkey Operators, and Hostlers",53-4013.00,"Rail Yard Engineers, Dinkey Operators, and Hostlers"
+53-4021.00,"Railroad Brake, Signal, and Switch Operators",53-4021.00,"Railroad Brake, Signal, and Switch Operators"
+53-4031.00,Railroad Conductors and Yardmasters,53-4031.00,Railroad Conductors and Yardmasters
+53-4041.00,Subway and Streetcar Operators,53-4041.00,Subway and Streetcar Operators
+53-4099.00,"Rail Transportation Workers, All Other",53-4099.00,"Rail Transportation Workers, All Other"
+53-5011.00,Sailors and Marine Oilers,53-5011.00,Sailors and Marine Oilers
+53-5021.00,"Captains, Mates, and Pilots of Water Vessels",53-5021.00,"Captains, Mates, and Pilots of Water Vessels"
+53-5021.01,Ship and Boat Captains,53-5021.01,Ship and Boat Captains
+53-5021.02,"Mates- Ship, Boat, and Barge",53-5021.02,"Mates- Ship, Boat, and Barge"
+53-5021.03,"Pilots, Ship",53-5021.03,"Pilots, Ship"
+53-5022.00,Motorboat Operators,53-5022.00,Motorboat Operators
+53-5031.00,Ship Engineers,53-5031.00,Ship Engineers
+53-6011.00,Bridge and Lock Tenders,53-6011.00,Bridge and Lock Tenders
+53-6021.00,Parking Lot Attendants,53-6021.00,Parking Lot Attendants
+53-6031.00,Service Station Attendants,53-6031.00,Automotive and Watercraft Service Attendants
+53-6041.00,Traffic Technicians,53-6041.00,Traffic Technicians
+53-6051.00,Transportation Inspectors,53-6051.00,Transportation Inspectors
+53-6051.01,Aviation Inspectors,53-6051.01,Aviation Inspectors
+53-6051.07,"Transportation Vehicle, Equipment and Systems Inspectors, Except Aviation",53-6051.07,"Transportation Vehicle, Equipment and Systems Inspectors, Except Aviation"
+53-6051.08,Freight and Cargo Inspectors,53-6051.08,Freight and Cargo Inspectors
+53-6099.00,"Transportation Workers, All Other",53-6099.00,"Transportation Workers, All Other"
+53-7011.00,Conveyor Operators and Tenders,53-7011.00,Conveyor Operators and Tenders
+53-7021.00,Crane and Tower Operators,53-7021.00,Crane and Tower Operators
+53-7031.00,Dredge Operators,53-7031.00,Dredge Operators
+53-7032.00,Excavating and Loading Machine and Dragline Operators,53-7032.00,Excavating and Loading Machine and Dragline Operators
+53-7033.00,"Loading Machine Operators, Underground Mining",53-7033.00,"Loading Machine Operators, Underground Mining"
+53-7041.00,Hoist and Winch Operators,53-7041.00,Hoist and Winch Operators
+53-7051.00,Industrial Truck and Tractor Operators,53-7051.00,Industrial Truck and Tractor Operators
+53-7061.00,Cleaners of Vehicles and Equipment,53-7061.00,Cleaners of Vehicles and Equipment
+53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand",53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand"
+53-7063.00,Machine Feeders and Offbearers,53-7063.00,Machine Feeders and Offbearers
+53-7064.00,"Packers and Packagers, Hand",53-7064.00,"Packers and Packagers, Hand"
+53-7071.00,Gas Compressor and Gas Pumping Station Operators,53-7071.00,Gas Compressor and Gas Pumping Station Operators
+53-7072.00,"Pump Operators, Except Wellhead Pumpers",53-7072.00,"Pump Operators, Except Wellhead Pumpers"
+53-7073.00,Wellhead Pumpers,53-7073.00,Wellhead Pumpers
+53-7081.00,Refuse and Recyclable Material Collectors,53-7081.00,Refuse and Recyclable Material Collectors
+53-7111.00,Shuttle Car Operators,53-7111.00,Mine Shuttle Car Operators
+53-7121.00,"Tank Car, Truck, and Ship Loaders",53-7121.00,"Tank Car, Truck, and Ship Loaders"
+53-7199.00,"Material Moving Workers, All Other",53-7199.00,"Material Moving Workers, All Other"
+55-1011.00,Air Crew Officers,55-1011.00,Air Crew Officers
+55-1012.00,Aircraft Launch and Recovery Officers,55-1012.00,Aircraft Launch and Recovery Officers
+55-1013.00,Armored Assault Vehicle Officers,55-1013.00,Armored Assault Vehicle Officers
+55-1014.00,Artillery and Missile Officers,55-1014.00,Artillery and Missile Officers
+55-1015.00,Command and Control Center Officers,55-1015.00,Command and Control Center Officers
+55-1016.00,Infantry Officers,55-1016.00,Infantry Officers
+55-1017.00,Special Forces Officers,55-1017.00,Special Forces Officers
+55-1019.00,"Military Officer Special and Tactical Operations Leaders/Managers, All Other",55-1019.00,"Military Officer Special and Tactical Operations Leaders, All Other"
+55-2011.00,First-Line Supervisors/Managers of Air Crew Members,55-2011.00,First-Line Supervisors of Air Crew Members
+55-2012.00,First-Line Supervisors/Managers of Weapons Specialists/Crew Members,55-2012.00,First-Line Supervisors of Weapons Specialists/Crew Members
+55-2013.00,First-Line Supervisors/Managers of All Other Tactical Operations Specialists,55-2013.00,First-Line Supervisors of All Other Tactical Operations Specialists
+55-3011.00,Air Crew Members,55-3011.00,Air Crew Members
+55-3012.00,Aircraft Launch and Recovery Specialists,55-3012.00,Aircraft Launch and Recovery Specialists
+55-3013.00,Armored Assault Vehicle Crew Members,55-3013.00,Armored Assault Vehicle Crew Members
+55-3014.00,Artillery and Missile Crew Members,55-3014.00,Artillery and Missile Crew Members
+55-3015.00,Command and Control Center Specialists,55-3015.00,Command and Control Center Specialists
+55-3016.00,Infantry,55-3016.00,Infantry
+55-3017.00,Radar and Sonar Technicians,55-3017.00,Radar and Sonar Technicians
+55-3018.00,Special Forces,55-3018.00,Special Forces
+55-3019.00,"Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members, All Other",55-3019.00,"Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members, All Other"

--- a/lib/tasks/files/2010_to_2019_Crosswalk.csv
+++ b/lib/tasks/files/2010_to_2019_Crosswalk.csv
@@ -1,0 +1,1165 @@
+O*NET-SOC 2010 Code,O*NET-SOC 2010 Title,O*NET-SOC 2019 Code,O*NET-SOC 2019 Title
+11-1011.00,Chief Executives,11-1011.00,Chief Executives
+11-1011.03,Chief Sustainability Officers,11-1011.03,Chief Sustainability Officers
+11-1021.00,General and Operations Managers,11-1021.00,General and Operations Managers
+11-1031.00,Legislators,11-1031.00,Legislators
+11-2011.00,Advertising and Promotions Managers,11-2011.00,Advertising and Promotions Managers
+11-2011.01,Green Marketers,11-2011.00,Advertising and Promotions Managers
+11-2021.00,Marketing Managers,11-2021.00,Marketing Managers
+11-2022.00,Sales Managers,11-2022.00,Sales Managers
+11-2031.00,Public Relations and Fundraising Managers,11-2032.00,Public Relations Managers
+11-2031.00,Public Relations and Fundraising Managers,11-2033.00,Fundraising Managers
+11-3011.00,Administrative Services Managers,11-3012.00,Administrative Services Managers
+11-3011.00,Administrative Services Managers,11-3013.00,Facilities Managers
+11-3021.00,Computer and Information Systems Managers,11-3021.00,Computer and Information Systems Managers
+11-3031.00,Financial Managers,11-3031.00,Financial Managers
+11-3031.01,Treasurers and Controllers,11-3031.01,Treasurers and Controllers
+11-3031.02,"Financial Managers, Branch or Department",11-3031.00,Financial Managers
+11-3051.00,Industrial Production Managers,11-3051.00,Industrial Production Managers
+11-3051.01,Quality Control Systems Managers,11-3051.01,Quality Control Systems Managers
+11-3051.02,Geothermal Production Managers,11-3051.02,Geothermal Production Managers
+11-3051.03,Biofuels Production Managers,11-3051.03,Biofuels Production Managers
+11-3051.04,Biomass Power Plant Managers,11-3051.04,Biomass Power Plant Managers
+11-3051.05,Methane/Landfill Gas Collection System Operators,11-3051.00,Industrial Production Managers
+11-3051.06,Hydroelectric Production Managers,11-3051.06,Hydroelectric Production Managers
+11-3061.00,Purchasing Managers,11-3061.00,Purchasing Managers
+11-3071.00,"Transportation, Storage, and Distribution Managers",11-3071.00,"Transportation, Storage, and Distribution Managers"
+11-3071.01,Transportation Managers,11-3071.00,"Transportation, Storage, and Distribution Managers"
+11-3071.02,Storage and Distribution Managers,11-3071.00,"Transportation, Storage, and Distribution Managers"
+11-3071.03,Logistics Managers,11-3071.00,"Transportation, Storage, and Distribution Managers"
+11-3111.00,Compensation and Benefits Managers,11-3111.00,Compensation and Benefits Managers
+11-3121.00,Human Resources Managers,11-3121.00,Human Resources Managers
+11-3131.00,Training and Development Managers,11-3131.00,Training and Development Managers
+11-9013.00,"Farmers, Ranchers, and Other Agricultural Managers",11-9013.00,"Farmers, Ranchers, and Other Agricultural Managers"
+11-9013.01,Nursery and Greenhouse Managers,11-9013.00,"Farmers, Ranchers, and Other Agricultural Managers"
+11-9013.02,Farm and Ranch Managers,11-9013.00,"Farmers, Ranchers, and Other Agricultural Managers"
+11-9013.03,Aquacultural Managers,11-9013.00,"Farmers, Ranchers, and Other Agricultural Managers"
+11-9021.00,Construction Managers,11-9021.00,Construction Managers
+11-9031.00,"Education Administrators, Preschool and Childcare Center/Program",11-9031.00,"Education and Childcare Administrators, Preschool and Daycare"
+11-9032.00,"Education Administrators, Elementary and Secondary School",11-9032.00,"Education Administrators, Kindergarten through Secondary"
+11-9033.00,"Education Administrators, Postsecondary",11-9033.00,"Education Administrators, Postsecondary"
+11-9039.00,"Education Administrators, All Other",11-9039.00,"Education Administrators, All Other"
+11-9039.01,Distance Learning Coordinators,11-9039.00,"Education Administrators, All Other"
+11-9039.02,Fitness and Wellness Coordinators,11-9179.01,Fitness and Wellness Coordinators
+11-9041.00,Architectural and Engineering Managers,11-9041.00,Architectural and Engineering Managers
+11-9041.01,Biofuels/Biodiesel Technology and Product Development Managers,11-9041.01,Biofuels/Biodiesel Technology and Product Development Managers
+11-9051.00,Food Service Managers,11-9051.00,Food Service Managers
+11-9061.00,Funeral Service Managers,11-9171.00,Funeral Home Managers
+11-9071.00,Gaming Managers,11-9071.00,Gambling Managers
+11-9081.00,Lodging Managers,11-9081.00,Lodging Managers
+11-9111.00,Medical and Health Services Managers,11-9111.00,Medical and Health Services Managers
+11-9121.00,Natural Sciences Managers,11-9121.00,Natural Sciences Managers
+11-9121.01,Clinical Research Coordinators,11-9121.01,Clinical Research Coordinators
+11-9121.02,Water Resource Specialists,11-9121.02,Water Resource Specialists
+11-9131.00,Postmasters and Mail Superintendents,11-9131.00,Postmasters and Mail Superintendents
+11-9141.00,"Property, Real Estate, and Community Association Managers",11-9141.00,"Property, Real Estate, and Community Association Managers"
+11-9151.00,Social and Community Service Managers,11-9151.00,Social and Community Service Managers
+11-9161.00,Emergency Management Directors,11-9161.00,Emergency Management Directors
+11-9199.00,"Managers, All Other",11-9072.00,"Entertainment and Recreation Managers, Except Gambling"
+11-9199.00,"Managers, All Other",11-9179.00,"Personal Service Managers, All Other"
+11-9199.00,"Managers, All Other",11-9199.00,"Managers, All Other"
+11-9199.00,"Managers, All Other",13-1082.00,Project Management Specialists
+11-9199.01,Regulatory Affairs Managers,11-9199.01,Regulatory Affairs Managers
+11-9199.02,Compliance Managers,11-9199.02,Compliance Managers
+11-9199.03,Investment Fund Managers,11-3031.03,Investment Fund Managers
+11-9199.04,Supply Chain Managers,11-3071.04,Supply Chain Managers
+11-9199.07,Security Managers,11-3013.01,Security Managers
+11-9199.07,Security Managers,11-9199.00,"Managers, All Other"
+11-9199.08,Loss Prevention Managers,11-9199.08,Loss Prevention Managers
+11-9199.09,Wind Energy Operations Managers,11-9199.09,Wind Energy Operations Managers
+11-9199.10,Wind Energy Project Managers,11-9199.10,Wind Energy Development Managers
+11-9199.11,Brownfield Redevelopment Specialists and Site Managers,11-9199.11,Brownfield Redevelopment Specialists and Site Managers
+13-1011.00,"Agents and Business Managers of Artists, Performers, and Athletes",13-1011.00,"Agents and Business Managers of Artists, Performers, and Athletes"
+13-1021.00,"Buyers and Purchasing Agents, Farm Products",13-1021.00,"Buyers and Purchasing Agents, Farm Products"
+13-1022.00,"Wholesale and Retail Buyers, Except Farm Products",13-1022.00,"Wholesale and Retail Buyers, Except Farm Products"
+13-1023.00,"Purchasing Agents, Except Wholesale, Retail, and Farm Products",13-1023.00,"Purchasing Agents, Except Wholesale, Retail, and Farm Products"
+13-1031.00,"Claims Adjusters, Examiners, and Investigators",13-1031.00,"Claims Adjusters, Examiners, and Investigators"
+13-1031.01,"Claims Examiners, Property and Casualty Insurance",13-1031.00,"Claims Adjusters, Examiners, and Investigators"
+13-1031.02,"Insurance Adjusters, Examiners, and Investigators",13-1031.00,"Claims Adjusters, Examiners, and Investigators"
+13-1032.00,"Insurance Appraisers, Auto Damage",13-1032.00,"Insurance Appraisers, Auto Damage"
+13-1041.00,Compliance Officers,13-1041.00,Compliance Officers
+13-1041.01,Environmental Compliance Inspectors,13-1041.01,Environmental Compliance Inspectors
+13-1041.02,Licensing Examiners and Inspectors,13-1041.00,Compliance Officers
+13-1041.03,Equal Opportunity Representatives and Officers,13-1041.03,Equal Opportunity Representatives and Officers
+13-1041.04,Government Property Inspectors and Investigators,13-1041.04,Government Property Inspectors and Investigators
+13-1041.06,Coroners,13-1041.06,Coroners
+13-1041.07,Regulatory Affairs Specialists,13-1041.07,Regulatory Affairs Specialists
+13-1051.00,Cost Estimators,13-1051.00,Cost Estimators
+13-1071.00,Human Resources Specialists,13-1071.00,Human Resources Specialists
+13-1074.00,Farm Labor Contractors,13-1074.00,Farm Labor Contractors
+13-1075.00,Labor Relations Specialists,13-1075.00,Labor Relations Specialists
+13-1081.00,Logisticians,13-1081.00,Logisticians
+13-1081.01,Logistics Engineers,13-1081.01,Logistics Engineers
+13-1081.02,Logistics Analysts,13-1081.02,Logistics Analysts
+13-1111.00,Management Analysts,13-1111.00,Management Analysts
+13-1121.00,"Meeting, Convention, and Event Planners",13-1121.00,"Meeting, Convention, and Event Planners"
+13-1131.00,Fundraisers,13-1131.00,Fundraisers
+13-1141.00,"Compensation, Benefits, and Job Analysis Specialists",13-1141.00,"Compensation, Benefits, and Job Analysis Specialists"
+13-1151.00,Training and Development Specialists,13-1151.00,Training and Development Specialists
+13-1161.00,Market Research Analysts and Marketing Specialists,13-1161.00,Market Research Analysts and Marketing Specialists
+13-1199.00,"Business Operations Specialists, All Other",13-1082.00,Project Management Specialists
+13-1199.00,"Business Operations Specialists, All Other",13-1199.00,"Business Operations Specialists, All Other"
+13-1199.01,Energy Auditors,47-4011.01,Energy Auditors
+13-1199.02,Security Management Specialists,13-1199.00,"Business Operations Specialists, All Other"
+13-1199.02,Security Management Specialists,13-1199.07,Security Management Specialists
+13-1199.03,Customs Brokers,13-1041.08,Customs Brokers
+13-1199.04,Business Continuity Planners,13-1199.04,Business Continuity Planners
+13-1199.05,Sustainability Specialists,13-1199.05,Sustainability Specialists
+13-1199.06,Online Merchants,13-1199.06,Online Merchants
+13-2011.00,Accountants and Auditors,13-2011.00,Accountants and Auditors
+13-2011.01,Accountants,13-2011.00,Accountants and Auditors
+13-2011.02,Auditors,13-2011.00,Accountants and Auditors
+13-2021.00,Appraisers and Assessors of Real Estate,13-2022.00,Appraisers of Personal and Business Property
+13-2021.00,Appraisers and Assessors of Real Estate,13-2023.00,Appraisers and Assessors of Real Estate
+13-2021.01,Assessors,13-2023.00,Appraisers and Assessors of Real Estate
+13-2021.02,"Appraisers, Real Estate",13-2023.00,Appraisers and Assessors of Real Estate
+13-2031.00,Budget Analysts,13-2031.00,Budget Analysts
+13-2041.00,Credit Analysts,13-2041.00,Credit Analysts
+13-2051.00,Financial Analysts,13-2051.00,Financial and Investment Analysts
+13-2051.00,Financial Analysts,13-2054.00,Financial Risk Specialists
+13-2052.00,Personal Financial Advisors,13-2052.00,Personal Financial Advisors
+13-2053.00,Insurance Underwriters,13-2053.00,Insurance Underwriters
+13-2061.00,Financial Examiners,13-2061.00,Financial Examiners
+13-2071.00,Credit Counselors,13-2071.00,Credit Counselors
+13-2071.01,Loan Counselors,13-2072.00,Loan Officers
+13-2072.00,Loan Officers,13-2072.00,Loan Officers
+13-2081.00,"Tax Examiners and Collectors, and Revenue Agents",13-2081.00,"Tax Examiners and Collectors, and Revenue Agents"
+13-2082.00,Tax Preparers,13-2082.00,Tax Preparers
+13-2099.00,"Financial Specialists, All Other",13-2054.00,Financial Risk Specialists
+13-2099.00,"Financial Specialists, All Other",13-2099.00,"Financial Specialists, All Other"
+13-2099.01,Financial Quantitative Analysts,13-2099.01,Financial Quantitative Analysts
+13-2099.02,Risk Management Specialists,13-2054.00,Financial Risk Specialists
+13-2099.03,Investment Underwriters,13-2051.00,Financial and Investment Analysts
+13-2099.04,"Fraud Examiners, Investigators and Analysts",13-2099.04,"Fraud Examiners, Investigators and Analysts"
+15-1111.00,Computer and Information Research Scientists,15-1221.00,Computer and Information Research Scientists
+15-1121.00,Computer Systems Analysts,15-1211.00,Computer Systems Analysts
+15-1121.01,Informatics Nurse Specialists,15-1211.01,Health Informatics Specialists
+15-1122.00,Information Security Analysts,15-1212.00,Information Security Analysts
+15-1131.00,Computer Programmers,15-1251.00,Computer Programmers
+15-1132.00,"Software Developers, Applications",15-1252.00,Software Developers
+15-1132.00,"Software Developers, Applications",15-1253.00,Software Quality Assurance Analysts and Testers
+15-1133.00,"Software Developers, Systems Software",15-1252.00,Software Developers
+15-1133.00,"Software Developers, Systems Software",15-1253.00,Software Quality Assurance Analysts and Testers
+15-1134.00,Web Developers,15-1254.00,Web Developers
+15-1134.00,Web Developers,15-1255.00,Web and Digital Interface Designers
+15-1141.00,Database Administrators,15-1242.00,Database Administrators
+15-1141.00,Database Administrators,15-1243.00,Database Architects
+15-1142.00,Network and Computer Systems Administrators,15-1244.00,Network and Computer Systems Administrators
+15-1143.00,Computer Network Architects,15-1241.00,Computer Network Architects
+15-1143.01,Telecommunications Engineering Specialists,15-1241.01,Telecommunications Engineering Specialists
+15-1151.00,Computer User Support Specialists,15-1232.00,Computer User Support Specialists
+15-1152.00,Computer Network Support Specialists,15-1231.00,Computer Network Support Specialists
+15-1199.00,"Computer Occupations, All Other",13-1082.00,Project Management Specialists
+15-1199.00,"Computer Occupations, All Other",15-1255.00,Web and Digital Interface Designers
+15-1199.00,"Computer Occupations, All Other",15-1299.00,"Computer Occupations, All Other"
+15-1199.01,Software Quality Assurance Engineers and Testers,15-1253.00,Software Quality Assurance Analysts and Testers
+15-1199.02,Computer Systems Engineers/Architects,15-1299.08,Computer Systems Engineers/Architects
+15-1199.03,Web Administrators,15-1299.01,Web Administrators
+15-1199.04,Geospatial Information Scientists and Technologists,15-1299.02,Geographic Information Systems Technologists and Technicians
+15-1199.05,Geographic Information Systems Technicians,15-1299.02,Geographic Information Systems Technologists and Technicians
+15-1199.06,Database Architects,15-1243.00,Database Architects
+15-1199.07,Data Warehousing Specialists,15-1243.01,Data Warehousing Specialists
+15-1199.08,Business Intelligence Analysts,15-2051.01,Business Intelligence Analysts
+15-1199.09,Information Technology Project Managers,15-1299.09,Information Technology Project Managers
+15-1199.10,Search Marketing Strategists,13-1161.01,Search Marketing Strategists
+15-1199.11,Video Game Designers,15-1255.01,Video Game Designers
+15-1199.12,Document Management Specialists,15-1299.03,Document Management Specialists
+15-2011.00,Actuaries,15-2011.00,Actuaries
+15-2021.00,Mathematicians,15-2021.00,Mathematicians
+15-2031.00,Operations Research Analysts,15-2031.00,Operations Research Analysts
+15-2041.00,Statisticians,15-2041.00,Statisticians
+15-2041.01,Biostatisticians,15-2041.01,Biostatisticians
+15-2041.02,Clinical Data Managers,15-2051.02,Clinical Data Managers
+15-2091.00,Mathematical Technicians,15-2099.00,"Mathematical Science Occupations, All Other"
+15-2099.00,"Mathematical Science Occupations, All Other",15-2051.00,Data Scientists
+15-2099.00,"Mathematical Science Occupations, All Other",15-2099.00,"Mathematical Science Occupations, All Other"
+17-1011.00,"Architects, Except Landscape and Naval",17-1011.00,"Architects, Except Landscape and Naval"
+17-1012.00,Landscape Architects,17-1012.00,Landscape Architects
+17-1021.00,Cartographers and Photogrammetrists,17-1021.00,Cartographers and Photogrammetrists
+17-1022.00,Surveyors,17-1022.00,Surveyors
+17-1022.01,Geodetic Surveyors,17-1022.01,Geodetic Surveyors
+17-2011.00,Aerospace Engineers,17-2011.00,Aerospace Engineers
+17-2021.00,Agricultural Engineers,17-2021.00,Agricultural Engineers
+17-2031.00,Biomedical Engineers,17-2031.00,Bioengineers and Biomedical Engineers
+17-2041.00,Chemical Engineers,17-2041.00,Chemical Engineers
+17-2051.00,Civil Engineers,17-2051.00,Civil Engineers
+17-2051.01,Transportation Engineers,17-2051.01,Transportation Engineers
+17-2061.00,Computer Hardware Engineers,17-2061.00,Computer Hardware Engineers
+17-2071.00,Electrical Engineers,17-2071.00,Electrical Engineers
+17-2072.00,"Electronics Engineers, Except Computer",17-2072.00,"Electronics Engineers, Except Computer"
+17-2072.01,Radio Frequency Identification Device Specialists,17-2072.01,Radio Frequency Identification Device Specialists
+17-2081.00,Environmental Engineers,17-2081.00,Environmental Engineers
+17-2081.01,Water/Wastewater Engineers,17-2051.02,Water/Wastewater Engineers
+17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors",17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors"
+17-2111.01,Industrial Safety and Health Engineers,17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors"
+17-2111.02,Fire-Prevention and Protection Engineers,17-2111.02,Fire-Prevention and Protection Engineers
+17-2111.03,Product Safety Engineers,17-2111.00,"Health and Safety Engineers, Except Mining Safety Engineers and Inspectors"
+17-2112.00,Industrial Engineers,17-2112.00,Industrial Engineers
+17-2112.01,Human Factors Engineers and Ergonomists,17-2112.01,Human Factors Engineers and Ergonomists
+17-2121.00,Marine Engineers and Naval Architects,17-2121.00,Marine Engineers and Naval Architects
+17-2121.01,Marine Engineers,17-2121.00,Marine Engineers and Naval Architects
+17-2121.02,Marine Architects,17-2121.00,Marine Engineers and Naval Architects
+17-2131.00,Materials Engineers,17-2131.00,Materials Engineers
+17-2141.00,Mechanical Engineers,17-2141.00,Mechanical Engineers
+17-2141.01,Fuel Cell Engineers,17-2141.01,Fuel Cell Engineers
+17-2141.02,Automotive Engineers,17-2141.02,Automotive Engineers
+17-2151.00,"Mining and Geological Engineers, Including Mining Safety Engineers",17-2151.00,"Mining and Geological Engineers, Including Mining Safety Engineers"
+17-2161.00,Nuclear Engineers,17-2161.00,Nuclear Engineers
+17-2171.00,Petroleum Engineers,17-2171.00,Petroleum Engineers
+17-2199.00,"Engineers, All Other",17-2199.00,"Engineers, All Other"
+17-2199.01,Biochemical Engineers,17-2031.00,Bioengineers and Biomedical Engineers
+17-2199.02,Validation Engineers,17-2112.02,Validation Engineers
+17-2199.03,Energy Engineers,17-2199.03,"Energy Engineers, Except Wind and Solar"
+17-2199.04,Manufacturing Engineers,17-2112.03,Manufacturing Engineers
+17-2199.05,Mechatronics Engineers,17-2199.05,Mechatronics Engineers
+17-2199.06,Microsystems Engineers,17-2199.06,Microsystems Engineers
+17-2199.07,Photonics Engineers,17-2199.07,Photonics Engineers
+17-2199.08,Robotics Engineers,17-2199.08,Robotics Engineers
+17-2199.09,Nanosystems Engineers,17-2199.09,Nanosystems Engineers
+17-2199.10,Wind Energy Engineers,17-2199.10,Wind Energy Engineers
+17-2199.11,Solar Energy Systems Engineers,17-2199.11,Solar Energy Systems Engineers
+17-3011.00,Architectural and Civil Drafters,17-3011.00,Architectural and Civil Drafters
+17-3011.01,Architectural Drafters,17-3011.00,Architectural and Civil Drafters
+17-3011.02,Civil Drafters,17-3011.00,Architectural and Civil Drafters
+17-3012.00,Electrical and Electronics Drafters,17-3012.00,Electrical and Electronics Drafters
+17-3012.01,Electronic Drafters,17-3012.00,Electrical and Electronics Drafters
+17-3012.02,Electrical Drafters,17-3012.00,Electrical and Electronics Drafters
+17-3013.00,Mechanical Drafters,17-3013.00,Mechanical Drafters
+17-3019.00,"Drafters, All Other",17-3019.00,"Drafters, All Other"
+17-3021.00,Aerospace Engineering and Operations Technicians,17-3021.00,Aerospace Engineering and Operations Technologists and Technicians
+17-3022.00,Civil Engineering Technicians,17-3022.00,Civil Engineering Technologists and Technicians
+17-3023.00,Electrical and Electronic Engineering Technicians,17-3023.00,Electrical and Electronic Engineering Technologists and Technicians
+17-3023.01,Electronics Engineering Technicians,17-3023.00,Electrical and Electronic Engineering Technologists and Technicians
+17-3023.03,Electrical Engineering Technicians,17-3023.00,Electrical and Electronic Engineering Technologists and Technicians
+17-3024.00,Electro-Mechanical Technicians,17-3024.00,Electro-Mechanical and Mechatronics Technologists and Technicians
+17-3024.01,Robotics Technicians,17-3024.01,Robotics Technicians
+17-3025.00,Environmental Engineering Technicians,17-3025.00,Environmental Engineering Technologists and Technicians
+17-3026.00,Industrial Engineering Technicians,17-3026.00,Industrial Engineering Technologists and Technicians
+17-3027.00,Mechanical Engineering Technicians,17-3027.00,Mechanical Engineering Technologists and Technicians
+17-3027.01,Automotive Engineering Technicians,17-3027.01,Automotive Engineering Technicians
+17-3029.00,"Engineering Technicians, Except Drafters, All Other",17-3028.00,Calibration Technologists and Technicians
+17-3029.00,"Engineering Technicians, Except Drafters, All Other",17-3029.00,"Engineering Technologists and Technicians, Except Drafters, All Other"
+17-3029.01,Non-Destructive Testing Specialists,17-3029.01,Non-Destructive Testing Specialists
+17-3029.02,Electrical Engineering Technologists,17-3023.00,Electrical and Electronic Engineering Technologists and Technicians
+17-3029.03,Electromechanical Engineering Technologists,17-3024.00,Electro-Mechanical and Mechatronics Technologists and Technicians
+17-3029.04,Electronics Engineering Technologists,17-3023.00,Electrical and Electronic Engineering Technologists and Technicians
+17-3029.05,Industrial Engineering Technologists,17-3026.00,Industrial Engineering Technologists and Technicians
+17-3029.06,Manufacturing Engineering Technologists,17-3026.00,Industrial Engineering Technologists and Technicians
+17-3029.07,Mechanical Engineering Technologists,17-3027.00,Mechanical Engineering Technologists and Technicians
+17-3029.08,Photonics Technicians,17-3029.08,Photonics Technicians
+17-3029.09,Manufacturing Production Technicians,17-3026.00,Industrial Engineering Technologists and Technicians
+17-3029.10,Fuel Cell Technicians,17-3029.00,"Engineering Technologists and Technicians, Except Drafters, All Other"
+17-3029.11,Nanotechnology Engineering Technologists,17-3026.01,Nanotechnology Engineering Technologists and Technicians
+17-3029.12,Nanotechnology Engineering Technicians,17-3026.01,Nanotechnology Engineering Technologists and Technicians
+17-3031.00,Surveying and Mapping Technicians,17-3031.00,Surveying and Mapping Technicians
+17-3031.01,Surveying Technicians,17-3031.00,Surveying and Mapping Technicians
+17-3031.02,Mapping Technicians,17-3031.00,Surveying and Mapping Technicians
+19-1011.00,Animal Scientists,19-1011.00,Animal Scientists
+19-1012.00,Food Scientists and Technologists,19-1012.00,Food Scientists and Technologists
+19-1013.00,Soil and Plant Scientists,19-1013.00,Soil and Plant Scientists
+19-1020.01,Biologists,19-1029.04,Biologists
+19-1021.00,Biochemists and Biophysicists,19-1021.00,Biochemists and Biophysicists
+19-1022.00,Microbiologists,19-1022.00,Microbiologists
+19-1023.00,Zoologists and Wildlife Biologists,19-1023.00,Zoologists and Wildlife Biologists
+19-1029.00,"Biological Scientists, All Other",19-1029.00,"Biological Scientists, All Other"
+19-1029.01,Bioinformatics Scientists,19-1029.01,Bioinformatics Scientists
+19-1029.02,Molecular and Cellular Biologists,19-1029.02,Molecular and Cellular Biologists
+19-1029.03,Geneticists,19-1029.03,Geneticists
+19-1031.00,Conservation Scientists,19-1031.00,Conservation Scientists
+19-1031.01,Soil and Water Conservationists,19-1031.00,Conservation Scientists
+19-1031.02,Range Managers,19-1031.02,Range Managers
+19-1031.03,Park Naturalists,19-1031.03,Park Naturalists
+19-1032.00,Foresters,19-1032.00,Foresters
+19-1041.00,Epidemiologists,19-1041.00,Epidemiologists
+19-1042.00,"Medical Scientists, Except Epidemiologists",19-1042.00,"Medical Scientists, Except Epidemiologists"
+19-1099.00,"Life Scientists, All Other",19-1099.00,"Life Scientists, All Other"
+19-2011.00,Astronomers,19-2011.00,Astronomers
+19-2012.00,Physicists,19-2012.00,Physicists
+19-2021.00,Atmospheric and Space Scientists,19-2021.00,Atmospheric and Space Scientists
+19-2031.00,Chemists,19-2031.00,Chemists
+19-2032.00,Materials Scientists,19-2032.00,Materials Scientists
+19-2041.00,"Environmental Scientists and Specialists, Including Health",19-2041.00,"Environmental Scientists and Specialists, Including Health"
+19-2041.01,Climate Change Analysts,19-2041.01,Climate Change Policy Analysts
+19-2041.02,Environmental Restoration Planners,19-2041.02,Environmental Restoration Planners
+19-2041.03,Industrial Ecologists,19-2041.03,Industrial Ecologists
+19-2042.00,"Geoscientists, Except Hydrologists and Geographers",19-2042.00,"Geoscientists, Except Hydrologists and Geographers"
+19-2043.00,Hydrologists,19-2043.00,Hydrologists
+19-2099.00,"Physical Scientists, All Other",19-2099.00,"Physical Scientists, All Other"
+19-2099.01,Remote Sensing Scientists and Technologists,19-2099.01,Remote Sensing Scientists and Technologists
+19-3011.00,Economists,19-3011.00,Economists
+19-3011.01,Environmental Economists,19-3011.01,Environmental Economists
+19-3022.00,Survey Researchers,19-3022.00,Survey Researchers
+19-3031.00,"Clinical, Counseling, and School Psychologists",19-3033.00,Clinical and Counseling Psychologists
+19-3031.01,School Psychologists,19-3034.00,School Psychologists
+19-3031.02,Clinical Psychologists,19-3033.00,Clinical and Counseling Psychologists
+19-3031.03,Counseling Psychologists,19-3033.00,Clinical and Counseling Psychologists
+19-3032.00,Industrial-Organizational Psychologists,19-3032.00,Industrial-Organizational Psychologists
+19-3039.00,"Psychologists, All Other",19-3039.00,"Psychologists, All Other"
+19-3039.01,Neuropsychologists and Clinical Neuropsychologists,19-3039.02,Neuropsychologists
+19-3039.01,Neuropsychologists and Clinical Neuropsychologists,19-3039.03,Clinical Neuropsychologists
+19-3041.00,Sociologists,19-3041.00,Sociologists
+19-3051.00,Urban and Regional Planners,19-3051.00,Urban and Regional Planners
+19-3091.00,Anthropologists and Archeologists,19-3091.00,Anthropologists and Archeologists
+19-3091.01,Anthropologists,19-3091.00,Anthropologists and Archeologists
+19-3091.02,Archeologists,19-3091.00,Anthropologists and Archeologists
+19-3092.00,Geographers,19-3092.00,Geographers
+19-3093.00,Historians,19-3093.00,Historians
+19-3094.00,Political Scientists,19-3094.00,Political Scientists
+19-3099.00,"Social Scientists and Related Workers, All Other",19-3099.00,"Social Scientists and Related Workers, All Other"
+19-3099.01,Transportation Planners,19-3099.01,Transportation Planners
+19-4011.00,Agricultural and Food Science Technicians,19-4012.00,Agricultural Technicians
+19-4011.00,Agricultural and Food Science Technicians,19-4013.00,Food Science Technicians
+19-4011.01,Agricultural Technicians,19-4012.00,Agricultural Technicians
+19-4011.02,Food Science Technicians,19-4013.00,Food Science Technicians
+19-4021.00,Biological Technicians,19-4021.00,Biological Technicians
+19-4031.00,Chemical Technicians,19-4031.00,Chemical Technicians
+19-4041.00,Geological and Petroleum Technicians,19-4043.00,"Geological Technicians, Except Hydrologic Technicians"
+19-4041.00,Geological and Petroleum Technicians,19-4044.00,Hydrologic Technicians
+19-4041.01,Geophysical Data Technicians,19-4043.00,"Geological Technicians, Except Hydrologic Technicians"
+19-4041.02,Geological Sample Test Technicians,19-4043.00,"Geological Technicians, Except Hydrologic Technicians"
+19-4051.00,Nuclear Technicians,19-4051.00,Nuclear Technicians
+19-4051.01,Nuclear Equipment Operation Technicians,19-4051.00,Nuclear Technicians
+19-4051.02,Nuclear Monitoring Technicians,19-4051.02,Nuclear Monitoring Technicians
+19-4061.00,Social Science Research Assistants,19-4061.00,Social Science Research Assistants
+19-4061.01,City and Regional Planning Aides,19-3051.00,Urban and Regional Planners
+19-4091.00,"Environmental Science and Protection Technicians, Including Health",19-4042.00,"Environmental Science and Protection Technicians, Including Health"
+19-4092.00,Forensic Science Technicians,19-4092.00,Forensic Science Technicians
+19-4093.00,Forest and Conservation Technicians,19-4071.00,Forest and Conservation Technicians
+19-4099.00,"Life, Physical, and Social Science Technicians, All Other",19-4044.00,Hydrologic Technicians
+19-4099.00,"Life, Physical, and Social Science Technicians, All Other",19-4099.00,"Life, Physical, and Social Science Technicians, All Other"
+19-4099.01,Quality Control Analysts,19-4099.01,Quality Control Analysts
+19-4099.02,Precision Agriculture Technicians,19-4012.01,Precision Agriculture Technicians
+19-4099.03,Remote Sensing Technicians,19-4099.03,Remote Sensing Technicians
+21-1011.00,Substance Abuse and Behavioral Disorder Counselors,21-1011.00,Substance Abuse and Behavioral Disorder Counselors
+21-1012.00,"Educational, Guidance, School, and Vocational Counselors",21-1012.00,"Educational, Guidance, and Career Counselors and Advisors"
+21-1013.00,Marriage and Family Therapists,21-1013.00,Marriage and Family Therapists
+21-1014.00,Mental Health Counselors,21-1014.00,Mental Health Counselors
+21-1015.00,Rehabilitation Counselors,21-1015.00,Rehabilitation Counselors
+21-1019.00,"Counselors, All Other",21-1019.00,"Counselors, All Other"
+21-1021.00,"Child, Family, and School Social Workers",21-1021.00,"Child, Family, and School Social Workers"
+21-1022.00,Healthcare Social Workers,21-1022.00,Healthcare Social Workers
+21-1023.00,Mental Health and Substance Abuse Social Workers,21-1023.00,Mental Health and Substance Abuse Social Workers
+21-1029.00,"Social Workers, All Other",21-1029.00,"Social Workers, All Other"
+21-1091.00,Health Educators,21-1091.00,Health Education Specialists
+21-1092.00,Probation Officers and Correctional Treatment Specialists,21-1092.00,Probation Officers and Correctional Treatment Specialists
+21-1093.00,Social and Human Service Assistants,21-1093.00,Social and Human Service Assistants
+21-1094.00,Community Health Workers,21-1094.00,Community Health Workers
+21-1099.00,"Community and Social Service Specialists, All Other",21-1099.00,"Community and Social Service Specialists, All Other"
+21-2011.00,Clergy,21-2011.00,Clergy
+21-2021.00,"Directors, Religious Activities and Education",21-2021.00,"Directors, Religious Activities and Education"
+21-2099.00,"Religious Workers, All Other",21-2099.00,"Religious Workers, All Other"
+23-1011.00,Lawyers,23-1011.00,Lawyers
+23-1012.00,Judicial Law Clerks,23-1012.00,Judicial Law Clerks
+23-1021.00,"Administrative Law Judges, Adjudicators, and Hearing Officers",23-1021.00,"Administrative Law Judges, Adjudicators, and Hearing Officers"
+23-1022.00,"Arbitrators, Mediators, and Conciliators",23-1022.00,"Arbitrators, Mediators, and Conciliators"
+23-1023.00,"Judges, Magistrate Judges, and Magistrates",23-1023.00,"Judges, Magistrate Judges, and Magistrates"
+23-2011.00,Paralegals and Legal Assistants,23-2011.00,Paralegals and Legal Assistants
+23-2091.00,Court Reporters,27-3092.00,Court Reporters and Simultaneous Captioners
+23-2093.00,"Title Examiners, Abstractors, and Searchers",23-2093.00,"Title Examiners, Abstractors, and Searchers"
+23-2099.00,"Legal Support Workers, All Other",23-2099.00,"Legal Support Workers, All Other"
+25-1011.00,"Business Teachers, Postsecondary",25-1011.00,"Business Teachers, Postsecondary"
+25-1021.00,"Computer Science Teachers, Postsecondary",25-1021.00,"Computer Science Teachers, Postsecondary"
+25-1022.00,"Mathematical Science Teachers, Postsecondary",25-1022.00,"Mathematical Science Teachers, Postsecondary"
+25-1031.00,"Architecture Teachers, Postsecondary",25-1031.00,"Architecture Teachers, Postsecondary"
+25-1032.00,"Engineering Teachers, Postsecondary",25-1032.00,"Engineering Teachers, Postsecondary"
+25-1041.00,"Agricultural Sciences Teachers, Postsecondary",25-1041.00,"Agricultural Sciences Teachers, Postsecondary"
+25-1042.00,"Biological Science Teachers, Postsecondary",25-1042.00,"Biological Science Teachers, Postsecondary"
+25-1043.00,"Forestry and Conservation Science Teachers, Postsecondary",25-1043.00,"Forestry and Conservation Science Teachers, Postsecondary"
+25-1051.00,"Atmospheric, Earth, Marine, and Space Sciences Teachers, Postsecondary",25-1051.00,"Atmospheric, Earth, Marine, and Space Sciences Teachers, Postsecondary"
+25-1052.00,"Chemistry Teachers, Postsecondary",25-1052.00,"Chemistry Teachers, Postsecondary"
+25-1053.00,"Environmental Science Teachers, Postsecondary",25-1053.00,"Environmental Science Teachers, Postsecondary"
+25-1054.00,"Physics Teachers, Postsecondary",25-1054.00,"Physics Teachers, Postsecondary"
+25-1061.00,"Anthropology and Archeology Teachers, Postsecondary",25-1061.00,"Anthropology and Archeology Teachers, Postsecondary"
+25-1062.00,"Area, Ethnic, and Cultural Studies Teachers, Postsecondary",25-1062.00,"Area, Ethnic, and Cultural Studies Teachers, Postsecondary"
+25-1063.00,"Economics Teachers, Postsecondary",25-1063.00,"Economics Teachers, Postsecondary"
+25-1064.00,"Geography Teachers, Postsecondary",25-1064.00,"Geography Teachers, Postsecondary"
+25-1065.00,"Political Science Teachers, Postsecondary",25-1065.00,"Political Science Teachers, Postsecondary"
+25-1066.00,"Psychology Teachers, Postsecondary",25-1066.00,"Psychology Teachers, Postsecondary"
+25-1067.00,"Sociology Teachers, Postsecondary",25-1067.00,"Sociology Teachers, Postsecondary"
+25-1069.00,"Social Sciences Teachers, Postsecondary, All Other",25-1069.00,"Social Sciences Teachers, Postsecondary, All Other"
+25-1071.00,"Health Specialties Teachers, Postsecondary",25-1071.00,"Health Specialties Teachers, Postsecondary"
+25-1072.00,"Nursing Instructors and Teachers, Postsecondary",25-1072.00,"Nursing Instructors and Teachers, Postsecondary"
+25-1081.00,"Education Teachers, Postsecondary",25-1081.00,"Education Teachers, Postsecondary"
+25-1082.00,"Library Science Teachers, Postsecondary",25-1082.00,"Library Science Teachers, Postsecondary"
+25-1111.00,"Criminal Justice and Law Enforcement Teachers, Postsecondary",25-1111.00,"Criminal Justice and Law Enforcement Teachers, Postsecondary"
+25-1112.00,"Law Teachers, Postsecondary",25-1112.00,"Law Teachers, Postsecondary"
+25-1113.00,"Social Work Teachers, Postsecondary",25-1113.00,"Social Work Teachers, Postsecondary"
+25-1121.00,"Art, Drama, and Music Teachers, Postsecondary",25-1121.00,"Art, Drama, and Music Teachers, Postsecondary"
+25-1122.00,"Communications Teachers, Postsecondary",25-1122.00,"Communications Teachers, Postsecondary"
+25-1123.00,"English Language and Literature Teachers, Postsecondary",25-1123.00,"English Language and Literature Teachers, Postsecondary"
+25-1124.00,"Foreign Language and Literature Teachers, Postsecondary",25-1124.00,"Foreign Language and Literature Teachers, Postsecondary"
+25-1125.00,"History Teachers, Postsecondary",25-1125.00,"History Teachers, Postsecondary"
+25-1126.00,"Philosophy and Religion Teachers, Postsecondary",25-1126.00,"Philosophy and Religion Teachers, Postsecondary"
+25-1191.00,Graduate Teaching Assistants,25-9044.00,"Teaching Assistants, Postsecondary"
+25-1192.00,"Home Economics Teachers, Postsecondary",25-1192.00,"Family and Consumer Sciences Teachers, Postsecondary"
+25-1193.00,"Recreation and Fitness Studies Teachers, Postsecondary",25-1193.00,"Recreation and Fitness Studies Teachers, Postsecondary"
+25-1194.00,"Vocational Education Teachers, Postsecondary",25-1194.00,"Career/Technical Education Teachers, Postsecondary"
+25-1199.00,"Postsecondary Teachers, All Other",25-1199.00,"Postsecondary Teachers, All Other"
+25-2011.00,"Preschool Teachers, Except Special Education",25-2011.00,"Preschool Teachers, Except Special Education"
+25-2012.00,"Kindergarten Teachers, Except Special Education",25-2012.00,"Kindergarten Teachers, Except Special Education"
+25-2021.00,"Elementary School Teachers, Except Special Education",25-2021.00,"Elementary School Teachers, Except Special Education"
+25-2022.00,"Middle School Teachers, Except Special and Career/Technical Education",25-2022.00,"Middle School Teachers, Except Special and Career/Technical Education"
+25-2023.00,"Career/Technical Education Teachers, Middle School",25-2023.00,"Career/Technical Education Teachers, Middle School"
+25-2031.00,"Secondary School Teachers, Except Special and Career/Technical Education",25-2031.00,"Secondary School Teachers, Except Special and Career/Technical Education"
+25-2032.00,"Career/Technical Education Teachers, Secondary School",25-2032.00,"Career/Technical Education Teachers, Secondary School"
+25-2051.00,"Special Education Teachers, Preschool",25-2051.00,"Special Education Teachers, Preschool"
+25-2052.00,"Special Education Teachers, Kindergarten and Elementary School",25-2055.00,"Special Education Teachers, Kindergarten"
+25-2052.00,"Special Education Teachers, Kindergarten and Elementary School",25-2056.00,"Special Education Teachers, Elementary School"
+25-2053.00,"Special Education Teachers, Middle School",25-2057.00,"Special Education Teachers, Middle School"
+25-2054.00,"Special Education Teachers, Secondary School",25-2058.00,"Special Education Teachers, Secondary School"
+25-2059.00,"Special Education Teachers, All Other",25-2059.00,"Special Education Teachers, All Other"
+25-2059.01,Adapted Physical Education Specialists,25-2059.01,Adapted Physical Education Specialists
+25-3011.00,Adult Basic and Secondary Education and Literacy Teachers and Instructors,25-3011.00,"Adult Basic Education, Adult Secondary Education, and English as a Second Language Instructors"
+25-3021.00,Self-Enrichment Education Teachers,25-3021.00,Self-Enrichment Teachers
+25-3099.00,"Teachers and Instructors, All Other",25-3031.00,"Substitute Teachers, Short-Term"
+25-3099.00,"Teachers and Instructors, All Other",25-3099.00,"Teachers and Instructors, All Other"
+25-3099.02,Tutors,25-3041.00,Tutors
+25-4011.00,Archivists,25-4011.00,Archivists
+25-4012.00,Curators,25-4012.00,Curators
+25-4013.00,Museum Technicians and Conservators,25-4013.00,Museum Technicians and Conservators
+25-4021.00,Librarians,25-4022.00,Librarians and Media Collections Specialists
+25-4031.00,Library Technicians,25-4031.00,Library Technicians
+25-9011.00,Audio-Visual and Multimedia Collections Specialists,25-4022.00,Librarians and Media Collections Specialists
+25-9021.00,Farm and Home Management Advisors,25-9021.00,Farm and Home Management Educators
+25-9031.00,Instructional Coordinators,25-9031.00,Instructional Coordinators
+25-9031.01,Instructional Designers and Technologists,25-9031.00,Instructional Coordinators
+25-9041.00,Teacher Assistants,25-9042.00,"Teaching Assistants, Preschool, Elementary, Middle, and Secondary School, Except Special Education"
+25-9041.00,Teacher Assistants,25-9043.00,"Teaching Assistants, Special Education"
+25-9041.00,Teacher Assistants,25-9049.00,"Teaching Assistants, All Other"
+25-9099.00,"Education, Training, and Library Workers, All Other",25-9099.00,"Educational Instruction and Library Workers, All Other"
+27-1011.00,Art Directors,27-1011.00,Art Directors
+27-1012.00,Craft Artists,27-1012.00,Craft Artists
+27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators",27-1013.00,"Fine Artists, Including Painters, Sculptors, and Illustrators"
+27-1014.00,Multimedia Artists and Animators,27-1014.00,Special Effects Artists and Animators
+27-1019.00,"Artists and Related Workers, All Other",27-1019.00,"Artists and Related Workers, All Other"
+27-1021.00,Commercial and Industrial Designers,27-1021.00,Commercial and Industrial Designers
+27-1022.00,Fashion Designers,27-1022.00,Fashion Designers
+27-1023.00,Floral Designers,27-1023.00,Floral Designers
+27-1024.00,Graphic Designers,27-1024.00,Graphic Designers
+27-1025.00,Interior Designers,27-1025.00,Interior Designers
+27-1026.00,Merchandise Displayers and Window Trimmers,27-1026.00,Merchandise Displayers and Window Trimmers
+27-1027.00,Set and Exhibit Designers,27-1027.00,Set and Exhibit Designers
+27-1029.00,"Designers, All Other",27-1029.00,"Designers, All Other"
+27-2011.00,Actors,27-2011.00,Actors
+27-2012.00,Producers and Directors,27-2012.00,Producers and Directors
+27-2012.01,Producers,27-2012.00,Producers and Directors
+27-2012.02,"Directors- Stage, Motion Pictures, Television, and Radio",27-2012.00,Producers and Directors
+27-2012.03,Program Directors,27-2012.03,Media Programming Directors
+27-2012.04,Talent Directors,27-2012.04,Talent Directors
+27-2012.05,Technical Directors/Managers,27-2012.05,Media Technical Directors/Managers
+27-2021.00,Athletes and Sports Competitors,27-2021.00,Athletes and Sports Competitors
+27-2022.00,Coaches and Scouts,27-2022.00,Coaches and Scouts
+27-2023.00,"Umpires, Referees, and Other Sports Officials",27-2023.00,"Umpires, Referees, and Other Sports Officials"
+27-2031.00,Dancers,27-2031.00,Dancers
+27-2032.00,Choreographers,27-2032.00,Choreographers
+27-2041.00,Music Directors and Composers,27-2041.00,Music Directors and Composers
+27-2041.01,Music Directors,27-2041.00,Music Directors and Composers
+27-2041.04,Music Composers and Arrangers,27-2041.00,Music Directors and Composers
+27-2042.00,Musicians and Singers,27-2042.00,Musicians and Singers
+27-2042.01,Singers,27-2042.00,Musicians and Singers
+27-2042.02,"Musicians, Instrumental",27-2042.00,Musicians and Singers
+27-2099.00,"Entertainers and Performers, Sports and Related Workers, All Other",27-2091.00,"Disc Jockeys, Except Radio"
+27-2099.00,"Entertainers and Performers, Sports and Related Workers, All Other",27-2099.00,"Entertainers and Performers, Sports and Related Workers, All Other"
+27-3011.00,Radio and Television Announcers,27-3011.00,Broadcast Announcers and Radio Disc Jockeys
+27-3012.00,Public Address System and Other Announcers,27-3099.00,"Media and Communication Workers, All Other"
+27-3021.00,Broadcast News Analysts,27-3023.00,"News Analysts, Reporters, and Journalists"
+27-3022.00,Reporters and Correspondents,27-3023.00,"News Analysts, Reporters, and Journalists"
+27-3031.00,Public Relations Specialists,27-3031.00,Public Relations Specialists
+27-3041.00,Editors,27-3041.00,Editors
+27-3042.00,Technical Writers,27-3042.00,Technical Writers
+27-3043.00,Writers and Authors,27-3043.00,Writers and Authors
+27-3043.04,Copy Writers,27-3043.00,Writers and Authors
+27-3043.05,"Poets, Lyricists and Creative Writers",27-3043.05,"Poets, Lyricists and Creative Writers"
+27-3091.00,Interpreters and Translators,27-3091.00,Interpreters and Translators
+27-3099.00,"Media and Communication Workers, All Other",27-3099.00,"Media and Communication Workers, All Other"
+27-4011.00,Audio and Video Equipment Technicians,27-4011.00,Audio and Video Technicians
+27-4012.00,Broadcast Technicians,27-4012.00,Broadcast Technicians
+27-4013.00,Radio Operators,43-2099.00,"Communications Equipment Operators, All Other"
+27-4014.00,Sound Engineering Technicians,27-4014.00,Sound Engineering Technicians
+27-4021.00,Photographers,27-4021.00,Photographers
+27-4031.00,"Camera Operators, Television, Video, and Motion Picture",27-4031.00,"Camera Operators, Television, Video, and Film"
+27-4032.00,Film and Video Editors,27-4032.00,Film and Video Editors
+27-4099.00,"Media and Communication Equipment Workers, All Other",27-4015.00,Lighting Technicians
+27-4099.00,"Media and Communication Equipment Workers, All Other",27-4099.00,"Media and Communication Equipment Workers, All Other"
+29-1011.00,Chiropractors,29-1011.00,Chiropractors
+29-1021.00,"Dentists, General",29-1021.00,"Dentists, General"
+29-1022.00,Oral and Maxillofacial Surgeons,29-1022.00,Oral and Maxillofacial Surgeons
+29-1023.00,Orthodontists,29-1023.00,Orthodontists
+29-1024.00,Prosthodontists,29-1024.00,Prosthodontists
+29-1029.00,"Dentists, All Other Specialists",29-1029.00,"Dentists, All Other Specialists"
+29-1031.00,Dietitians and Nutritionists,29-1031.00,Dietitians and Nutritionists
+29-1041.00,Optometrists,29-1041.00,Optometrists
+29-1051.00,Pharmacists,29-1051.00,Pharmacists
+29-1061.00,Anesthesiologists,29-1211.00,Anesthesiologists
+29-1062.00,Family and General Practitioners,29-1215.00,Family Medicine Physicians
+29-1063.00,"Internists, General",29-1216.00,General Internal Medicine Physicians
+29-1064.00,Obstetricians and Gynecologists,29-1218.00,Obstetricians and Gynecologists
+29-1065.00,"Pediatricians, General",29-1221.00,"Pediatricians, General"
+29-1066.00,Psychiatrists,29-1223.00,Psychiatrists
+29-1067.00,Surgeons,29-1242.00,"Orthopedic Surgeons, Except Pediatric"
+29-1067.00,Surgeons,29-1243.00,Pediatric Surgeons
+29-1067.00,Surgeons,29-1249.00,"Surgeons, All Other"
+29-1069.00,"Physicians and Surgeons, All Other",29-1212.00,Cardiologists
+29-1069.00,"Physicians and Surgeons, All Other",29-1214.00,Emergency Medicine Physicians
+29-1069.00,"Physicians and Surgeons, All Other",29-1229.00,"Physicians, All Other"
+29-1069.01,Allergists and Immunologists,29-1229.01,Allergists and Immunologists
+29-1069.02,Dermatologists,29-1213.00,Dermatologists
+29-1069.03,Hospitalists,29-1229.02,Hospitalists
+29-1069.04,Neurologists,29-1217.00,Neurologists
+29-1069.05,Nuclear Medicine Physicians,29-1224.00,Radiologists
+29-1069.06,Ophthalmologists,29-1241.00,"Ophthalmologists, Except Pediatric"
+29-1069.07,Pathologists,29-1222.00,"Physicians, Pathologists"
+29-1069.08,Physical Medicine and Rehabilitation Physicians,29-1229.04,Physical Medicine and Rehabilitation Physicians
+29-1069.09,Preventive Medicine Physicians,29-1229.05,Preventive Medicine Physicians
+29-1069.10,Radiologists,29-1224.00,Radiologists
+29-1069.11,Sports Medicine Physicians,29-1229.06,Sports Medicine Physicians
+29-1069.12,Urologists,29-1229.03,Urologists
+29-1071.00,Physician Assistants,29-1071.00,Physician Assistants
+29-1071.01,Anesthesiologist Assistants,29-1071.01,Anesthesiologist Assistants
+29-1081.00,Podiatrists,29-1081.00,Podiatrists
+29-1122.00,Occupational Therapists,29-1122.00,Occupational Therapists
+29-1122.01,"Low Vision Therapists, Orientation and Mobility Specialists, and Vision Rehabilitation Therapists",29-1122.01,"Low Vision Therapists, Orientation and Mobility Specialists, and Vision Rehabilitation Therapists"
+29-1123.00,Physical Therapists,29-1123.00,Physical Therapists
+29-1124.00,Radiation Therapists,29-1124.00,Radiation Therapists
+29-1125.00,Recreational Therapists,29-1125.00,Recreational Therapists
+29-1125.01,Art Therapists,29-1129.01,Art Therapists
+29-1125.02,Music Therapists,29-1129.02,Music Therapists
+29-1126.00,Respiratory Therapists,29-1126.00,Respiratory Therapists
+29-1127.00,Speech-Language Pathologists,29-1127.00,Speech-Language Pathologists
+29-1128.00,Exercise Physiologists,29-1128.00,Exercise Physiologists
+29-1129.00,"Therapists, All Other",29-1129.00,"Therapists, All Other"
+29-1131.00,Veterinarians,29-1131.00,Veterinarians
+29-1141.00,Registered Nurses,29-1141.00,Registered Nurses
+29-1141.01,Acute Care Nurses,29-1141.01,Acute Care Nurses
+29-1141.02,Advanced Practice Psychiatric Nurses,29-1141.02,Advanced Practice Psychiatric Nurses
+29-1141.03,Critical Care Nurses,29-1141.03,Critical Care Nurses
+29-1141.04,Clinical Nurse Specialists,29-1141.04,Clinical Nurse Specialists
+29-1151.00,Nurse Anesthetists,29-1151.00,Nurse Anesthetists
+29-1161.00,Nurse Midwives,29-1161.00,Nurse Midwives
+29-1171.00,Nurse Practitioners,29-1171.00,Nurse Practitioners
+29-1181.00,Audiologists,29-1181.00,Audiologists
+29-1199.00,"Health Diagnosing and Treating Practitioners, All Other",29-1299.00,"Healthcare Diagnosing or Treating Practitioners, All Other"
+29-1199.01,Acupuncturists,29-1291.00,Acupuncturists
+29-1199.04,Naturopathic Physicians,29-1299.01,Naturopathic Physicians
+29-1199.05,Orthoptists,29-1299.02,Orthoptists
+29-2011.00,Medical and Clinical Laboratory Technologists,29-2011.00,Medical and Clinical Laboratory Technologists
+29-2011.01,Cytogenetic Technologists,29-2011.01,Cytogenetic Technologists
+29-2011.02,Cytotechnologists,29-2011.02,Cytotechnologists
+29-2011.03,Histotechnologists and Histologic Technicians,29-2011.04,Histotechnologists
+29-2011.03,Histotechnologists and Histologic Technicians,29-2012.01,Histology Technicians
+29-2012.00,Medical and Clinical Laboratory Technicians,29-2012.00,Medical and Clinical Laboratory Technicians
+29-2021.00,Dental Hygienists,29-1292.00,Dental Hygienists
+29-2031.00,Cardiovascular Technologists and Technicians,29-2031.00,Cardiovascular Technologists and Technicians
+29-2032.00,Diagnostic Medical Sonographers,29-2032.00,Diagnostic Medical Sonographers
+29-2033.00,Nuclear Medicine Technologists,29-2033.00,Nuclear Medicine Technologists
+29-2034.00,Radiologic Technologists,29-2034.00,Radiologic Technologists and Technicians
+29-2035.00,Magnetic Resonance Imaging Technologists,29-2035.00,Magnetic Resonance Imaging Technologists
+29-2041.00,Emergency Medical Technicians and Paramedics,29-2042.00,Emergency Medical Technicians
+29-2041.00,Emergency Medical Technicians and Paramedics,29-2043.00,Paramedics
+29-2051.00,Dietetic Technicians,29-2051.00,Dietetic Technicians
+29-2052.00,Pharmacy Technicians,29-2052.00,Pharmacy Technicians
+29-2053.00,Psychiatric Technicians,29-2053.00,Psychiatric Technicians
+29-2054.00,Respiratory Therapy Technicians,29-2099.00,"Health Technologists and Technicians, All Other"
+29-2055.00,Surgical Technologists,29-2055.00,Surgical Technologists
+29-2056.00,Veterinary Technologists and Technicians,29-2056.00,Veterinary Technologists and Technicians
+29-2057.00,Ophthalmic Medical Technicians,29-2057.00,Ophthalmic Medical Technicians
+29-2061.00,Licensed Practical and Licensed Vocational Nurses,29-2061.00,Licensed Practical and Licensed Vocational Nurses
+29-2071.00,Medical Records and Health Information Technicians,29-2072.00,Medical Records Specialists
+29-2071.00,Medical Records and Health Information Technicians,29-9021.00,Health Information Technologists and Medical Registrars
+29-2081.00,"Opticians, Dispensing",29-2081.00,"Opticians, Dispensing"
+29-2091.00,Orthotists and Prosthetists,29-2091.00,Orthotists and Prosthetists
+29-2092.00,Hearing Aid Specialists,29-2092.00,Hearing Aid Specialists
+29-2099.00,"Health Technologists and Technicians, All Other",29-2036.00,Medical Dosimetrists
+29-2099.00,"Health Technologists and Technicians, All Other",29-2099.00,"Health Technologists and Technicians, All Other"
+29-2099.01,Neurodiagnostic Technologists,29-2099.01,Neurodiagnostic Technologists
+29-2099.05,Ophthalmic Medical Technologists,29-2099.05,Ophthalmic Medical Technologists
+29-2099.06,Radiologic Technicians,29-2034.00,Radiologic Technologists and Technicians
+29-2099.07,Surgical Assistants,29-9093.00,Surgical Assistants
+29-9011.00,Occupational Health and Safety Specialists,19-5011.00,Occupational Health and Safety Specialists
+29-9012.00,Occupational Health and Safety Technicians,19-5012.00,Occupational Health and Safety Technicians
+29-9091.00,Athletic Trainers,29-9091.00,Athletic Trainers
+29-9092.00,Genetic Counselors,29-9092.00,Genetic Counselors
+29-9099.00,"Healthcare Practitioners and Technical Workers, All Other",29-9021.00,Health Information Technologists and Medical Registrars
+29-9099.00,"Healthcare Practitioners and Technical Workers, All Other",29-9093.00,Surgical Assistants
+29-9099.00,"Healthcare Practitioners and Technical Workers, All Other",29-9099.00,"Healthcare Practitioners and Technical Workers, All Other"
+29-9099.01,Midwives,29-9099.01,Midwives
+31-1011.00,Home Health Aides,31-1121.00,Home Health Aides
+31-1013.00,Psychiatric Aides,31-1133.00,Psychiatric Aides
+31-1014.00,Nursing Assistants,31-1131.00,Nursing Assistants
+31-1015.00,Orderlies,31-1132.00,Orderlies
+31-2011.00,Occupational Therapy Assistants,31-2011.00,Occupational Therapy Assistants
+31-2012.00,Occupational Therapy Aides,31-2012.00,Occupational Therapy Aides
+31-2021.00,Physical Therapist Assistants,31-2021.00,Physical Therapist Assistants
+31-2022.00,Physical Therapist Aides,31-2022.00,Physical Therapist Aides
+31-9011.00,Massage Therapists,31-9011.00,Massage Therapists
+31-9091.00,Dental Assistants,31-9091.00,Dental Assistants
+31-9092.00,Medical Assistants,31-9092.00,Medical Assistants
+31-9093.00,Medical Equipment Preparers,31-9093.00,Medical Equipment Preparers
+31-9094.00,Medical Transcriptionists,31-9094.00,Medical Transcriptionists
+31-9095.00,Pharmacy Aides,31-9095.00,Pharmacy Aides
+31-9096.00,Veterinary Assistants and Laboratory Animal Caretakers,31-9096.00,Veterinary Assistants and Laboratory Animal Caretakers
+31-9097.00,Phlebotomists,31-9097.00,Phlebotomists
+31-9099.00,"Healthcare Support Workers, All Other",31-9099.00,"Healthcare Support Workers, All Other"
+31-9099.01,Speech-Language Pathology Assistants,31-9099.01,Speech-Language Pathology Assistants
+31-9099.02,Endoscopy Technicians,31-9099.02,Endoscopy Technicians
+33-1011.00,First-Line Supervisors of Correctional Officers,33-1011.00,First-Line Supervisors of Correctional Officers
+33-1012.00,First-Line Supervisors of Police and Detectives,33-1012.00,First-Line Supervisors of Police and Detectives
+33-1021.00,First-Line Supervisors of Fire Fighting and Prevention Workers,33-1021.00,First-Line Supervisors of Firefighting and Prevention Workers
+33-1021.01,Municipal Fire Fighting and Prevention Supervisors,33-1021.00,First-Line Supervisors of Firefighting and Prevention Workers
+33-1021.02,Forest Fire Fighting and Prevention Supervisors,33-1021.00,First-Line Supervisors of Firefighting and Prevention Workers
+33-1099.00,"First-Line Supervisors of Protective Service Workers, All Other",33-1091.00,First-Line Supervisors of Security Workers
+33-1099.00,"First-Line Supervisors of Protective Service Workers, All Other",33-1099.00,"First-Line Supervisors of Protective Service Workers, All Other"
+33-2011.00,Firefighters,33-2011.00,Firefighters
+33-2011.01,Municipal Firefighters,33-2011.00,Firefighters
+33-2011.02,Forest Firefighters,33-2011.00,Firefighters
+33-2021.00,Fire Inspectors and Investigators,33-2021.00,Fire Inspectors and Investigators
+33-2021.01,Fire Inspectors,33-2021.00,Fire Inspectors and Investigators
+33-2021.02,Fire Investigators,33-2021.00,Fire Inspectors and Investigators
+33-2022.00,Forest Fire Inspectors and Prevention Specialists,33-2022.00,Forest Fire Inspectors and Prevention Specialists
+33-3011.00,Bailiffs,33-3011.00,Bailiffs
+33-3012.00,Correctional Officers and Jailers,33-3012.00,Correctional Officers and Jailers
+33-3021.00,Detectives and Criminal Investigators,33-3021.00,Detectives and Criminal Investigators
+33-3021.01,Police Detectives,33-3021.00,Detectives and Criminal Investigators
+33-3021.02,Police Identification and Records Officers,33-3021.02,Police Identification and Records Officers
+33-3021.03,Criminal Investigators and Special Agents,33-3021.00,Detectives and Criminal Investigators
+33-3021.05,Immigration and Customs Inspectors,33-3051.04,Customs and Border Protection Officers
+33-3021.06,Intelligence Analysts,33-3021.06,Intelligence Analysts
+33-3031.00,Fish and Game Wardens,33-3031.00,Fish and Game Wardens
+33-3041.00,Parking Enforcement Workers,33-3041.00,Parking Enforcement Workers
+33-3051.00,Police and Sheriff's Patrol Officers,33-3051.00,Police and Sheriff's Patrol Officers
+33-3051.01,Police Patrol Officers,33-3051.00,Police and Sheriff's Patrol Officers
+33-3051.03,Sheriffs and Deputy Sheriffs,33-3051.00,Police and Sheriff's Patrol Officers
+33-3052.00,Transit and Railroad Police,33-3052.00,Transit and Railroad Police
+33-9011.00,Animal Control Workers,33-9011.00,Animal Control Workers
+33-9021.00,Private Detectives and Investigators,33-9021.00,Private Detectives and Investigators
+33-9031.00,Gaming Surveillance Officers and Gaming Investigators,33-9031.00,Gambling Surveillance Officers and Gambling Investigators
+33-9032.00,Security Guards,33-9032.00,Security Guards
+33-9091.00,Crossing Guards,33-9091.00,Crossing Guards and Flaggers
+33-9092.00,"Lifeguards, Ski Patrol, and Other Recreational Protective Service Workers",33-9092.00,"Lifeguards, Ski Patrol, and Other Recreational Protective Service Workers"
+33-9093.00,Transportation Security Screeners,33-9093.00,Transportation Security Screeners
+33-9099.00,"Protective Service Workers, All Other",33-9094.00,School Bus Monitors
+33-9099.00,"Protective Service Workers, All Other",33-9099.00,"Protective Service Workers, All Other"
+33-9099.02,Retail Loss Prevention Specialists,33-9099.02,Retail Loss Prevention Specialists
+35-1011.00,Chefs and Head Cooks,35-1011.00,Chefs and Head Cooks
+35-1012.00,First-Line Supervisors of Food Preparation and Serving Workers,35-1012.00,First-Line Supervisors of Food Preparation and Serving Workers
+35-2011.00,"Cooks, Fast Food",35-2011.00,"Cooks, Fast Food"
+35-2012.00,"Cooks, Institution and Cafeteria",35-2012.00,"Cooks, Institution and Cafeteria"
+35-2013.00,"Cooks, Private Household",35-2013.00,"Cooks, Private Household"
+35-2014.00,"Cooks, Restaurant",35-2014.00,"Cooks, Restaurant"
+35-2015.00,"Cooks, Short Order",35-2015.00,"Cooks, Short Order"
+35-2019.00,"Cooks, All Other",35-2019.00,"Cooks, All Other"
+35-2021.00,Food Preparation Workers,35-2021.00,Food Preparation Workers
+35-3011.00,Bartenders,35-3011.00,Bartenders
+35-3021.00,"Combined Food Preparation and Serving Workers, Including Fast Food",35-3023.00,Fast Food and Counter Workers
+35-3022.00,"Counter Attendants, Cafeteria, Food Concession, and Coffee Shop",35-3023.00,Fast Food and Counter Workers
+35-3022.01,Baristas,35-3023.01,Baristas
+35-3031.00,Waiters and Waitresses,35-3031.00,Waiters and Waitresses
+35-3041.00,"Food Servers, Nonrestaurant",35-3041.00,"Food Servers, Nonrestaurant"
+35-9011.00,Dining Room and Cafeteria Attendants and Bartender Helpers,35-9011.00,Dining Room and Cafeteria Attendants and Bartender Helpers
+35-9021.00,Dishwashers,35-9021.00,Dishwashers
+35-9031.00,"Hosts and Hostesses, Restaurant, Lounge, and Coffee Shop",35-9031.00,"Hosts and Hostesses, Restaurant, Lounge, and Coffee Shop"
+35-9099.00,"Food Preparation and Serving Related Workers, All Other",35-9099.00,"Food Preparation and Serving Related Workers, All Other"
+37-1011.00,First-Line Supervisors of Housekeeping and Janitorial Workers,37-1011.00,First-Line Supervisors of Housekeeping and Janitorial Workers
+37-1012.00,"First-Line Supervisors of Landscaping, Lawn Service, and Groundskeeping Workers",37-1012.00,"First-Line Supervisors of Landscaping, Lawn Service, and Groundskeeping Workers"
+37-2011.00,"Janitors and Cleaners, Except Maids and Housekeeping Cleaners",37-2011.00,"Janitors and Cleaners, Except Maids and Housekeeping Cleaners"
+37-2012.00,Maids and Housekeeping Cleaners,37-2012.00,Maids and Housekeeping Cleaners
+37-2019.00,"Building Cleaning Workers, All Other",37-2019.00,"Building Cleaning Workers, All Other"
+37-2021.00,Pest Control Workers,37-2021.00,Pest Control Workers
+37-3011.00,Landscaping and Groundskeeping Workers,37-3011.00,Landscaping and Groundskeeping Workers
+37-3012.00,"Pesticide Handlers, Sprayers, and Applicators, Vegetation",37-3012.00,"Pesticide Handlers, Sprayers, and Applicators, Vegetation"
+37-3013.00,Tree Trimmers and Pruners,37-3013.00,Tree Trimmers and Pruners
+37-3019.00,"Grounds Maintenance Workers, All Other",37-3019.00,"Grounds Maintenance Workers, All Other"
+39-1011.00,Gaming Supervisors,39-1013.00,First-Line Supervisors of Gambling Services Workers
+39-1012.00,Slot Supervisors,39-1013.00,First-Line Supervisors of Gambling Services Workers
+39-1021.00,First-Line Supervisors of Personal Service Workers,39-1014.00,"First-Line Supervisors of Entertainment and Recreation Workers, Except Gambling Services"
+39-1021.00,First-Line Supervisors of Personal Service Workers,39-1022.00,First-Line Supervisors of Personal Service Workers
+39-1021.00,First-Line Supervisors of Personal Service Workers,53-1044.00,First-Line Supervisors of Passenger Attendants
+39-1021.01,Spa Managers,11-9179.02,Spa Managers
+39-2011.00,Animal Trainers,39-2011.00,Animal Trainers
+39-2021.00,Nonfarm Animal Caretakers,39-2021.00,Animal Caretakers
+39-3011.00,Gaming Dealers,39-3011.00,Gambling Dealers
+39-3012.00,Gaming and Sports Book Writers and Runners,39-3012.00,Gambling and Sports Book Writers and Runners
+39-3019.00,"Gaming Service Workers, All Other",39-3019.00,"Gambling Service Workers, All Other"
+39-3021.00,Motion Picture Projectionists,39-3021.00,Motion Picture Projectionists
+39-3031.00,"Ushers, Lobby Attendants, and Ticket Takers",39-3031.00,"Ushers, Lobby Attendants, and Ticket Takers"
+39-3091.00,Amusement and Recreation Attendants,39-3091.00,Amusement and Recreation Attendants
+39-3092.00,Costume Attendants,39-3092.00,Costume Attendants
+39-3093.00,"Locker Room, Coatroom, and Dressing Room Attendants",39-3093.00,"Locker Room, Coatroom, and Dressing Room Attendants"
+39-3099.00,"Entertainment Attendants and Related Workers, All Other",39-3099.00,"Entertainment Attendants and Related Workers, All Other"
+39-4011.00,Embalmers,39-4011.00,Embalmers
+39-4021.00,Funeral Attendants,39-4021.00,Funeral Attendants
+39-4031.00,"Morticians, Undertakers, and Funeral Directors",39-4031.00,"Morticians, Undertakers, and Funeral Arrangers"
+39-5011.00,Barbers,39-5011.00,Barbers
+39-5012.00,"Hairdressers, Hairstylists, and Cosmetologists",39-5012.00,"Hairdressers, Hairstylists, and Cosmetologists"
+39-5091.00,"Makeup Artists, Theatrical and Performance",39-5091.00,"Makeup Artists, Theatrical and Performance"
+39-5092.00,Manicurists and Pedicurists,39-5092.00,Manicurists and Pedicurists
+39-5093.00,Shampooers,39-5093.00,Shampooers
+39-5094.00,Skincare Specialists,39-5094.00,Skincare Specialists
+39-6011.00,Baggage Porters and Bellhops,39-6011.00,Baggage Porters and Bellhops
+39-6012.00,Concierges,39-6012.00,Concierges
+39-7011.00,Tour Guides and Escorts,39-7011.00,Tour Guides and Escorts
+39-7012.00,Travel Guides,39-7012.00,Travel Guides
+39-9011.00,Childcare Workers,39-9011.00,Childcare Workers
+39-9011.01,Nannies,39-9011.01,Nannies
+39-9021.00,Personal Care Aides,31-1122.00,Personal Care Aides
+39-9031.00,Fitness Trainers and Aerobics Instructors,39-9031.00,Exercise Trainers and Group Fitness Instructors
+39-9032.00,Recreation Workers,39-9032.00,Recreation Workers
+39-9041.00,Residential Advisors,39-9041.00,Residential Advisors
+39-9099.00,"Personal Care and Service Workers, All Other",39-4012.00,Crematory Operators
+39-9099.00,"Personal Care and Service Workers, All Other",39-9099.00,"Personal Care and Service Workers, All Other"
+41-1011.00,First-Line Supervisors of Retail Sales Workers,41-1011.00,First-Line Supervisors of Retail Sales Workers
+41-1012.00,First-Line Supervisors of Non-Retail Sales Workers,41-1012.00,First-Line Supervisors of Non-Retail Sales Workers
+41-2011.00,Cashiers,41-2011.00,Cashiers
+41-2012.00,Gaming Change Persons and Booth Cashiers,41-2012.00,Gambling Change Persons and Booth Cashiers
+41-2021.00,Counter and Rental Clerks,41-2021.00,Counter and Rental Clerks
+41-2022.00,Parts Salespersons,41-2022.00,Parts Salespersons
+41-2031.00,Retail Salespersons,41-2031.00,Retail Salespersons
+41-3011.00,Advertising Sales Agents,41-3011.00,Advertising Sales Agents
+41-3021.00,Insurance Sales Agents,41-3021.00,Insurance Sales Agents
+41-3031.00,"Securities, Commodities, and Financial Services Sales Agents",41-3031.00,"Securities, Commodities, and Financial Services Sales Agents"
+41-3031.01,"Sales Agents, Securities and Commodities",41-3031.00,"Securities, Commodities, and Financial Services Sales Agents"
+41-3031.02,"Sales Agents, Financial Services",41-3031.00,"Securities, Commodities, and Financial Services Sales Agents"
+41-3031.03,Securities and Commodities Traders,41-3031.00,"Securities, Commodities, and Financial Services Sales Agents"
+41-3041.00,Travel Agents,41-3041.00,Travel Agents
+41-3099.00,"Sales Representatives, Services, All Other",41-3091.00,"Sales Representatives of Services, Except Advertising, Insurance, Financial Services, and Travel"
+41-3099.01,Energy Brokers,41-3031.00,"Securities, Commodities, and Financial Services Sales Agents"
+41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products",41-4011.00,"Sales Representatives, Wholesale and Manufacturing, Technical and Scientific Products"
+41-4011.07,Solar Sales Representatives and Assessors,41-4011.07,Solar Sales Representatives and Assessors
+41-4012.00,"Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products",41-4012.00,"Sales Representatives, Wholesale and Manufacturing, Except Technical and Scientific Products"
+41-9011.00,Demonstrators and Product Promoters,41-9011.00,Demonstrators and Product Promoters
+41-9012.00,Models,41-9012.00,Models
+41-9021.00,Real Estate Brokers,41-9021.00,Real Estate Brokers
+41-9022.00,Real Estate Sales Agents,41-9022.00,Real Estate Sales Agents
+41-9031.00,Sales Engineers,41-9031.00,Sales Engineers
+41-9041.00,Telemarketers,41-9041.00,Telemarketers
+41-9091.00,"Door-To-Door Sales Workers, News and Street Vendors, and Related Workers",41-9091.00,"Door-to-Door Sales Workers, News and Street Vendors, and Related Workers"
+41-9099.00,"Sales and Related Workers, All Other",41-9099.00,"Sales and Related Workers, All Other"
+43-1011.00,First-Line Supervisors of Office and Administrative Support Workers,43-1011.00,First-Line Supervisors of Office and Administrative Support Workers
+43-2011.00,"Switchboard Operators, Including Answering Service",43-2011.00,"Switchboard Operators, Including Answering Service"
+43-2021.00,Telephone Operators,43-2021.00,Telephone Operators
+43-2099.00,"Communications Equipment Operators, All Other",43-2099.00,"Communications Equipment Operators, All Other"
+43-3011.00,Bill and Account Collectors,43-3011.00,Bill and Account Collectors
+43-3021.00,Billing and Posting Clerks,43-3021.00,Billing and Posting Clerks
+43-3021.01,Statement Clerks,43-3021.00,Billing and Posting Clerks
+43-3021.02,"Billing, Cost, and Rate Clerks",43-3021.00,Billing and Posting Clerks
+43-3031.00,"Bookkeeping, Accounting, and Auditing Clerks",43-3031.00,"Bookkeeping, Accounting, and Auditing Clerks"
+43-3041.00,Gaming Cage Workers,43-3041.00,Gambling Cage Workers
+43-3051.00,Payroll and Timekeeping Clerks,43-3051.00,Payroll and Timekeeping Clerks
+43-3061.00,Procurement Clerks,43-3061.00,Procurement Clerks
+43-3071.00,Tellers,43-3071.00,Tellers
+43-3099.00,"Financial Clerks, All Other",43-3099.00,"Financial Clerks, All Other"
+43-4011.00,Brokerage Clerks,43-4011.00,Brokerage Clerks
+43-4021.00,Correspondence Clerks,43-4021.00,Correspondence Clerks
+43-4031.00,"Court, Municipal, and License Clerks",43-4031.00,"Court, Municipal, and License Clerks"
+43-4031.01,Court Clerks,43-4031.00,"Court, Municipal, and License Clerks"
+43-4031.02,Municipal Clerks,43-4031.00,"Court, Municipal, and License Clerks"
+43-4031.03,License Clerks,43-4031.00,"Court, Municipal, and License Clerks"
+43-4041.00,"Credit Authorizers, Checkers, and Clerks",43-4041.00,"Credit Authorizers, Checkers, and Clerks"
+43-4041.01,Credit Authorizers,43-4041.00,"Credit Authorizers, Checkers, and Clerks"
+43-4041.02,Credit Checkers,43-4041.00,"Credit Authorizers, Checkers, and Clerks"
+43-4051.00,Customer Service Representatives,43-4051.00,Customer Service Representatives
+43-4051.03,Patient Representatives,29-2099.08,Patient Representatives
+43-4061.00,"Eligibility Interviewers, Government Programs",43-4061.00,"Eligibility Interviewers, Government Programs"
+43-4071.00,File Clerks,43-4071.00,File Clerks
+43-4081.00,"Hotel, Motel, and Resort Desk Clerks",43-4081.00,"Hotel, Motel, and Resort Desk Clerks"
+43-4111.00,"Interviewers, Except Eligibility and Loan",43-4111.00,"Interviewers, Except Eligibility and Loan"
+43-4121.00,"Library Assistants, Clerical",43-4121.00,"Library Assistants, Clerical"
+43-4131.00,Loan Interviewers and Clerks,43-4131.00,Loan Interviewers and Clerks
+43-4141.00,New Accounts Clerks,43-4141.00,New Accounts Clerks
+43-4151.00,Order Clerks,43-4151.00,Order Clerks
+43-4161.00,"Human Resources Assistants, Except Payroll and Timekeeping",43-4161.00,"Human Resources Assistants, Except Payroll and Timekeeping"
+43-4171.00,Receptionists and Information Clerks,43-4171.00,Receptionists and Information Clerks
+43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks,43-4181.00,Reservation and Transportation Ticket Agents and Travel Clerks
+43-4199.00,"Information and Record Clerks, All Other",43-4199.00,"Information and Record Clerks, All Other"
+43-5011.00,Cargo and Freight Agents,43-5011.00,Cargo and Freight Agents
+43-5011.01,Freight Forwarders,43-5011.01,Freight Forwarders
+43-5021.00,Couriers and Messengers,43-5021.00,Couriers and Messengers
+43-5031.00,"Police, Fire, and Ambulance Dispatchers",43-5031.00,Public Safety Telecommunicators
+43-5032.00,"Dispatchers, Except Police, Fire, and Ambulance",43-5032.00,"Dispatchers, Except Police, Fire, and Ambulance"
+43-5041.00,"Meter Readers, Utilities",43-5041.00,"Meter Readers, Utilities"
+43-5051.00,Postal Service Clerks,43-5051.00,Postal Service Clerks
+43-5052.00,Postal Service Mail Carriers,43-5052.00,Postal Service Mail Carriers
+43-5053.00,"Postal Service Mail Sorters, Processors, and Processing Machine Operators",43-5053.00,"Postal Service Mail Sorters, Processors, and Processing Machine Operators"
+43-5061.00,"Production, Planning, and Expediting Clerks",43-5061.00,"Production, Planning, and Expediting Clerks"
+43-5071.00,"Shipping, Receiving, and Traffic Clerks",43-5071.00,"Shipping, Receiving, and Inventory Clerks"
+43-5081.00,Stock Clerks and Order Fillers,53-7065.00,Stockers and Order Fillers
+43-5081.01,"Stock Clerks, Sales Floor",53-7065.00,Stockers and Order Fillers
+43-5081.02,Marking Clerks,53-7065.00,Stockers and Order Fillers
+43-5081.03,"Stock Clerks- Stockroom, Warehouse, or Storage Yard",53-7065.00,Stockers and Order Fillers
+43-5081.04,"Order Fillers, Wholesale and Retail Sales",53-7065.00,Stockers and Order Fillers
+43-5111.00,"Weighers, Measurers, Checkers, and Samplers, Recordkeeping",43-5111.00,"Weighers, Measurers, Checkers, and Samplers, Recordkeeping"
+43-6011.00,Executive Secretaries and Executive Administrative Assistants,43-6011.00,Executive Secretaries and Executive Administrative Assistants
+43-6012.00,Legal Secretaries,43-6012.00,Legal Secretaries and Administrative Assistants
+43-6013.00,Medical Secretaries,43-6013.00,Medical Secretaries and Administrative Assistants
+43-6014.00,"Secretaries and Administrative Assistants, Except Legal, Medical, and Executive",43-6014.00,"Secretaries and Administrative Assistants, Except Legal, Medical, and Executive"
+43-9011.00,Computer Operators,15-1299.00,"Computer Occupations, All Other"
+43-9021.00,Data Entry Keyers,43-9021.00,Data Entry Keyers
+43-9022.00,Word Processors and Typists,43-9022.00,Word Processors and Typists
+43-9031.00,Desktop Publishers,43-9031.00,Desktop Publishers
+43-9041.00,Insurance Claims and Policy Processing Clerks,43-9041.00,Insurance Claims and Policy Processing Clerks
+43-9041.01,Insurance Claims Clerks,43-9041.00,Insurance Claims and Policy Processing Clerks
+43-9041.02,Insurance Policy Processing Clerks,43-9041.00,Insurance Claims and Policy Processing Clerks
+43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service",43-9051.00,"Mail Clerks and Mail Machine Operators, Except Postal Service"
+43-9061.00,"Office Clerks, General",43-9061.00,"Office Clerks, General"
+43-9071.00,"Office Machine Operators, Except Computer",43-9071.00,"Office Machine Operators, Except Computer"
+43-9081.00,Proofreaders and Copy Markers,43-9081.00,Proofreaders and Copy Markers
+43-9111.00,Statistical Assistants,43-9111.00,Statistical Assistants
+43-9111.01,Bioinformatics Technicians,15-2099.01,Bioinformatics Technicians
+43-9199.00,"Office and Administrative Support Workers, All Other",43-9199.00,"Office and Administrative Support Workers, All Other"
+45-1011.00,"First-Line Supervisors of Farming, Fishing, and Forestry Workers",45-1011.00,"First-Line Supervisors of Farming, Fishing, and Forestry Workers"
+45-1011.05,First-Line Supervisors of Logging Workers,45-1011.00,"First-Line Supervisors of Farming, Fishing, and Forestry Workers"
+45-1011.06,First-Line Supervisors of Aquacultural Workers,45-1011.00,"First-Line Supervisors of Farming, Fishing, and Forestry Workers"
+45-1011.07,First-Line Supervisors of Agricultural Crop and Horticultural Workers,45-1011.00,"First-Line Supervisors of Farming, Fishing, and Forestry Workers"
+45-1011.08,First-Line Supervisors of Animal Husbandry and Animal Care Workers,45-1011.00,"First-Line Supervisors of Farming, Fishing, and Forestry Workers"
+45-2011.00,Agricultural Inspectors,45-2011.00,Agricultural Inspectors
+45-2021.00,Animal Breeders,45-2021.00,Animal Breeders
+45-2041.00,"Graders and Sorters, Agricultural Products",45-2041.00,"Graders and Sorters, Agricultural Products"
+45-2091.00,Agricultural Equipment Operators,45-2091.00,Agricultural Equipment Operators
+45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse",45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse"
+45-2092.01,Nursery Workers,45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse"
+45-2092.02,"Farmworkers and Laborers, Crop",45-2092.00,"Farmworkers and Laborers, Crop, Nursery, and Greenhouse"
+45-2093.00,"Farmworkers, Farm, Ranch, and Aquacultural Animals",45-2093.00,"Farmworkers, Farm, Ranch, and Aquacultural Animals"
+45-2099.00,"Agricultural Workers, All Other",45-2099.00,"Agricultural Workers, All Other"
+45-3011.00,Fishers and Related Fishing Workers,45-3031.00,Fishing and Hunting Workers
+45-3021.00,Hunters and Trappers,45-3031.00,Fishing and Hunting Workers
+45-4011.00,Forest and Conservation Workers,45-4011.00,Forest and Conservation Workers
+45-4021.00,Fallers,45-4021.00,Fallers
+45-4022.00,Logging Equipment Operators,45-4022.00,Logging Equipment Operators
+45-4023.00,Log Graders and Scalers,45-4023.00,Log Graders and Scalers
+45-4029.00,"Logging Workers, All Other",45-4029.00,"Logging Workers, All Other"
+47-1011.00,First-Line Supervisors of Construction Trades and Extraction Workers,47-1011.00,First-Line Supervisors of Construction Trades and Extraction Workers
+47-1011.03,Solar Energy Installation Managers,47-1011.03,Solar Energy Installation Managers
+47-2011.00,Boilermakers,47-2011.00,Boilermakers
+47-2021.00,Brickmasons and Blockmasons,47-2021.00,Brickmasons and Blockmasons
+47-2022.00,Stonemasons,47-2022.00,Stonemasons
+47-2031.00,Carpenters,47-2031.00,Carpenters
+47-2031.01,Construction Carpenters,47-2031.00,Carpenters
+47-2031.02,Rough Carpenters,47-2031.00,Carpenters
+47-2041.00,Carpet Installers,47-2041.00,Carpet Installers
+47-2042.00,"Floor Layers, Except Carpet, Wood, and Hard Tiles",47-2042.00,"Floor Layers, Except Carpet, Wood, and Hard Tiles"
+47-2043.00,Floor Sanders and Finishers,47-2043.00,Floor Sanders and Finishers
+47-2044.00,Tile and Marble Setters,47-2044.00,Tile and Stone Setters
+47-2051.00,Cement Masons and Concrete Finishers,47-2051.00,Cement Masons and Concrete Finishers
+47-2053.00,Terrazzo Workers and Finishers,47-2053.00,Terrazzo Workers and Finishers
+47-2061.00,Construction Laborers,47-2061.00,Construction Laborers
+47-2071.00,"Paving, Surfacing, and Tamping Equipment Operators",47-2071.00,"Paving, Surfacing, and Tamping Equipment Operators"
+47-2072.00,Pile-Driver Operators,47-2072.00,Pile Driver Operators
+47-2073.00,Operating Engineers and Other Construction Equipment Operators,47-2073.00,Operating Engineers and Other Construction Equipment Operators
+47-2081.00,Drywall and Ceiling Tile Installers,47-2081.00,Drywall and Ceiling Tile Installers
+47-2082.00,Tapers,47-2082.00,Tapers
+47-2111.00,Electricians,47-2111.00,Electricians
+47-2121.00,Glaziers,47-2121.00,Glaziers
+47-2131.00,"Insulation Workers, Floor, Ceiling, and Wall",47-2131.00,"Insulation Workers, Floor, Ceiling, and Wall"
+47-2132.00,"Insulation Workers, Mechanical",47-2132.00,"Insulation Workers, Mechanical"
+47-2141.00,"Painters, Construction and Maintenance",47-2141.00,"Painters, Construction and Maintenance"
+47-2142.00,Paperhangers,47-2142.00,Paperhangers
+47-2151.00,Pipelayers,47-2151.00,Pipelayers
+47-2152.00,"Plumbers, Pipefitters, and Steamfitters",47-2152.00,"Plumbers, Pipefitters, and Steamfitters"
+47-2152.01,Pipe Fitters and Steamfitters,47-2152.00,"Plumbers, Pipefitters, and Steamfitters"
+47-2152.02,Plumbers,47-2152.00,"Plumbers, Pipefitters, and Steamfitters"
+47-2161.00,Plasterers and Stucco Masons,47-2161.00,Plasterers and Stucco Masons
+47-2171.00,Reinforcing Iron and Rebar Workers,47-2171.00,Reinforcing Iron and Rebar Workers
+47-2181.00,Roofers,47-2181.00,Roofers
+47-2211.00,Sheet Metal Workers,47-2211.00,Sheet Metal Workers
+47-2221.00,Structural Iron and Steel Workers,47-2221.00,Structural Iron and Steel Workers
+47-2231.00,Solar Photovoltaic Installers,47-2231.00,Solar Photovoltaic Installers
+47-3011.00,"Helpers--Brickmasons, Blockmasons, Stonemasons, and Tile and Marble Setters",47-3011.00,"Helpers--Brickmasons, Blockmasons, Stonemasons, and Tile and Marble Setters"
+47-3012.00,Helpers--Carpenters,47-3012.00,Helpers--Carpenters
+47-3013.00,Helpers--Electricians,47-3013.00,Helpers--Electricians
+47-3014.00,"Helpers--Painters, Paperhangers, Plasterers, and Stucco Masons",47-3014.00,"Helpers--Painters, Paperhangers, Plasterers, and Stucco Masons"
+47-3015.00,"Helpers--Pipelayers, Plumbers, Pipefitters, and Steamfitters",47-3015.00,"Helpers--Pipelayers, Plumbers, Pipefitters, and Steamfitters"
+47-3016.00,Helpers--Roofers,47-3016.00,Helpers--Roofers
+47-3019.00,"Helpers, Construction Trades, All Other",47-3019.00,"Helpers, Construction Trades, All Other"
+47-4011.00,Construction and Building Inspectors,47-4011.00,Construction and Building Inspectors
+47-4021.00,Elevator Installers and Repairers,47-4021.00,Elevator and Escalator Installers and Repairers
+47-4031.00,Fence Erectors,47-4031.00,Fence Erectors
+47-4041.00,Hazardous Materials Removal Workers,47-4041.00,Hazardous Materials Removal Workers
+47-4051.00,Highway Maintenance Workers,47-4051.00,Highway Maintenance Workers
+47-4061.00,Rail-Track Laying and Maintenance Equipment Operators,47-4061.00,Rail-Track Laying and Maintenance Equipment Operators
+47-4071.00,Septic Tank Servicers and Sewer Pipe Cleaners,47-4071.00,Septic Tank Servicers and Sewer Pipe Cleaners
+47-4091.00,Segmental Pavers,47-4091.00,Segmental Pavers
+47-4099.00,"Construction and Related Workers, All Other",47-4099.00,"Construction and Related Workers, All Other"
+47-4099.02,Solar Thermal Installers and Technicians,47-2152.04,Solar Thermal Installers and Technicians
+47-4099.03,Weatherization Installers and Technicians,47-4099.03,Weatherization Installers and Technicians
+47-5011.00,"Derrick Operators, Oil and Gas",47-5011.00,"Derrick Operators, Oil and Gas"
+47-5012.00,"Rotary Drill Operators, Oil and Gas",47-5012.00,"Rotary Drill Operators, Oil and Gas"
+47-5013.00,"Service Unit Operators, Oil, Gas, and Mining",47-5013.00,"Service Unit Operators, Oil and Gas"
+47-5021.00,"Earth Drillers, Except Oil and Gas",47-5023.00,"Earth Drillers, Except Oil and Gas"
+47-5021.00,"Earth Drillers, Except Oil and Gas",47-5032.00,"Explosives Workers, Ordnance Handling Experts, and Blasters"
+47-5031.00,"Explosives Workers, Ordnance Handling Experts, and Blasters",47-5032.00,"Explosives Workers, Ordnance Handling Experts, and Blasters"
+47-5041.00,Continuous Mining Machine Operators,47-5041.00,Continuous Mining Machine Operators
+47-5042.00,Mine Cutting and Channeling Machine Operators,47-5049.00,"Underground Mining Machine Operators, All Other"
+47-5049.00,"Mining Machine Operators, All Other",47-5049.00,"Underground Mining Machine Operators, All Other"
+47-5049.00,"Mining Machine Operators, All Other",47-5099.00,"Extraction Workers, All Other"
+47-5051.00,"Rock Splitters, Quarry",47-5051.00,"Rock Splitters, Quarry"
+47-5061.00,"Roof Bolters, Mining",47-5043.00,"Roof Bolters, Mining"
+47-5071.00,"Roustabouts, Oil and Gas",47-5071.00,"Roustabouts, Oil and Gas"
+47-5081.00,Helpers--Extraction Workers,47-5081.00,Helpers--Extraction Workers
+47-5099.00,"Extraction Workers, All Other",47-5099.00,"Extraction Workers, All Other"
+49-1011.00,"First-Line Supervisors of Mechanics, Installers, and Repairers",49-1011.00,"First-Line Supervisors of Mechanics, Installers, and Repairers"
+49-2011.00,"Computer, Automated Teller, and Office Machine Repairers",49-2011.00,"Computer, Automated Teller, and Office Machine Repairers"
+49-2021.00,"Radio, Cellular, and Tower Equipment Installers and Repairers",49-2021.00,"Radio, Cellular, and Tower Equipment Installers and Repairers"
+49-2021.01,Radio Mechanics,49-2021.00,"Radio, Cellular, and Tower Equipment Installers and Repairers"
+49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers",49-2022.00,"Telecommunications Equipment Installers and Repairers, Except Line Installers"
+49-2091.00,Avionics Technicians,49-2091.00,Avionics Technicians
+49-2092.00,"Electric Motor, Power Tool, and Related Repairers",49-2092.00,"Electric Motor, Power Tool, and Related Repairers"
+49-2093.00,"Electrical and Electronics Installers and Repairers, Transportation Equipment",49-2093.00,"Electrical and Electronics Installers and Repairers, Transportation Equipment"
+49-2094.00,"Electrical and Electronics Repairers, Commercial and Industrial Equipment",49-2094.00,"Electrical and Electronics Repairers, Commercial and Industrial Equipment"
+49-2095.00,"Electrical and Electronics Repairers, Powerhouse, Substation, and Relay",49-2095.00,"Electrical and Electronics Repairers, Powerhouse, Substation, and Relay"
+49-2096.00,"Electronic Equipment Installers and Repairers, Motor Vehicles",49-2096.00,"Electronic Equipment Installers and Repairers, Motor Vehicles"
+49-2097.00,Electronic Home Entertainment Equipment Installers and Repairers,49-2097.00,Audiovisual Equipment Installers and Repairers
+49-2098.00,Security and Fire Alarm Systems Installers,49-2098.00,Security and Fire Alarm Systems Installers
+49-3011.00,Aircraft Mechanics and Service Technicians,49-3011.00,Aircraft Mechanics and Service Technicians
+49-3021.00,Automotive Body and Related Repairers,49-3021.00,Automotive Body and Related Repairers
+49-3022.00,Automotive Glass Installers and Repairers,49-3022.00,Automotive Glass Installers and Repairers
+49-3023.00,Automotive Service Technicians and Mechanics,49-3023.00,Automotive Service Technicians and Mechanics
+49-3023.01,Automotive Master Mechanics,49-3023.00,Automotive Service Technicians and Mechanics
+49-3023.02,Automotive Specialty Technicians,49-3023.00,Automotive Service Technicians and Mechanics
+49-3031.00,Bus and Truck Mechanics and Diesel Engine Specialists,49-3031.00,Bus and Truck Mechanics and Diesel Engine Specialists
+49-3041.00,Farm Equipment Mechanics and Service Technicians,49-3041.00,Farm Equipment Mechanics and Service Technicians
+49-3042.00,"Mobile Heavy Equipment Mechanics, Except Engines",49-3042.00,"Mobile Heavy Equipment Mechanics, Except Engines"
+49-3043.00,Rail Car Repairers,49-3043.00,Rail Car Repairers
+49-3051.00,Motorboat Mechanics and Service Technicians,49-3051.00,Motorboat Mechanics and Service Technicians
+49-3052.00,Motorcycle Mechanics,49-3052.00,Motorcycle Mechanics
+49-3053.00,Outdoor Power Equipment and Other Small Engine Mechanics,49-3053.00,Outdoor Power Equipment and Other Small Engine Mechanics
+49-3091.00,Bicycle Repairers,49-3091.00,Bicycle Repairers
+49-3092.00,Recreational Vehicle Service Technicians,49-3092.00,Recreational Vehicle Service Technicians
+49-3093.00,Tire Repairers and Changers,49-3093.00,Tire Repairers and Changers
+49-9011.00,Mechanical Door Repairers,49-9011.00,Mechanical Door Repairers
+49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door",49-9012.00,"Control and Valve Installers and Repairers, Except Mechanical Door"
+49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers",49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers"
+49-9021.01,Heating and Air Conditioning Mechanics and Installers,49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers"
+49-9021.02,Refrigeration Mechanics and Installers,49-9021.00,"Heating, Air Conditioning, and Refrigeration Mechanics and Installers"
+49-9031.00,Home Appliance Repairers,49-9031.00,Home Appliance Repairers
+49-9041.00,Industrial Machinery Mechanics,49-9041.00,Industrial Machinery Mechanics
+49-9043.00,"Maintenance Workers, Machinery",49-9043.00,"Maintenance Workers, Machinery"
+49-9044.00,Millwrights,49-9044.00,Millwrights
+49-9045.00,"Refractory Materials Repairers, Except Brickmasons",49-9045.00,"Refractory Materials Repairers, Except Brickmasons"
+49-9051.00,Electrical Power-Line Installers and Repairers,49-9051.00,Electrical Power-Line Installers and Repairers
+49-9052.00,Telecommunications Line Installers and Repairers,49-9052.00,Telecommunications Line Installers and Repairers
+49-9061.00,Camera and Photographic Equipment Repairers,49-9061.00,Camera and Photographic Equipment Repairers
+49-9062.00,Medical Equipment Repairers,49-9062.00,Medical Equipment Repairers
+49-9063.00,Musical Instrument Repairers and Tuners,49-9063.00,Musical Instrument Repairers and Tuners
+49-9064.00,Watch Repairers,49-9064.00,Watch and Clock Repairers
+49-9069.00,"Precision Instrument and Equipment Repairers, All Other",49-9069.00,"Precision Instrument and Equipment Repairers, All Other"
+49-9071.00,"Maintenance and Repair Workers, General",49-9071.00,"Maintenance and Repair Workers, General"
+49-9081.00,Wind Turbine Service Technicians,49-9081.00,Wind Turbine Service Technicians
+49-9091.00,"Coin, Vending, and Amusement Machine Servicers and Repairers",49-9091.00,"Coin, Vending, and Amusement Machine Servicers and Repairers"
+49-9092.00,Commercial Divers,49-9092.00,Commercial Divers
+49-9093.00,"Fabric Menders, Except Garment",49-9099.00,"Installation, Maintenance, and Repair Workers, All Other"
+49-9094.00,Locksmiths and Safe Repairers,49-9094.00,Locksmiths and Safe Repairers
+49-9095.00,Manufactured Building and Mobile Home Installers,49-9095.00,Manufactured Building and Mobile Home Installers
+49-9096.00,Riggers,49-9096.00,Riggers
+49-9097.00,Signal and Track Switch Repairers,49-9097.00,Signal and Track Switch Repairers
+49-9098.00,"Helpers--Installation, Maintenance, and Repair Workers",49-9098.00,"Helpers--Installation, Maintenance, and Repair Workers"
+49-9099.00,"Installation, Maintenance, and Repair Workers, All Other",49-9099.00,"Installation, Maintenance, and Repair Workers, All Other"
+49-9099.01,Geothermal Technicians,49-9099.01,Geothermal Technicians
+51-1011.00,First-Line Supervisors of Production and Operating Workers,51-1011.00,First-Line Supervisors of Production and Operating Workers
+51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers",51-2011.00,"Aircraft Structure, Surfaces, Rigging, and Systems Assemblers"
+51-2021.00,"Coil Winders, Tapers, and Finishers",51-2021.00,"Coil Winders, Tapers, and Finishers"
+51-2022.00,Electrical and Electronic Equipment Assemblers,51-2022.00,Electrical and Electronic Equipment Assemblers
+51-2023.00,Electromechanical Equipment Assemblers,51-2023.00,Electromechanical Equipment Assemblers
+51-2031.00,Engine and Other Machine Assemblers,51-2031.00,Engine and Other Machine Assemblers
+51-2041.00,Structural Metal Fabricators and Fitters,51-2041.00,Structural Metal Fabricators and Fitters
+51-2091.00,Fiberglass Laminators and Fabricators,51-2051.00,Fiberglass Laminators and Fabricators
+51-2092.00,Team Assemblers,51-2092.00,Team Assemblers
+51-2093.00,Timing Device Assemblers and Adjusters,51-2061.00,Timing Device Assemblers and Adjusters
+51-2099.00,"Assemblers and Fabricators, All Other",51-2099.00,"Assemblers and Fabricators, All Other"
+51-3011.00,Bakers,51-3011.00,Bakers
+51-3021.00,Butchers and Meat Cutters,51-3021.00,Butchers and Meat Cutters
+51-3022.00,"Meat, Poultry, and Fish Cutters and Trimmers",51-3022.00,"Meat, Poultry, and Fish Cutters and Trimmers"
+51-3023.00,Slaughterers and Meat Packers,51-3023.00,Slaughterers and Meat Packers
+51-3091.00,"Food and Tobacco Roasting, Baking, and Drying Machine Operators and Tenders",51-3091.00,"Food and Tobacco Roasting, Baking, and Drying Machine Operators and Tenders"
+51-3092.00,Food Batchmakers,51-3092.00,Food Batchmakers
+51-3093.00,Food Cooking Machine Operators and Tenders,51-3093.00,Food Cooking Machine Operators and Tenders
+51-3099.00,"Food Processing Workers, All Other",51-3099.00,"Food Processing Workers, All Other"
+51-4011.00,"Computer-Controlled Machine Tool Operators, Metal and Plastic",51-9161.00,Computer Numerically Controlled Tool Operators
+51-4012.00,"Computer Numerically Controlled Machine Tool Programmers, Metal and Plastic",51-9162.00,Computer Numerically Controlled Tool Programmers
+51-4021.00,"Extruding and Drawing Machine Setters, Operators, and Tenders, Metal and Plastic",51-4021.00,"Extruding and Drawing Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4022.00,"Forging Machine Setters, Operators, and Tenders, Metal and Plastic",51-4022.00,"Forging Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4023.00,"Rolling Machine Setters, Operators, and Tenders, Metal and Plastic",51-4023.00,"Rolling Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic",51-4031.00,"Cutting, Punching, and Press Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4032.00,"Drilling and Boring Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4032.00,"Drilling and Boring Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4033.00,"Grinding, Lapping, Polishing, and Buffing Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4034.00,"Lathe and Turning Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4034.00,"Lathe and Turning Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4035.00,"Milling and Planing Machine Setters, Operators, and Tenders, Metal and Plastic",51-4035.00,"Milling and Planing Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4041.00,Machinists,51-4041.00,Machinists
+51-4051.00,Metal-Refining Furnace Operators and Tenders,51-4051.00,Metal-Refining Furnace Operators and Tenders
+51-4052.00,"Pourers and Casters, Metal",51-4052.00,"Pourers and Casters, Metal"
+51-4061.00,"Model Makers, Metal and Plastic",51-4061.00,"Model Makers, Metal and Plastic"
+51-4062.00,"Patternmakers, Metal and Plastic",51-4062.00,"Patternmakers, Metal and Plastic"
+51-4071.00,Foundry Mold and Coremakers,51-4071.00,Foundry Mold and Coremakers
+51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic",51-4072.00,"Molding, Coremaking, and Casting Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic",51-4081.00,"Multiple Machine Tool Setters, Operators, and Tenders, Metal and Plastic"
+51-4111.00,Tool and Die Makers,51-4111.00,Tool and Die Makers
+51-4121.00,"Welders, Cutters, Solderers, and Brazers",51-4121.00,"Welders, Cutters, Solderers, and Brazers"
+51-4121.06,"Welders, Cutters, and Welder Fitters",51-4121.00,"Welders, Cutters, Solderers, and Brazers"
+51-4121.07,Solderers and Brazers,51-4121.00,"Welders, Cutters, Solderers, and Brazers"
+51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders",51-4122.00,"Welding, Soldering, and Brazing Machine Setters, Operators, and Tenders"
+51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic",51-4191.00,"Heat Treating Equipment Setters, Operators, and Tenders, Metal and Plastic"
+51-4192.00,"Layout Workers, Metal and Plastic",51-4192.00,"Layout Workers, Metal and Plastic"
+51-4193.00,"Plating and Coating Machine Setters, Operators, and Tenders, Metal and Plastic",51-4193.00,"Plating Machine Setters, Operators, and Tenders, Metal and Plastic"
+51-4194.00,"Tool Grinders, Filers, and Sharpeners",51-4194.00,"Tool Grinders, Filers, and Sharpeners"
+51-4199.00,"Metal Workers and Plastic Workers, All Other",51-4199.00,"Metal Workers and Plastic Workers, All Other"
+51-5111.00,Prepress Technicians and Workers,51-5111.00,Prepress Technicians and Workers
+51-5112.00,Printing Press Operators,51-5112.00,Printing Press Operators
+51-5113.00,Print Binding and Finishing Workers,51-5113.00,Print Binding and Finishing Workers
+51-6011.00,Laundry and Dry-Cleaning Workers,51-6011.00,Laundry and Dry-Cleaning Workers
+51-6021.00,"Pressers, Textile, Garment, and Related Materials",51-6021.00,"Pressers, Textile, Garment, and Related Materials"
+51-6031.00,Sewing Machine Operators,51-6031.00,Sewing Machine Operators
+51-6041.00,Shoe and Leather Workers and Repairers,51-6041.00,Shoe and Leather Workers and Repairers
+51-6042.00,Shoe Machine Operators and Tenders,51-6042.00,Shoe Machine Operators and Tenders
+51-6051.00,"Sewers, Hand",51-6051.00,"Sewers, Hand"
+51-6052.00,"Tailors, Dressmakers, and Custom Sewers",51-6052.00,"Tailors, Dressmakers, and Custom Sewers"
+51-6061.00,Textile Bleaching and Dyeing Machine Operators and Tenders,51-6061.00,Textile Bleaching and Dyeing Machine Operators and Tenders
+51-6062.00,"Textile Cutting Machine Setters, Operators, and Tenders",51-6062.00,"Textile Cutting Machine Setters, Operators, and Tenders"
+51-6063.00,"Textile Knitting and Weaving Machine Setters, Operators, and Tenders",51-6063.00,"Textile Knitting and Weaving Machine Setters, Operators, and Tenders"
+51-6064.00,"Textile Winding, Twisting, and Drawing Out Machine Setters, Operators, and Tenders",51-6064.00,"Textile Winding, Twisting, and Drawing Out Machine Setters, Operators, and Tenders"
+51-6091.00,"Extruding and Forming Machine Setters, Operators, and Tenders, Synthetic and Glass Fibers",51-6091.00,"Extruding and Forming Machine Setters, Operators, and Tenders, Synthetic and Glass Fibers"
+51-6092.00,Fabric and Apparel Patternmakers,51-6092.00,Fabric and Apparel Patternmakers
+51-6093.00,Upholsterers,51-6093.00,Upholsterers
+51-6099.00,"Textile, Apparel, and Furnishings Workers, All Other",51-6099.00,"Textile, Apparel, and Furnishings Workers, All Other"
+51-7011.00,Cabinetmakers and Bench Carpenters,51-7011.00,Cabinetmakers and Bench Carpenters
+51-7021.00,Furniture Finishers,51-7021.00,Furniture Finishers
+51-7031.00,"Model Makers, Wood",51-7031.00,"Model Makers, Wood"
+51-7032.00,"Patternmakers, Wood",51-7032.00,"Patternmakers, Wood"
+51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood",51-7041.00,"Sawing Machine Setters, Operators, and Tenders, Wood"
+51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing",51-7042.00,"Woodworking Machine Setters, Operators, and Tenders, Except Sawing"
+51-7099.00,"Woodworkers, All Other",51-7099.00,"Woodworkers, All Other"
+51-8011.00,Nuclear Power Reactor Operators,51-8011.00,Nuclear Power Reactor Operators
+51-8012.00,Power Distributors and Dispatchers,51-8012.00,Power Distributors and Dispatchers
+51-8013.00,Power Plant Operators,51-8013.00,Power Plant Operators
+51-8021.00,Stationary Engineers and Boiler Operators,51-8021.00,Stationary Engineers and Boiler Operators
+51-8031.00,Water and Wastewater Treatment Plant and System Operators,51-8031.00,Water and Wastewater Treatment Plant and System Operators
+51-8091.00,Chemical Plant and System Operators,51-8091.00,Chemical Plant and System Operators
+51-8092.00,Gas Plant Operators,51-8092.00,Gas Plant Operators
+51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers",51-8093.00,"Petroleum Pump System Operators, Refinery Operators, and Gaugers"
+51-8099.00,"Plant and System Operators, All Other",51-8099.00,"Plant and System Operators, All Other"
+51-8099.01,Biofuels Processing Technicians,51-8099.01,Biofuels Processing Technicians
+51-8099.02,Methane/Landfill Gas Generation System Technicians,51-8013.00,Power Plant Operators
+51-8099.03,Biomass Plant Technicians,51-8013.03,Biomass Plant Technicians
+51-8099.04,Hydroelectric Plant Technicians,51-8013.04,Hydroelectric Plant Technicians
+51-9011.00,Chemical Equipment Operators and Tenders,51-9011.00,Chemical Equipment Operators and Tenders
+51-9012.00,"Separating, Filtering, Clarifying, Precipitating, and Still Machine Setters, Operators, and Tenders",51-9012.00,"Separating, Filtering, Clarifying, Precipitating, and Still Machine Setters, Operators, and Tenders"
+51-9021.00,"Crushing, Grinding, and Polishing Machine Setters, Operators, and Tenders",51-9021.00,"Crushing, Grinding, and Polishing Machine Setters, Operators, and Tenders"
+51-9022.00,"Grinding and Polishing Workers, Hand",51-9022.00,"Grinding and Polishing Workers, Hand"
+51-9023.00,"Mixing and Blending Machine Setters, Operators, and Tenders",51-9023.00,"Mixing and Blending Machine Setters, Operators, and Tenders"
+51-9031.00,"Cutters and Trimmers, Hand",51-9031.00,"Cutters and Trimmers, Hand"
+51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders",51-9032.00,"Cutting and Slicing Machine Setters, Operators, and Tenders"
+51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders",51-9041.00,"Extruding, Forming, Pressing, and Compacting Machine Setters, Operators, and Tenders"
+51-9051.00,"Furnace, Kiln, Oven, Drier, and Kettle Operators and Tenders",51-9051.00,"Furnace, Kiln, Oven, Drier, and Kettle Operators and Tenders"
+51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers",51-9061.00,"Inspectors, Testers, Sorters, Samplers, and Weighers"
+51-9071.00,Jewelers and Precious Stone and Metal Workers,51-9071.00,Jewelers and Precious Stone and Metal Workers
+51-9071.01,Jewelers,51-9071.00,Jewelers and Precious Stone and Metal Workers
+51-9071.06,Gem and Diamond Workers,51-9071.06,Gem and Diamond Workers
+51-9071.07,Precious Metal Workers,51-9071.00,Jewelers and Precious Stone and Metal Workers
+51-9081.00,Dental Laboratory Technicians,51-9081.00,Dental Laboratory Technicians
+51-9082.00,Medical Appliance Technicians,51-9082.00,Medical Appliance Technicians
+51-9083.00,Ophthalmic Laboratory Technicians,51-9083.00,Ophthalmic Laboratory Technicians
+51-9111.00,Packaging and Filling Machine Operators and Tenders,51-9111.00,Packaging and Filling Machine Operators and Tenders
+51-9121.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders",51-9124.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders"
+51-9122.00,"Painters, Transportation Equipment",51-9124.00,"Coating, Painting, and Spraying Machine Setters, Operators, and Tenders"
+51-9123.00,"Painting, Coating, and Decorating Workers",51-9123.00,"Painting, Coating, and Decorating Workers"
+51-9141.00,Semiconductor Processors,51-9141.00,Semiconductor Processing Technicians
+51-9151.00,Photographic Process Workers and Processing Machine Operators,51-9151.00,Photographic Process Workers and Processing Machine Operators
+51-9191.00,Adhesive Bonding Machine Operators and Tenders,51-9191.00,Adhesive Bonding Machine Operators and Tenders
+51-9192.00,"Cleaning, Washing, and Metal Pickling Equipment Operators and Tenders",51-9192.00,"Cleaning, Washing, and Metal Pickling Equipment Operators and Tenders"
+51-9193.00,Cooling and Freezing Equipment Operators and Tenders,51-9193.00,Cooling and Freezing Equipment Operators and Tenders
+51-9194.00,Etchers and Engravers,51-9194.00,Etchers and Engravers
+51-9195.00,"Molders, Shapers, and Casters, Except Metal and Plastic",51-9195.00,"Molders, Shapers, and Casters, Except Metal and Plastic"
+51-9195.03,"Stone Cutters and Carvers, Manufacturing",51-9195.03,"Stone Cutters and Carvers, Manufacturing"
+51-9195.04,"Glass Blowers, Molders, Benders, and Finishers",51-9195.04,"Glass Blowers, Molders, Benders, and Finishers"
+51-9195.05,"Potters, Manufacturing",51-9195.05,"Potters, Manufacturing"
+51-9195.07,Molding and Casting Workers,51-9195.00,"Molders, Shapers, and Casters, Except Metal and Plastic"
+51-9196.00,"Paper Goods Machine Setters, Operators, and Tenders",51-9196.00,"Paper Goods Machine Setters, Operators, and Tenders"
+51-9197.00,Tire Builders,51-9197.00,Tire Builders
+51-9198.00,Helpers--Production Workers,51-9198.00,Helpers--Production Workers
+51-9199.00,"Production Workers, All Other",51-9161.00,Computer Numerically Controlled Tool Operators
+51-9199.00,"Production Workers, All Other",51-9162.00,Computer Numerically Controlled Tool Programmers
+51-9199.00,"Production Workers, All Other",51-9199.00,"Production Workers, All Other"
+51-9199.01,Recycling and Reclamation Workers,53-7062.04,Recycling and Reclamation Workers
+53-1011.00,Aircraft Cargo Handling Supervisors,53-1041.00,Aircraft Cargo Handling Supervisors
+53-1021.00,"First-Line Supervisors of Helpers, Laborers, and Material Movers, Hand",53-1042.00,"First-Line Supervisors of Helpers, Laborers, and Material Movers, Hand"
+53-1021.01,Recycling Coordinators,53-1042.01,Recycling Coordinators
+53-1031.00,First-Line Supervisors of Transportation and Material-Moving Machine and Vehicle Operators,53-1043.00,First-Line Supervisors of Material-Moving Machine and Vehicle Operators
+53-1031.00,First-Line Supervisors of Transportation and Material-Moving Machine and Vehicle Operators,53-1044.00,First-Line Supervisors of Passenger Attendants
+53-1031.00,First-Line Supervisors of Transportation and Material-Moving Machine and Vehicle Operators,53-1049.00,"First-Line Supervisors of Transportation Workers, All Other"
+53-2011.00,"Airline Pilots, Copilots, and Flight Engineers",53-2011.00,"Airline Pilots, Copilots, and Flight Engineers"
+53-2012.00,Commercial Pilots,53-2012.00,Commercial Pilots
+53-2021.00,Air Traffic Controllers,53-2021.00,Air Traffic Controllers
+53-2022.00,Airfield Operations Specialists,53-2022.00,Airfield Operations Specialists
+53-2031.00,Flight Attendants,53-2031.00,Flight Attendants
+53-3011.00,"Ambulance Drivers and Attendants, Except Emergency Medical Technicians",53-3011.00,"Ambulance Drivers and Attendants, Except Emergency Medical Technicians"
+53-3021.00,"Bus Drivers, Transit and Intercity",53-3052.00,"Bus Drivers, Transit and Intercity"
+53-3022.00,"Bus Drivers, School or Special Client",53-3051.00,"Bus Drivers, School"
+53-3022.00,"Bus Drivers, School or Special Client",53-3053.00,Shuttle Drivers and Chauffeurs
+53-3031.00,Driver/Sales Workers,53-3031.00,Driver/Sales Workers
+53-3032.00,Heavy and Tractor-Trailer Truck Drivers,53-3032.00,Heavy and Tractor-Trailer Truck Drivers
+53-3033.00,Light Truck or Delivery Services Drivers,53-3033.00,Light Truck Drivers
+53-3041.00,Taxi Drivers and Chauffeurs,53-3053.00,Shuttle Drivers and Chauffeurs
+53-3041.00,Taxi Drivers and Chauffeurs,53-3054.00,Taxi Drivers
+53-3099.00,"Motor Vehicle Operators, All Other",53-3099.00,"Motor Vehicle Operators, All Other"
+53-4011.00,Locomotive Engineers,53-4011.00,Locomotive Engineers
+53-4012.00,Locomotive Firers,53-4022.00,"Railroad Brake, Signal, and Switch Operators and Locomotive Firers"
+53-4013.00,"Rail Yard Engineers, Dinkey Operators, and Hostlers",53-4013.00,"Rail Yard Engineers, Dinkey Operators, and Hostlers"
+53-4021.00,"Railroad Brake, Signal, and Switch Operators",53-4022.00,"Railroad Brake, Signal, and Switch Operators and Locomotive Firers"
+53-4031.00,Railroad Conductors and Yardmasters,53-4031.00,Railroad Conductors and Yardmasters
+53-4041.00,Subway and Streetcar Operators,53-4041.00,Subway and Streetcar Operators
+53-4099.00,"Rail Transportation Workers, All Other",53-4099.00,"Rail Transportation Workers, All Other"
+53-5011.00,Sailors and Marine Oilers,53-5011.00,Sailors and Marine Oilers
+53-5021.00,"Captains, Mates, and Pilots of Water Vessels",53-5021.00,"Captains, Mates, and Pilots of Water Vessels"
+53-5021.01,Ship and Boat Captains,53-5021.00,"Captains, Mates, and Pilots of Water Vessels"
+53-5021.02,"Mates- Ship, Boat, and Barge",53-5021.00,"Captains, Mates, and Pilots of Water Vessels"
+53-5021.03,"Pilots, Ship",53-5021.00,"Captains, Mates, and Pilots of Water Vessels"
+53-5022.00,Motorboat Operators,53-5022.00,Motorboat Operators
+53-5031.00,Ship Engineers,53-5031.00,Ship Engineers
+53-6011.00,Bridge and Lock Tenders,53-6011.00,Bridge and Lock Tenders
+53-6021.00,Parking Lot Attendants,53-6021.00,Parking Attendants
+53-6031.00,Automotive and Watercraft Service Attendants,53-6031.00,Automotive and Watercraft Service Attendants
+53-6041.00,Traffic Technicians,53-6041.00,Traffic Technicians
+53-6051.00,Transportation Inspectors,53-6051.00,Transportation Inspectors
+53-6051.01,Aviation Inspectors,53-6051.01,Aviation Inspectors
+53-6051.07,"Transportation Vehicle, Equipment and Systems Inspectors, Except Aviation",53-6051.07,"Transportation Vehicle, Equipment and Systems Inspectors, Except Aviation"
+53-6051.08,Freight and Cargo Inspectors,53-6051.00,Transportation Inspectors
+53-6061.00,"Transportation Attendants, Except Flight Attendants",53-6061.00,Passenger Attendants
+53-6099.00,"Transportation Workers, All Other",53-6032.00,Aircraft Service Attendants
+53-6099.00,"Transportation Workers, All Other",53-6099.00,"Transportation Workers, All Other"
+53-7011.00,Conveyor Operators and Tenders,53-7011.00,Conveyor Operators and Tenders
+53-7021.00,Crane and Tower Operators,53-7021.00,Crane and Tower Operators
+53-7031.00,Dredge Operators,53-7031.00,Dredge Operators
+53-7032.00,Excavating and Loading Machine and Dragline Operators,47-5022.00,"Excavating and Loading Machine and Dragline Operators, Surface Mining"
+53-7032.00,Excavating and Loading Machine and Dragline Operators,53-7199.00,"Material Moving Workers, All Other"
+53-7033.00,"Loading Machine Operators, Underground Mining",47-5044.00,"Loading and Moving Machine Operators, Underground Mining"
+53-7041.00,Hoist and Winch Operators,53-7041.00,Hoist and Winch Operators
+53-7051.00,Industrial Truck and Tractor Operators,53-7051.00,Industrial Truck and Tractor Operators
+53-7061.00,Cleaners of Vehicles and Equipment,53-7061.00,Cleaners of Vehicles and Equipment
+53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand",53-7062.00,"Laborers and Freight, Stock, and Material Movers, Hand"
+53-7063.00,Machine Feeders and Offbearers,53-7063.00,Machine Feeders and Offbearers
+53-7064.00,"Packers and Packagers, Hand",53-7064.00,"Packers and Packagers, Hand"
+53-7071.00,Gas Compressor and Gas Pumping Station Operators,53-7071.00,Gas Compressor and Gas Pumping Station Operators
+53-7072.00,"Pump Operators, Except Wellhead Pumpers",53-7072.00,"Pump Operators, Except Wellhead Pumpers"
+53-7073.00,Wellhead Pumpers,53-7073.00,Wellhead Pumpers
+53-7081.00,Refuse and Recyclable Material Collectors,53-7081.00,Refuse and Recyclable Material Collectors
+53-7111.00,Mine Shuttle Car Operators,47-5044.00,"Loading and Moving Machine Operators, Underground Mining"
+53-7121.00,"Tank Car, Truck, and Ship Loaders",53-7121.00,"Tank Car, Truck, and Ship Loaders"
+53-7199.00,"Material Moving Workers, All Other",53-7199.00,"Material Moving Workers, All Other"
+55-1011.00,Air Crew Officers,55-1011.00,Air Crew Officers
+55-1012.00,Aircraft Launch and Recovery Officers,55-1012.00,Aircraft Launch and Recovery Officers
+55-1013.00,Armored Assault Vehicle Officers,55-1013.00,Armored Assault Vehicle Officers
+55-1014.00,Artillery and Missile Officers,55-1014.00,Artillery and Missile Officers
+55-1015.00,Command and Control Center Officers,55-1015.00,Command and Control Center Officers
+55-1016.00,Infantry Officers,55-1016.00,Infantry Officers
+55-1017.00,Special Forces Officers,55-1017.00,Special Forces Officers
+55-1019.00,"Military Officer Special and Tactical Operations Leaders, All Other",55-1019.00,"Military Officer Special and Tactical Operations Leaders, All Other"
+55-2011.00,First-Line Supervisors of Air Crew Members,55-2011.00,First-Line Supervisors of Air Crew Members
+55-2012.00,First-Line Supervisors of Weapons Specialists/Crew Members,55-2012.00,First-Line Supervisors of Weapons Specialists/Crew Members
+55-2013.00,First-Line Supervisors of All Other Tactical Operations Specialists,55-2013.00,First-Line Supervisors of All Other Tactical Operations Specialists
+55-3011.00,Air Crew Members,55-3011.00,Air Crew Members
+55-3012.00,Aircraft Launch and Recovery Specialists,55-3012.00,Aircraft Launch and Recovery Specialists
+55-3013.00,Armored Assault Vehicle Crew Members,55-3013.00,Armored Assault Vehicle Crew Members
+55-3014.00,Artillery and Missile Crew Members,55-3014.00,Artillery and Missile Crew Members
+55-3015.00,Command and Control Center Specialists,55-3015.00,Command and Control Center Specialists
+55-3016.00,Infantry,55-3016.00,Infantry
+55-3017.00,Radar and Sonar Technicians,17-3029.00,"Engineering Technologists and Technicians, Except Drafters, All Other"
+55-3018.00,Special Forces,55-3018.00,Special Forces
+55-3019.00,"Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members, All Other",55-3019.00,"Military Enlisted Tactical Operations and Air/Weapons Specialists and Crew Members, All Other"

--- a/spec/factories/onet_mappings.rb
+++ b/spec/factories/onet_mappings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :onet_mapping do
+    onet
+    association :next_version_onet, factory: :onet
+  end
+end

--- a/spec/factories/onets.rb
+++ b/spec/factories/onets.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :onet do
     title { "Actors" }
-    code { "27-2011.00" }
+    sequence(:code) { |n| "27-2011.#{n}" }
     version { Onet::CURRENT_VERSION }
   end
 end

--- a/spec/models/onet_mapping_spec.rb
+++ b/spec/models/onet_mapping_spec.rb
@@ -6,4 +6,11 @@ RSpec.describe OnetMapping, type: :model do
 
     expect(onet_mapping).to be_valid
   end
+
+  it "is unique wrt onet_id, next_version_onet_id" do
+    onet_mapping = create(:onet_mapping)
+    new_onet_mapping = build(:onet_mapping, onet: onet_mapping.onet, next_version_onet: onet_mapping.next_version_onet)
+
+    expect(new_onet_mapping).to_not be_valid
+  end
 end

--- a/spec/models/onet_mapping_spec.rb
+++ b/spec/models/onet_mapping_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe OnetMapping, type: :model do
+  it "has a valid factory" do
+    onet_mapping = build(:onet_mapping)
+
+    expect(onet_mapping).to be_valid
+  end
+end

--- a/spec/models/onet_spec.rb
+++ b/spec/models/onet_spec.rb
@@ -16,4 +16,15 @@ RSpec.describe Onet, type: :model do
     onet.version = "2020"
     expect(onet).to be_valid
   end
+
+  it "has many next versions" do
+    onet_2018 = create(:onet, version: "2018", code: "11-1011")
+    onet_2019a = create(:onet, version: "2019", code: "11-1011.00")
+    onet_2019b = create(:onet, version: "2019", code: "11-1011.03")
+
+    create(:onet_mapping, onet: onet_2018, next_version_onet: onet_2019a)
+    create(:onet_mapping, onet: onet_2018, next_version_onet: onet_2019b)
+
+    expect(onet_2018.next_versions).to contain_exactly(onet_2019a, onet_2019b)
+  end
 end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1205644361042004/f)

This adds a mapping table which links an onet code to its next version. Several rake tasks were added to import the mappings data.

I'm happy for any other naming suggestions on the mappings table, or for the association. I don't necessarily love `next_version`.