### PR TITLE
Fix NoMethodError: undefined method `redacted_document' for nil:NilClass

### DIFF
--- a/app/controllers/admin/redact_files_controller.rb
+++ b/app/controllers/admin/redact_files_controller.rb
@@ -14,7 +14,7 @@ module Admin
           authorize :redact_file, :new?
           if params[:redacted_file]
             @source_file.redacted_source_file.attach(params[:redacted_file])
-            @source_file.data_imports.map(&:occupation_standard).each do |occupation_standard|
+            @source_file.associated_occupation_standards.each do |occupation_standard|
               occupation_standard.redacted_document.attach(params[:redacted_file])
             end
             render json: {

--- a/spec/requests/admin/redact_file_spec.rb
+++ b/spec/requests/admin/redact_file_spec.rb
@@ -93,6 +93,28 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
             expect(source_file.redacted_source_file).to be_attached
           end
         end
+
+        context "without occupation standard" do
+          it "only updates redacted_source_file" do
+            admin = create(:admin)
+            data_import = create(:data_import, occupation_standard: nil)
+            source_file = create(:source_file, data_imports: [data_import])
+            redacted_file = fixture_file_upload("pixel1x1.jpg", "image/jpeg")
+
+            params = {
+              format: :json,
+              redacted_file: redacted_file
+            }
+
+            sign_in admin
+            post admin_source_file_redact_file_path(source_file), params: params
+
+            source_file.reload
+
+            expect(response).to be_successful
+            expect(source_file.redacted_source_file).to be_attached
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
[Asata ticket](https://app.asana.com/0/1203289004376659/1206012022370384/f)

[Rollbar error](https://app.rollbar.com/a/apprenticeship-standards-dot-o/fix/item/apprenticeship-standards-dot-o/314/occurrence/371992114024?utm_campaign=new_item&utm_medium=email&utm_source=rollbar-notification&utm_content=view-item-button-1#detail)

When trying to save a redacted document, we want to attach the file to all of the related association standards through the data imports of the source file. It may be the case that the data import is not yet associated to a occupation standard, throwing the error above.

This change uses a scope previously defined to get all the associated occupation standards. This removes all nil values and only iterates through existing occupation standards