### PR TITLE
Add an explainer video on the hompage

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,6 +17,11 @@
     </div>
   </div>
 </section>
+<section>
+  <iframe class="w-full md:w-3/4 lg:w-6/12 aspect-video mx-auto"
+    src="https://www.youtube.com/embed/-cmdvkj0IV0">
+  </iframe>
+</section>
 <section aria-labelledby="section-title" class="bg-accent-300">
   <div class="py-8 px-4 mx-auto max-w-screen-xl sm:py-16 lg:px-6">
     <div class="mb-8 lg:mb-16 flex justify-between">

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -123,7 +123,6 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/forms'),
-    require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/typography'),
     require('flowbite/plugin'),
   ]


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1205901391498413/f)

The tailwind aspect-ratio module is not needed as aspect-ratio is built in to Tailwind 3.

**Large screens**
<img width="1658" alt="Screenshot 2023-11-08 at 12 58 56 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/c789bb6a-6b6d-471a-855f-3dc94bed9c45">

**Medium screens**
<img width="871" alt="Screenshot 2023-11-08 at 12 59 10 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/fafa7228-836f-4e51-88a4-676ac6249a00">

**Small screens**
<img width="696" alt="Screenshot 2023-11-08 at 12 59 16 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/edc0b3e1-d64e-41c7-b2e8-adab58650472">


