### PR TITLE
Do not run Elasticsearch callbacks for non ES specs

### DIFF
--- a/app/models/concerns/elasticsearchable.rb
+++ b/app/models/concerns/elasticsearchable.rb
@@ -1,0 +1,25 @@
+module Elasticsearchable
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit on: [:create] do
+      __elasticsearch__.index_document unless self.class.elasticsearch_disabled?
+    end
+
+    after_commit on: [:update] do
+      unless elasticsearch_disabled?
+        __elasticsearch__.update_document
+      end
+    end
+
+    after_commit on: [:destroy] do
+      __elasticsearch__.delete_document unless self.class.elasticsearch_disabled?
+    end
+  end
+
+  class_methods do
+    def elasticsearch_disabled?
+      Rails.env.test? && !self.__elasticsearch__.index_exists?
+    end
+  end
+end

--- a/app/models/concerns/elasticsearchable.rb
+++ b/app/models/concerns/elasticsearchable.rb
@@ -3,7 +3,7 @@ module Elasticsearchable
 
   included do
     after_commit on: [:create] do
-      __elasticsearch__.index_document unless self.class.elasticsearch_disabled?
+      __elasticsearch__.index_document unless elasticsearch_disabled?
     end
 
     after_commit on: [:update] do
@@ -13,13 +13,11 @@ module Elasticsearchable
     end
 
     after_commit on: [:destroy] do
-      __elasticsearch__.delete_document unless self.class.elasticsearch_disabled?
+      __elasticsearch__.delete_document unless elasticsearch_disabled?
     end
   end
 
-  class_methods do
-    def elasticsearch_disabled?
-      Rails.env.test? && !self.__elasticsearch__.index_exists?
-    end
+  def elasticsearch_disabled?
+    Rails.env.test? && RSpec.configuration.elasticsearch_disabled?
   end
 end

--- a/app/models/concerns/elasticsearchable.rb
+++ b/app/models/concerns/elasticsearchable.rb
@@ -3,7 +3,9 @@ module Elasticsearchable
 
   included do
     after_commit on: [:create] do
-      __elasticsearch__.index_document unless elasticsearch_disabled?
+      unless elasticsearch_disabled?
+        __elasticsearch__.index_document
+      end
     end
 
     after_commit on: [:update] do
@@ -13,7 +15,9 @@ module Elasticsearchable
     end
 
     after_commit on: [:destroy] do
-      __elasticsearch__.delete_document unless elasticsearch_disabled?
+      unless elasticsearch_disabled?
+        __elasticsearch__.delete_document
+      end
     end
   end
 

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -1,6 +1,6 @@
 class Occupation < ApplicationRecord
   include Elasticsearch::Model
-  include Elasticsearch::Model::Callbacks
+  include Elasticsearchable
 
   has_many :competency_options, as: :resource
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -3,7 +3,7 @@ require "elasticsearch_wrapper/synonyms"
 class OccupationStandard < ApplicationRecord
   include ActionView::Helpers::NumberHelper
   include Elasticsearch::Model
-  include Elasticsearch::Model::Callbacks
+  include Elasticsearchable
 
   belongs_to :occupation, optional: true
   belongs_to :registration_agency

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.add_setting :elasticsearch_disabled, default: true
+
   config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :request

--- a/spec/support/elasticseach.rb
+++ b/spec/support/elasticseach.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
   end
 
   config.before :each, elasticsearch: true do
+    config.elasticsearch_disabled = false
     ApplicationRecord.descendants.each do |model|
       if model.respond_to?(:__elasticsearch__)
         begin
@@ -35,6 +36,7 @@ RSpec.configure do |config|
   end
 
   config.after :each, elasticsearch: true do
+    config.elasticsearch_disabled = true
     ApplicationRecord.descendants.each do |model|
       if model.respond_to?(:__elasticsearch__)
         begin

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters standards based on onet_code search term and state filter", :js do
+    it "filters standards based on onet_code search term and state filter", :js, :elasticsearch do
       wa = create(:state, name: "Washington")
       ra = create(:registration_agency, state: wa)
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
@@ -96,7 +96,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters standards based on onet_code search term and national_standard_type filter", :js do
+    it "filters standards based on onet_code search term and national_standard_type filter", :js, :elasticsearch do
       mechanic = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :guideline_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -125,7 +125,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "filters standards based on onet_code search term and ojt_type filter", :js do
+    it "filters standards based on onet_code search term and ojt_type filter", :js, :elasticsearch do
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -216,7 +216,7 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "HR"
     end
 
-    it "can clear form", :js do
+    it "can clear form", :js, :elasticsearch do
       wa = create(:state, name: "Washington")
       ra = create(:registration_agency, state: wa)
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)


### PR DESCRIPTION
The automatic callbacks that were in place for Elasticsearch would create the index and PUT the records in the ES index for all Occupation and OccupationStandard records, even if we did not care about testing anything related to Elasticsearch. This change uses custom callbacks that will not add records to Elasticsearch unless we are specifically running specs that have the `:elasticsearch` tag.

This change only shaved off about 10 seconds for me locally, but I think as our test suite grows, the time savings will be more beneficial.
