### PR TITLE
Fix elasticsearch for test env

### DIFF
--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -306,6 +306,11 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     os1 = create(:occupation_standard, :with_work_processes, title: "User experience designer")
     os2 = create(:occupation_standard, :with_work_processes, title: "UX Designer")
     create(:occupation_standard, :with_work_processes, title: "Mechanic")
+    synonym = create(:synonym, word: "UX", synonyms: "User experience")
+    ElasticsearchWrapper::Synonyms.create_set(
+      value: synonym.to_elasticsearch_value,
+      rule_id: synonym.id
+    )
 
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!


### PR DESCRIPTION
The specs hang when trying to create the
OccupationStandard index since it depends
on the dynamic synonym set existing. This
adds the creation of the synonym set
to the start of the suite and removes
it when the suite is finished.

This also fixes a spec that was using the
old synonym definition.