### PR TITLE
Eager load application in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
-  config.eager_load = ENV["CI"].present?
+  config.eager_load = true
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
In the elasticsearch specs, the start up
for creating Elasticsearch models calls
`ApplicationRecord.descendants`. However, when
running a single spec, this does not always load
both Occupation and OccupationStandard
so the indexes may not be created before the start
of running the spec. This results in the index
getting created by default through the Elasticsearch
callbacks when the record is created, and for some
reason it does not apply the settings that are defined
in the model correctly, and the spec may fail.