### PR TITLE
Searching on onet code returns standards that match any version of the code

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -120,6 +120,7 @@ class OccupationStandard < ApplicationRecord
       indexes :onet_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search do
         indexes :prefix, type: :text, analyzer: :onet_prefix
       end
+      indexes :other_onet_codes
       indexes :rapids_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
       indexes :state, type: :text, analyzer: :keyword
       indexes :state_id, type: :keyword
@@ -141,7 +142,8 @@ class OccupationStandard < ApplicationRecord
       state_id: state_id,
       work_process_titles: work_processes.pluck(:title).uniq,
       related_job_titles: related_job_titles,
-      headline: headline
+      headline: headline,
+      other_onet_codes: other_onet_codes
     )
   end
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -330,6 +330,15 @@ class OccupationStandard < ApplicationRecord
     )
   end
 
+  def other_onet_codes
+    onet = Onet.find_by(code: onet_code)
+    if onet
+      onet.all_versions
+    else
+      []
+    end
+  end
+
   # #duplicates is used in OccupationStandardsController#index
   # It gets the values from ES collapse if feature flag enabled
   def duplicates

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -120,7 +120,7 @@ class OccupationStandard < ApplicationRecord
       indexes :onet_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search do
         indexes :prefix, type: :text, analyzer: :onet_prefix
       end
-      indexes :other_onet_codes
+      indexes :related_onet_code_versions
       indexes :rapids_code, type: :text, analyzer: :autocomplete, search_analyzer: :autocomplete_search
       indexes :state, type: :text, analyzer: :keyword
       indexes :state_id, type: :keyword
@@ -143,7 +143,7 @@ class OccupationStandard < ApplicationRecord
       work_process_titles: work_processes.pluck(:title).uniq,
       related_job_titles: related_job_titles,
       headline: headline,
-      other_onet_codes: other_onet_codes
+      related_onet_code_versions: related_onet_code_versions
     )
   end
 
@@ -332,7 +332,7 @@ class OccupationStandard < ApplicationRecord
     )
   end
 
-  def other_onet_codes
+  def related_onet_code_versions
     onet = Onet.find_by(code: onet_code)
     onet&.all_versions || []
   end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -332,11 +332,7 @@ class OccupationStandard < ApplicationRecord
 
   def other_onet_codes
     onet = Onet.find_by(code: onet_code)
-    if onet
-      onet.all_versions
-    else
-      []
-    end
+    onet&.all_versions || []
   end
 
   # #duplicates is used in OccupationStandardsController#index

--- a/app/models/onet.rb
+++ b/app/models/onet.rb
@@ -5,6 +5,9 @@ class Onet < ApplicationRecord
   has_many :onet_mappings
   has_many :next_versions, through: :onet_mappings, source: :next_version_onet
 
+  has_many :reverse_onet_mappings, class_name: "OnetMapping", foreign_key: :next_version_onet
+  has_many :previous_versions, through: :reverse_onet_mappings, source: :onet
+
   CURRENT_VERSION = "2019".freeze
 
   scope :current_version, -> { where(version: Onet::CURRENT_VERSION) }

--- a/app/models/onet.rb
+++ b/app/models/onet.rb
@@ -17,9 +17,8 @@ class Onet < ApplicationRecord
   end
 
   def all_versions
-    current_codes = [code]
-    next_codes = get_next_versions(self, current_codes)
-    previous_codes = get_previous_versions(self, current_codes)
+    next_codes = get_next_versions(self, [])
+    previous_codes = get_previous_versions(self, [])
     (next_codes + previous_codes).flatten.uniq
   end
 

--- a/app/models/onet.rb
+++ b/app/models/onet.rb
@@ -24,19 +24,19 @@ class Onet < ApplicationRecord
 
   private
 
-  def get_next_versions(onet, current_codes = [])
-    current_codes << onet.next_versions.map(&:code)
+  def get_next_versions(onet, onet_codes = [])
+    onet_codes << onet.next_versions.map(&:code)
     onet.next_versions.each do |next_onet|
-      current_codes = get_next_versions(next_onet, current_codes.flatten)
+      onet_codes = get_next_versions(next_onet, onet_codes.flatten)
     end
-    current_codes
+    onet_codes
   end
 
-  def get_previous_versions(onet, current_codes = [])
-    current_codes << onet.previous_versions.map(&:code)
+  def get_previous_versions(onet, onet_codes = [])
+    onet_codes << onet.previous_versions.map(&:code)
     onet.previous_versions.each do |previous_onet|
-      current_codes = get_previous_versions(previous_onet, current_codes.flatten)
+      onet_codes = get_previous_versions(previous_onet, onet_codes.flatten)
     end
-    current_codes
+    onet_codes
   end
 end

--- a/app/models/onet.rb
+++ b/app/models/onet.rb
@@ -24,7 +24,7 @@ class Onet < ApplicationRecord
 
   private
 
-  def get_next_versions(onet, current_codes=[])
+  def get_next_versions(onet, current_codes = [])
     current_codes << onet.next_versions.map(&:code)
     onet.next_versions.each do |next_onet|
       current_codes = get_next_versions(next_onet, current_codes.flatten)
@@ -32,7 +32,7 @@ class Onet < ApplicationRecord
     current_codes
   end
 
-  def get_previous_versions(onet, current_codes=[])
+  def get_previous_versions(onet, current_codes = [])
     current_codes << onet.previous_versions.map(&:code)
     onet.previous_versions.each do |previous_onet|
       current_codes = get_previous_versions(previous_onet, current_codes.flatten)

--- a/app/models/onet.rb
+++ b/app/models/onet.rb
@@ -15,4 +15,29 @@ class Onet < ApplicationRecord
   def to_s
     "#{title} (#{code})"
   end
+
+  def all_versions
+    current_codes = [code]
+    next_codes = get_next_versions(self, current_codes)
+    previous_codes = get_previous_versions(self, current_codes)
+    (next_codes + previous_codes).flatten.uniq
+  end
+
+  private
+
+  def get_next_versions(onet, current_codes=[])
+    current_codes << onet.next_versions.map(&:code)
+    onet.next_versions.each do |next_onet|
+      current_codes = get_next_versions(next_onet, current_codes.flatten)
+    end
+    current_codes
+  end
+
+  def get_previous_versions(onet, current_codes=[])
+    current_codes << onet.previous_versions.map(&:code)
+    onet.previous_versions.each do |previous_onet|
+      current_codes = get_previous_versions(previous_onet, current_codes.flatten)
+    end
+    current_codes
+  end
 end

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -110,6 +110,11 @@ class OccupationStandardElasticsearchQuery
                     query: q
                   }
                 end
+                should do
+                  match other_onet_codes: {
+                    query: q
+                  }
+                end
                 minimum_should_match 1
               end
             end

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -111,7 +111,7 @@ class OccupationStandardElasticsearchQuery
                   }
                 end
                 should do
-                  match other_onet_codes: {
+                  match related_onet_code_versions: {
                     query: q
                   }
                 end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,7 +1,7 @@
 require "elasticsearch"
 
+enable_logging = ENV.fetch("ELASTIC_LOGGING_ENABLED", "false")
 args = if Rails.env.production? && ENV["ELASTIC_CLOUD_ID"].present?
-  enable_logging = ENV.fetch("ELASTIC_LOGGING_ENABLED", "false")
   {
     cloud_id: ENV.fetch("ELASTIC_CLOUD_ID"),
     user: ENV.fetch("ELASTIC_USER"),
@@ -9,7 +9,7 @@ args = if Rails.env.production? && ENV["ELASTIC_CLOUD_ID"].present?
     log: ActiveModel::Type::Boolean.new.cast(enable_logging)
   }
 else
-  {log: false}
+  {log: ActiveModel::Type::Boolean.new.cast(enable_logging)}
 end
 
 Elasticsearch::Model.client = Elasticsearch::Client.new(args)

--- a/lib/tasks/deployment/20231108000743_reindex_occupation_standards.rake
+++ b/lib/tasks/deployment/20231108000743_reindex_occupation_standards.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc "Deployment task: reindex_occupation_standards"
+  task reindex_occupation_standards: :environment do
+    puts "Running deploy task 'reindex_occupation_standards'"
+
+    OccupationStandard.__elasticsearch__.create_index!(force: true)
+    OccupationStandard.import
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -845,4 +845,27 @@ RSpec.describe OccupationStandard, type: :model do
       end.not_to change(occupation_standard, :onet_code)
     end
   end
+
+  describe "#other_onet_codes" do
+    it "is empty if onet_code is nil" do
+      occupation_standard = build(:occupation_standard, onet_code: nil)
+
+      expect(occupation_standard.other_onet_codes).to be_empty
+    end
+
+    it "is empty if onet does not exist for onet_code" do
+      occupation_standard = build(:occupation_standard, onet_code: "12-3456.00")
+
+      expect(occupation_standard.other_onet_codes).to be_empty
+    end
+
+    it "returns all versions of onet_code if onet exists" do
+      onet = build(:onet, code: "12-3456.00")
+      occupation_standard = build(:occupation_standard, onet_code: "12-3456.00")
+      allow(Onet).to receive(:find_by).with(code: "12-3456.00").and_return(onet)
+      allow(onet).to receive(:all_versions).and_return(["12.3456.00", "12.3456"])
+
+      expect(occupation_standard.other_onet_codes).to eq(["12.3456.00", "12.3456"])
+    end
+  end
 end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -846,17 +846,17 @@ RSpec.describe OccupationStandard, type: :model do
     end
   end
 
-  describe "#other_onet_codes" do
+  describe "#related_onet_code_versions" do
     it "is empty if onet_code is nil" do
       occupation_standard = build(:occupation_standard, onet_code: nil)
 
-      expect(occupation_standard.other_onet_codes).to be_empty
+      expect(occupation_standard.related_onet_code_versions).to be_empty
     end
 
     it "is empty if onet does not exist for onet_code" do
       occupation_standard = build(:occupation_standard, onet_code: "12-3456.00")
 
-      expect(occupation_standard.other_onet_codes).to be_empty
+      expect(occupation_standard.related_onet_code_versions).to be_empty
     end
 
     it "returns all versions of onet_code if onet exists" do
@@ -865,7 +865,7 @@ RSpec.describe OccupationStandard, type: :model do
       allow(Onet).to receive(:find_by).with(code: "12-3456.00").and_return(onet)
       allow(onet).to receive(:all_versions).and_return(["12.3456.00", "12.3456"])
 
-      expect(occupation_standard.other_onet_codes).to eq(["12.3456.00", "12.3456"])
+      expect(occupation_standard.related_onet_code_versions).to eq(["12.3456.00", "12.3456"])
     end
   end
 end

--- a/spec/models/onet_spec.rb
+++ b/spec/models/onet_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe Onet, type: :model do
     expect(onet_2018.next_versions).to contain_exactly(onet_2019a, onet_2019b)
   end
 
+  it "has many previous versions" do
+    onet_2018a = create(:onet, version: "2018", code: "11-1011")
+    onet_2018b = create(:onet, version: "2018", code: "11-1012")
+    onet_2019 = create(:onet, version: "2019", code: "11-1011.00")
+
+    create(:onet_mapping, onet: onet_2018a, next_version_onet: onet_2019)
+    create(:onet_mapping, onet: onet_2018b, next_version_onet: onet_2019)
+
+    expect(onet_2019.previous_versions).to contain_exactly(onet_2018a, onet_2018b)
+  end
+
   describe "scopes" do
     describe "current_version" do
       it "returns onet codes with current version only" do

--- a/spec/models/onet_spec.rb
+++ b/spec/models/onet_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe Onet, type: :model do
     it "returns all onet code strings up and down the chain (excluding self)" do
       onet_2009 = create(:onet, version: "2009", code: "09-1011")
       onet_2010 = create(:onet, version: "2010", code: "10-1011")
-      onet_2018 = create(:onet, version: "2018", code: "11-1011")
-      onet_2019a = create(:onet, version: "2019", code: "11-1011.00")
-      onet_2019b = create(:onet, version: "2019", code: "11-1011.03")
+      onet_2018 = create(:onet, version: "2018", code: "18-1011")
+      onet_2019a = create(:onet, version: "2019", code: "19-1011.00")
+      onet_2019b = create(:onet, version: "2019", code: "19-1011.03")
       onet_2020 = create(:onet, version: "2020", code: "20-1011.00")
 
       create(:onet_mapping, onet: onet_2009, next_version_onet: onet_2010)
@@ -60,7 +60,7 @@ RSpec.describe Onet, type: :model do
       create(:onet_mapping, onet: onet_2018, next_version_onet: onet_2019b)
       create(:onet_mapping, onet: onet_2019a, next_version_onet: onet_2020)
 
-      expect(onet_2018.all_versions).to contain_exactly("09-1011", "10-1011", "11-1011.00", "11-1011.03", "20-1011.00")
+      expect(onet_2018.all_versions).to contain_exactly("09-1011", "10-1011", "19-1011.00", "19-1011.03", "20-1011.00")
     end
   end
 

--- a/spec/models/onet_spec.rb
+++ b/spec/models/onet_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe Onet, type: :model do
   end
 
   describe "#all_versions" do
+    it "returns an empty array if no mappings" do
+      onet_2018 = create(:onet, version: "2018", code: "11-1011")
+
+      expect(onet_2018.all_versions).to be_empty
+    end
+
     it "returns all onet code strings up and down the chain (excluding self)" do
       onet_2009 = create(:onet, version: "2009", code: "09-1011")
       onet_2010 = create(:onet, version: "2010", code: "10-1011")

--- a/spec/models/onet_spec.rb
+++ b/spec/models/onet_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe Onet, type: :model do
     expect(onet_2019.previous_versions).to contain_exactly(onet_2018a, onet_2018b)
   end
 
+  describe "#all_versions" do
+    it "returns all onet code strings up and down the chain" do
+      onet_2009 = create(:onet, version: "2009", code: "09-1011")
+      onet_2010 = create(:onet, version: "2010", code: "10-1011")
+      onet_2018 = create(:onet, version: "2018", code: "11-1011")
+      onet_2019a = create(:onet, version: "2019", code: "11-1011.00")
+      onet_2019b = create(:onet, version: "2019", code: "11-1011.03")
+      onet_2020 = create(:onet, version: "2020", code: "20-1011.00")
+
+      create(:onet_mapping, onet: onet_2009, next_version_onet: onet_2010)
+      create(:onet_mapping, onet: onet_2010, next_version_onet: onet_2018)
+      create(:onet_mapping, onet: onet_2018, next_version_onet: onet_2019a)
+      create(:onet_mapping, onet: onet_2018, next_version_onet: onet_2019b)
+      create(:onet_mapping, onet: onet_2019a, next_version_onet: onet_2020)
+
+      expect(onet_2018.all_versions).to contain_exactly("09-1011", "10-1011", "11-1011", "11-1011.00", "11-1011.03", "20-1011.00")
+    end
+  end
+
   describe "scopes" do
     describe "current_version" do
       it "returns onet codes with current version only" do

--- a/spec/models/onet_spec.rb
+++ b/spec/models/onet_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Onet, type: :model do
   end
 
   describe "#all_versions" do
-    it "returns all onet code strings up and down the chain" do
+    it "returns all onet code strings up and down the chain (excluding self)" do
       onet_2009 = create(:onet, version: "2009", code: "09-1011")
       onet_2010 = create(:onet, version: "2010", code: "10-1011")
       onet_2018 = create(:onet, version: "2018", code: "11-1011")
@@ -54,7 +54,7 @@ RSpec.describe Onet, type: :model do
       create(:onet_mapping, onet: onet_2018, next_version_onet: onet_2019b)
       create(:onet_mapping, onet: onet_2019a, next_version_onet: onet_2020)
 
-      expect(onet_2018.all_versions).to contain_exactly("09-1011", "10-1011", "11-1011", "11-1011.00", "11-1011.03", "20-1011.00")
+      expect(onet_2018.all_versions).to contain_exactly("09-1011", "10-1011", "11-1011.00", "11-1011.03", "20-1011.00")
     end
   end
 

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
   it "allows searching occupation standards by onet code" do
     os1 = create(:occupation_standard, :with_work_processes, onet_code: "12-3456")
     create(:occupation_standard, :with_work_processes, onet_code: "12-3457")
-    create(:occupation_standard, :with_work_processes, title: "HR", onet_code: "11-2345")
+    create(:occupation_standard, :with_work_processes, onet_code: "11-2345")
 
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!
@@ -144,18 +144,16 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
   end
 
   it "allows searching occupation standards by other onet code version" do
-    onet_2019 = create(:onet, version: "2019", code: "12-3456.00")
-    onet_2010 = create(:onet, version: "2010", code: "11-3456.00")
+    onet_2010 = create(:onet, version: "2010", code: "10-3456.00")
+    onet_2019 = create(:onet, version: "2019", code: "19-3456.00")
     create(:onet_mapping, onet: onet_2010, next_version_onet: onet_2019)
 
-    os1 = create(:occupation_standard, :with_work_processes, onet_code: "12-3456.00")
-    create(:occupation_standard, :with_work_processes, onet_code: "12-3457")
-    create(:occupation_standard, :with_work_processes, title: "HR", onet_code: "11-2345")
+    os1 = create(:occupation_standard, :with_work_processes, onet_code: "19-3456.00")
 
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!
 
-    params = {q: "11-3456"}
+    params = {q: "10-3456"}
     response = described_class.new(search_params: params).call
 
     expect(response.records.pluck(:id)).to contain_exactly(os1.id)

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -130,14 +130,32 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
   end
 
   it "allows searching occupation standards by onet code" do
-    os1 = create(:occupation_standard, :with_work_processes, onet_code: "12.3456")
-    create(:occupation_standard, :with_work_processes, onet_code: "12.3457")
-    create(:occupation_standard, :with_work_processes, title: "HR", onet_code: "11.2345")
+    os1 = create(:occupation_standard, :with_work_processes, onet_code: "12-3456")
+    create(:occupation_standard, :with_work_processes, onet_code: "12-3457")
+    create(:occupation_standard, :with_work_processes, title: "HR", onet_code: "11-2345")
 
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!
 
-    params = {q: "12.3456"}
+    params = {q: "12-3456"}
+    response = described_class.new(search_params: params).call
+
+    expect(response.records.pluck(:id)).to contain_exactly(os1.id)
+  end
+
+  it "allows searching occupation standards by other onet code version" do
+    onet_2019 = create(:onet, version: "2019", code: "12-3456.00")
+    onet_2010 = create(:onet, version: "2010", code: "11-3456.00")
+    create(:onet_mapping, onet: onet_2010, next_version_onet: onet_2019)
+
+    os1 = create(:occupation_standard, :with_work_processes, onet_code: "12-3456.00")
+    create(:occupation_standard, :with_work_processes, onet_code: "12-3457")
+    create(:occupation_standard, :with_work_processes, title: "HR", onet_code: "11-2345")
+
+    OccupationStandard.import
+    OccupationStandard.__elasticsearch__.refresh_index!
+
+    params = {q: "11-3456"}
     response = described_class.new(search_params: params).call
 
     expect(response.records.pluck(:id)).to contain_exactly(os1.id)


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1205644361042008/f)

This change will return Elasticsearch results for standards that may not match the onet_code in the search term, but match a previous (or future) version of the onet code.


