### PR TITLE
Remove unnecessary 'within' block which may be contributing to flaky spec

### DIFF
--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -306,10 +306,7 @@ RSpec.describe "occupation_standards/index" do
       visit occupation_standards_path
 
       find('button[data-action="click->accordion#changeVisibility"]', match: :first).click
-
-      within "#accordion-#{mechanic.id}" do
-        click_on "Collapse duplicates"
-      end
+      click_on "Collapse duplicates"
 
       expect(page).not_to have_selector("#accordion-#{mechanic.id}")
       Flipper.disable :similar_programs_accordion
@@ -848,10 +845,7 @@ RSpec.describe "occupation_standards/index" do
       visit occupation_standards_path
 
       find('button[data-action="click->accordion#changeVisibility"]', match: :first).click
-
-      within "#accordion-#{mechanic.id}" do
-        click_on "Collapse duplicates"
-      end
+      click_on "Collapse duplicates"
 
       expect(page).not_to have_selector("#accordion-#{mechanic.id}")
       Flipper.disable :similar_programs_accordion


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1205931295164756/f)

Here was the failing screenshot from the spec in CI:

![failures_r_spec_example_groups_occupation_standards_index_when_not_using_elasticsearch_for_search_closes_similar_results_accordion_when_accordion_button_is_clicked_428](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/b58a8ee0-1a8b-4bad-b0f2-36d3ebe1af3f)
