### PR TITLE
Add redacted_source_file to SourceFile

### DIFF
--- a/app/controllers/admin/redact_files_controller.rb
+++ b/app/controllers/admin/redact_files_controller.rb
@@ -13,6 +13,7 @@ module Admin
           @source_file = SourceFile.find(params[:source_file_id])
           authorize :redact_file, :new?
           if params[:redacted_file]
+            @source_file.redacted_source_file.attach(params[:redacted_file])
             @source_file.data_imports.map(&:occupation_standard).each do |occupation_standard|
               occupation_standard.redacted_document.attach(params[:redacted_file])
             end

--- a/app/dashboards/source_file_dashboard.rb
+++ b/app/dashboards/source_file_dashboard.rb
@@ -13,7 +13,9 @@ class SourceFileDashboard < Administrate::BaseDashboard
     assignee: AssigneeField,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    public_document: Field::Boolean
+    public_document: Field::Boolean,
+    redacted_source_file: Field::ActiveStorage,
+    redacted_source_file_url: Field::Url.with_options(searchable: false)
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[
@@ -35,6 +37,8 @@ class SourceFileDashboard < Administrate::BaseDashboard
     notes
     assignee
     public_document
+    redacted_source_file
+    redacted_source_file_url
     created_at
     updated_at
   ].freeze

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -2,6 +2,7 @@ class SourceFile < ApplicationRecord
   belongs_to :active_storage_attachment, class_name: "ActiveStorage::Attachment"
   belongs_to :assignee, class_name: "User", optional: true
   has_many :data_imports, -> { includes(:occupation_standard, file_attachment: :blob) }
+  has_one_attached :redacted_source_file
 
   enum :status, [:pending, :completed, :needs_support]
 
@@ -37,5 +38,13 @@ class SourceFile < ApplicationRecord
 
   def pdf?
     active_storage_attachment&.blob&.content_type == "application/pdf"
+  end
+
+  def redacted_source_file_url
+    redacted_source_file&.blob&.url
+  end
+
+  def file_for_redaction
+    redacted_source_file.attached? ? redacted_source_file : active_storage_attachment
   end
 end

--- a/app/views/admin/redact_files/new.html.erb
+++ b/app/views/admin/redact_files/new.html.erb
@@ -2,9 +2,9 @@
   data-controller="pdf-editor"
   data-pdf-editor-license-key-value="<%= ENV["FOXIT_SDK_LICENSE_KEY"] %>"
   data-pdf-editor-license-serial-number-value="<%= ENV["FOXIT_SDK_SERIAL_NUMBER"] %>"
-  data-pdf-editor-file-url-value="<%= rails_storage_proxy_path(@source_file.active_storage_attachment) %>"
-  data-pdf-editor-file-size-value="<%= @source_file.active_storage_attachment.byte_size %>"
-  data-pdf-editor-file-name-value="<%= @source_file.filename %>"
+  data-pdf-editor-file-url-value="<%= rails_storage_proxy_path(@source_file.file_for_redaction) %>"
+  data-pdf-editor-file-size-value="<%= @source_file.file_for_redaction.byte_size %>"
+  data-pdf-editor-file-name-value="<%= @source_file.file_for_redaction.blob.filename %>"
   data-pdf-editor-save-file-url-value="<%= admin_source_file_redact_file_path(@source_file, format: :json) %>"
   data-pdf-editor-go-back-url-value="<%= admin_source_file_path(@source_file) %>">
   <%= form_tag(url_for(action: :create), method: :post, multipart: true, data: {turbo: false, pdf_editor_target: "form"}) do %>

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -70,4 +70,41 @@ RSpec.describe SourceFile, type: :model do
       expect(source_file.pdf?).to be false
     end
   end
+
+  describe "#redacted_source_file_url" do
+    it "returns nil if file not present" do
+      source_file = build(:source_file, redacted_source_file: nil)
+
+      expect(source_file.redacted_source_file_url).to be nil
+    end
+
+    it "returns file url if file present", :url_generation do
+      source_file = build(:source_file, redacted_source_file: fixture_file_upload("pixel1x1.jpg", "image/jpeg"))
+
+      expect(source_file.redacted_source_file_url).to be_present
+    end
+  end
+
+  describe "#file_for_redaction" do
+    it "returns redacted_source_file if present" do
+      source_file = build(:source_file, redacted_source_file: fixture_file_upload("pixel1x1.jpg", "image/jpeg"))
+
+      expect(source_file.file_for_redaction).to eq source_file.redacted_source_file
+    end
+
+    it "returns active_storage_attachment if redacted_source_file is not present" do
+      active_storage_attachment = build_stubbed(:active_storage_attachment, content_type: "image/png")
+      source_file = build(:source_file,
+        active_storage_attachment: active_storage_attachment,
+        redacted_source_file: nil)
+
+      expect(source_file.file_for_redaction).to eq source_file.active_storage_attachment
+    end
+
+    it "returns nil if no file present" do
+      source_file = build(:source_file, active_storage_attachment: nil, redacted_source_file: nil)
+
+      expect(source_file.file_for_redaction).to be nil
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,4 +89,10 @@ RSpec.configure do |config|
   config.before(:each, type: :system, admin: true) do
     Capybara.app_host = "http://admin.example.localhost"
   end
+
+  config.before(:each, url_generation: true) do
+    ActiveStorage::Current.url_options = {
+      host: "https://www.example.com"
+    }
+  end
 end

--- a/spec/requests/admin/redact_file_spec.rb
+++ b/spec/requests/admin/redact_file_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
             }
 
             sign_in admin
-            post admin_source_file_redact_file_path(source_file, params)
+            post admin_source_file_redact_file_path(source_file), params: params
 
             expect(response).to be_successful
           end
@@ -85,9 +85,12 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
             }
 
             sign_in admin
-            post admin_source_file_redact_file_path(source_file, params)
+            post admin_source_file_redact_file_path(source_file), params: params
+
+            source_file.reload
 
             expect(response).to be_successful
+            expect(source_file.redacted_source_file).to be_attached
           end
         end
       end


### PR DESCRIPTION
[Asana ticket](#https://app.asana.com/0/1203289004376659/1205865477449298/f)

In order to see the differences between the original source file and the redacted source file, we need to store a copy of the redacted file in the source file additionally to update the redacted_file on each associated OccupationStandard.

This also updates the redact tool document view to use the redacted version instead of the original version if available

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/3736cd7f-b4d0-4691-a8ef-5587abdc5264)
