### PR TITLE
Add redis gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,10 @@ gem "administrate-field-jsonb"
 gem "pundit"
 gem "image_processing"
 gem "pagy"
+
+# Throttle excessive requests
 gem "rack-attack"
+gem "redis"
 
 # This is needed  to make FoxitSDK work since it uses file paths relative to the view instead of /assests
 gem "rack-rewrite", "~> 1.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,8 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redis (5.0.8)
+      redis-client (>= 0.17.0)
     redis-client (0.17.0)
       connection_pool
     regexp_parser (2.8.1)
@@ -525,6 +527,7 @@ DEPENDENCIES
   rack-cors
   rack-rewrite (~> 1.5.0)
   rails (~> 7.0.8)
+  redis
   rollbar
   roo (~> 2.10.0)
   rspec-rails


### PR DESCRIPTION
The redis gem is needed to use Redis
as a cache store for Rack Attack on
production. (Ref #478)

[Asana ticket](https://app.asana.com/0/1203289004376659/1205550593976927/f)
