### PR TITLE
Allow page removal from PDF editor

### DIFF
--- a/app/assets/stylesheets/pdf_editor.css
+++ b/app/assets/stylesheets/pdf_editor.css
@@ -1,0 +1,6 @@
+.editor-target {
+   height: 100vh;
+   overflow: hidden;
+   position: absolute;
+   width: 100vw;
+}

--- a/app/views/admin/redact_files/new.html.erb
+++ b/app/views/admin/redact_files/new.html.erb
@@ -12,7 +12,7 @@
 
   <div
     id="#pdf-ui"
-    class="absolute w-screen h-screen overflow-hidden"
+    class="editor-target"
     data-pdf-editor-target="renderTo">
   </div>
 </div>

--- a/app/views/layouts/admin/pdf_editor.html.erb
+++ b/app/views/layouts/admin/pdf_editor.html.erb
@@ -8,7 +8,7 @@
     <script src="/assets/lib/UIExtension.full.js"></script>
     <script src="/assets/lib/uix-addons/allInOne.js"></script>
     <link href="/assets/lib/UIExtension.vw.css" media="screen" rel="stylesheet">
-    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "pdf_editor" %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag if defined?(csp_meta_tag) %>
     <%= javascript_importmap_tags %>


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1205865477449307/f)

* Remove tailwind from PDF editor view since it's defining styles that clash with Foxit SDK

Foxit SDK sidebar allows to remove pages from a PDF, but it is not working due to tailwind adding `visibility: collapse` to `.collapse` CSS class, which is used by Foxit. This style makes the sidebar unsuable

By removing tailwind, we avoid the clash

Before:

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/2a6c316e-cd75-4697-b14e-d6009f0d687f)


After:


![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/c1ca2136-1fd4-467e-8fef-7cf0a001144b)

