### PR TITLE
Small styling changes to explainer video on home page

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,10 +17,12 @@
     </div>
   </div>
 </section>
-<section>
-  <iframe class="w-full md:w-3/4 lg:w-6/12 aspect-video mx-auto"
-    src="https://www.youtube.com/embed/-cmdvkj0IV0">
-  </iframe>
+<section class="bg-accent-300">
+  <div class="py-8 sm:py-16 px-4 lg:px-6 max-w-screen-xl mx-auto">
+    <iframe class="w-full md:w-3/4 lg:w-6/12 aspect-video mx-auto"
+      src="https://www.youtube.com/embed/-cmdvkj0IV0">
+    </iframe>
+  </div>
 </section>
 <section aria-labelledby="section-title" class="bg-accent-300">
   <div class="py-8 px-4 mx-auto max-w-screen-xl sm:py-16 lg:px-6">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,8 +17,9 @@
     </div>
   </div>
 </section>
-<section class="bg-accent-300">
+<section aria-labelledby="section-title" class="bg-accent-300">
   <div class="py-8 sm:py-16 px-4 lg:px-6 max-w-screen-xl mx-auto">
+    <h2 class="section-title sr-only">Embedded video to introduce the Registered Apprenticeship Standards Library</h2>
     <iframe class="w-full md:w-3/4 lg:w-6/12 aspect-video mx-auto"
       src="https://www.youtube.com/embed/-cmdvkj0IV0">
     </iframe>


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1205901391498413/f)

## Changes
* Add some padding to the video on the home page
* Make the background pale green like the section below
* Make the video slightly smaller on large screens
* Add a section title for screen readers

## Screenshots
### Large screens
<img width="1576" alt="Screenshot 2023-11-09 at 9 47 27 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/567b996f-7c17-4eb4-b798-a5792b7dbca4">

### Medium screens
<img width="1005" alt="Screenshot 2023-11-09 at 9 47 53 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/0f91a04e-0435-40e5-8e1a-a91f72597d97">

### Small screens
<img width="708" alt="Screenshot 2023-11-09 at 9 48 03 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/778600ce-cfdc-45be-b646-9c3c99cd129e">


