### PR TITLE
Fixes and additions for Admin dashboard

### DIFF
--- a/app/dashboards/source_file_dashboard.rb
+++ b/app/dashboards/source_file_dashboard.rb
@@ -18,6 +18,7 @@ class SourceFileDashboard < Administrate::BaseDashboard
     redacted_source_file: Field::ActiveStorage,
     redacted_source_file_url: Field::Url.with_options(searchable: false),
     associated_occupation_standards: HasManyAssociatedOccupationStandardsField,
+    standards_import: GenericRecordField,
     plain_text_version: Field::Text
 
   }.freeze
@@ -45,6 +46,7 @@ class SourceFileDashboard < Administrate::BaseDashboard
     redacted_source_file
     redacted_source_file_url
     associated_occupation_standards
+    standards_import
     plain_text_version
     created_at
     updated_at

--- a/app/dashboards/standards_import_dashboard.rb
+++ b/app/dashboards/standards_import_dashboard.rb
@@ -42,7 +42,7 @@ class StandardsImportDashboard < Administrate::BaseDashboard
 
   COLLECTION_FILTERS = {}.freeze
 
-  def permitted_attributes
+  def permitted_attributes(action = nil)
     super + [attachments: []]
   end
 end

--- a/app/fields/generic_record_field.rb
+++ b/app/fields/generic_record_field.rb
@@ -1,0 +1,7 @@
+require "administrate/field/base"
+
+class GenericRecordField < Administrate::Field::Base
+  def to_s
+    data
+  end
+end

--- a/app/views/fields/generic_record_field/_form.html.erb
+++ b/app/views/fields/generic_record_field/_form.html.erb
@@ -1,0 +1,6 @@
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.select field.attribute, options_from_collection_for_select(field.data.class.all, :id, :id) %>
+</div>

--- a/app/views/fields/generic_record_field/_index.html.erb
+++ b/app/views/fields/generic_record_field/_index.html.erb
@@ -1,0 +1,1 @@
+<%= link_to field.data&.id, url_for([:admin, field.data]) %>

--- a/app/views/fields/generic_record_field/_show.html.erb
+++ b/app/views/fields/generic_record_field/_show.html.erb
@@ -1,0 +1,1 @@
+<%= link_to field.data&.id, url_for([:admin, field.data]) %>

--- a/spec/system/admin/standards_imports/edit_spec.rb
+++ b/spec/system/admin/standards_imports/edit_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "admin/standards_imports/edit" do
+  it "allows admin user to edit standards_import", :admin do
+    import = create(:standards_import)
+    admin = create(:admin)
+
+    login_as admin
+    visit edit_admin_standards_import_path(import)
+
+    select "Pending", from: "Courtesy notification"
+    click_on "Update"
+
+    expect(page).to have_content "Pending"
+  end
+end


### PR DESCRIPTION
* Add GenericRecord field type 

There was no way to display the StandardsImport
associated with a SourceFile, since there
wasn't a built-in association between
the objects. This adds a new GenericRecord
administrate field that display a link
to the record.

* Fixed editing of StandardsImport

The StandardsImport uses custom
permitted_params but the latest
Administrate release had updated
that method to take a parameter
https://github.com/thoughtbot/administrate/pull/2356

**admin/source_files#show**
<img width="565" alt="Screenshot 2023-11-30 at 3 31 04 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/b59de3d3-e373-483e-a740-fe459760eb18">


