### PR TITLE
Do not display expansion icon if nothing to display

### DIFF
--- a/app/helpers/occupation_standards_helper.rb
+++ b/app/helpers/occupation_standards_helper.rb
@@ -3,6 +3,12 @@ module OccupationStandardsHelper
     occupation_standard.ojt_type&.titleize
   end
 
+  def standard_descendants_toggle_icon(record)
+    if record.has_details_to_display?
+      "before:content-['+']"
+    end
+  end
+
   def filters_class
     if params[:state_id].blank? && params[:national_standard_type].blank? && params[:ojt_type].blank?
       "hidden"

--- a/app/helpers/occupation_standards_helper.rb
+++ b/app/helpers/occupation_standards_helper.rb
@@ -3,6 +3,12 @@ module OccupationStandardsHelper
     occupation_standard.ojt_type&.titleize
   end
 
+  def standard_descendants_accordion_class(record)
+    if record.has_details_to_display?
+      "accordion"
+    end
+  end
+
   def standard_descendants_toggle_icon(record)
     if record.has_details_to_display?
       "before:content-['+']"

--- a/app/helpers/related_instructions_helper.rb
+++ b/app/helpers/related_instructions_helper.rb
@@ -1,10 +1,4 @@
 module RelatedInstructionsHelper
-  def related_instruction_accordion_class(related_instruction)
-    if related_instruction.has_details_to_display?
-      "accordion"
-    end
-  end
-
   def related_instruction_hours_display_class(related_instruction)
     if related_instruction.hours.to_i.positive?
       "visible"

--- a/app/helpers/related_instructions_helper.rb
+++ b/app/helpers/related_instructions_helper.rb
@@ -1,0 +1,9 @@
+module RelatedInstructionsHelper
+  def related_instruction_hours_display_class(related_instruction)
+    if related_instruction.hours.to_i.positive?
+      "visible"
+    else
+      "invisible"
+    end
+  end
+end

--- a/app/helpers/related_instructions_helper.rb
+++ b/app/helpers/related_instructions_helper.rb
@@ -5,12 +5,6 @@ module RelatedInstructionsHelper
     end
   end
 
-  def related_instruction_toggle_icon(related_instruction)
-    if related_instruction.has_details_to_display?
-      "before:content-['+']"
-    end
-  end
-
   def related_instruction_hours_display_class(related_instruction)
     if related_instruction.hours.to_i.positive?
       "visible"

--- a/app/helpers/related_instructions_helper.rb
+++ b/app/helpers/related_instructions_helper.rb
@@ -1,4 +1,16 @@
 module RelatedInstructionsHelper
+  def related_instruction_accordion_class(related_instruction)
+    if related_instruction.has_details_to_display?
+      "accordion"
+    end
+  end
+
+  def related_instruction_toggle_icon(related_instruction)
+    if related_instruction.has_details_to_display?
+      "before:content-['+']"
+    end
+  end
+
   def related_instruction_hours_display_class(related_instruction)
     if related_instruction.hours.to_i.positive?
       "visible"

--- a/app/helpers/work_processes_helper.rb
+++ b/app/helpers/work_processes_helper.rb
@@ -20,4 +20,20 @@ module WorkProcessesHelper
       "before:content-['+']"
     end
   end
+
+  def competencies_count_display_class(work_process)
+    if work_process.competencies_count.positive?
+      "visible"
+    else
+      "invisible"
+    end
+  end
+
+  def hours_display_class(work_process)
+    if work_process.hours.present? && work_process.occupation_standard_work_processes_hours.positive?
+      "visible"
+    else
+      "invisible"
+    end
+  end
 end

--- a/app/helpers/work_processes_helper.rb
+++ b/app/helpers/work_processes_helper.rb
@@ -15,12 +15,6 @@ module WorkProcessesHelper
     )
   end
 
-  def work_process_accordion_class(work_process)
-    if work_process.has_details_to_display?
-      "accordion"
-    end
-  end
-
   def competencies_count_display_class(work_process)
     if work_process.competencies_count.positive?
       "visible"

--- a/app/helpers/work_processes_helper.rb
+++ b/app/helpers/work_processes_helper.rb
@@ -21,12 +21,6 @@ module WorkProcessesHelper
     end
   end
 
-  def work_process_toggle_icon(work_process)
-    if work_process.has_details_to_display?
-      "before:content-['+']"
-    end
-  end
-
   def competencies_count_display_class(work_process)
     if work_process.competencies_count.positive?
       "visible"

--- a/app/helpers/work_processes_helper.rb
+++ b/app/helpers/work_processes_helper.rb
@@ -15,6 +15,12 @@ module WorkProcessesHelper
     )
   end
 
+  def work_process_accordion_class(work_process)
+    if work_process.has_details_to_display?
+      "accordion"
+    end
+  end
+
   def work_process_toggle_icon(work_process)
     if work_process.has_details_to_display?
       "before:content-['+']"

--- a/app/helpers/work_processes_helper.rb
+++ b/app/helpers/work_processes_helper.rb
@@ -15,7 +15,7 @@ module WorkProcessesHelper
     )
   end
 
-  def toggle_icon(work_process)
+  def work_process_toggle_icon(work_process)
     if work_process.description.present? || work_process.competencies.any?
       "before:content-['+']"
     end

--- a/app/helpers/work_processes_helper.rb
+++ b/app/helpers/work_processes_helper.rb
@@ -14,4 +14,10 @@ module WorkProcessesHelper
       }
     )
   end
+
+  def toggle_icon(work_process)
+    if work_process.description.present? || work_process.competencies.any?
+      "before:content-['+']"
+    end
+  end
 end

--- a/app/helpers/work_processes_helper.rb
+++ b/app/helpers/work_processes_helper.rb
@@ -35,7 +35,7 @@ module WorkProcessesHelper
     end
   end
 
-  def hours_display_class(work_process)
+  def work_process_hours_display_class(work_process)
     if work_process.hours.present? && work_process.occupation_standard_work_processes_hours.positive?
       "visible"
     else

--- a/app/helpers/work_processes_helper.rb
+++ b/app/helpers/work_processes_helper.rb
@@ -16,7 +16,7 @@ module WorkProcessesHelper
   end
 
   def work_process_toggle_icon(work_process)
-    if work_process.description.present? || work_process.competencies.any?
+    if work_process.has_details_to_display?
       "before:content-['+']"
     end
   end

--- a/app/models/related_instruction.rb
+++ b/app/models/related_instruction.rb
@@ -22,4 +22,8 @@ class RelatedInstruction < ApplicationRecord
       }
     )
   end
+
+  def has_details_to_display?
+    description.present?
+  end
 end

--- a/app/models/work_process.rb
+++ b/app/models/work_process.rb
@@ -23,4 +23,8 @@ class WorkProcess < ApplicationRecord
       }
     )
   end
+
+  def has_details_to_display?
+    description.present? || competencies.any?
+  end
 end

--- a/app/views/occupation_standards/_accordion.html.erb
+++ b/app/views/occupation_standards/_accordion.html.erb
@@ -1,0 +1,5 @@
+<div class="<%= standard_descendants_accordion_class(record) %> w-full mx-auto">
+  <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
+    <%= yield %>
+  </details>
+</div>

--- a/app/views/occupation_standards/_accordion_details.html.erb
+++ b/app/views/occupation_standards/_accordion_details.html.erb
@@ -1,0 +1,5 @@
+<% if record.has_details_to_display? %>
+  <div class="accordion-content space-y-4 p-8 text-primary-600">
+    <%= yield %>
+  </div>
+<% end %>

--- a/app/views/occupation_standards/_accordion_summary.html.erb
+++ b/app/views/occupation_standards/_accordion_summary.html.erb
@@ -1,0 +1,18 @@
+<summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= standard_descendants_toggle_icon(record) %>">
+  <div class="flex w-full items-center justify-between">
+    <div class="space-x-3 flex-col md:flex-row">
+      <span class="skill-title text-xl text-primary-900 font-bold">
+        <%= record.title %>
+      </span>
+      <span class="skill-code text-primary-600"></span>
+    </div>
+
+    <div class="flex items-center">
+      <div class="flex flex-col md:flex-row">
+
+        <%= yield %>
+
+      </div>
+    </div>
+  </div>
+</summary>

--- a/app/views/occupation_standards/_accordion_summary.html.erb
+++ b/app/views/occupation_standards/_accordion_summary.html.erb
@@ -9,9 +9,7 @@
 
     <div class="flex items-center">
       <div class="flex flex-col md:flex-row">
-
         <%= yield %>
-
       </div>
     </div>
   </div>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -2,7 +2,7 @@
     <% work_processes.each do |work_process| %>
 
         <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
-            <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:content-['+'] before:mr-4 before:font-bold before:text-3xl before:text-secondary-600">
+            <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= toggle_icon(work_process) %>">
                 <div class="flex w-full items-center justify-between">
                     <div class="space-x-3 flex-col md:flex-row">
                         <span class="skill-title text-xl text-primary-900 font-bold"><%= work_process.title %></span>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -11,16 +11,12 @@
 
                     <div class="flex items-center">
                         <div class="flex flex-col md:flex-row">
-                            <% if work_process.competencies_count.positive? %>
-                                <div class="m-1.5 w-28 rounded bg-yonder-100 px-1 py-3 text-center">
-                                    <div class="text-3xl font-bold text-yonder-600"><%= work_process.competencies_count %></div>
-                                </div>
-                            <% end %>
-                            <% if work_process.hours.present? && work_process.occupation_standard_work_processes_hours.positive? %>
-                                <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center">
-                                    <div class="text-3xl font-bold text-rust-800"><%= hours_in_human_format(work_process.hours) %></div>
-                                </div>
-                            <% end %>
+                            <div class="m-1.5 w-28 rounded bg-yonder-100 px-1 py-3 text-center <%= competencies_count_display_class(work_process) %>">
+                                <div class="text-3xl font-bold text-yonder-600"><%= work_process.competencies_count %></div>
+                            </div>
+                            <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center <%= hours_display_class(work_process) %>">
+                                <div class="text-3xl font-bold text-rust-800"><%= hours_in_human_format(work_process.hours) %></div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -21,16 +21,18 @@
                     </div>
                 </div>
             </summary>
-            <div class="accordion-content space-y-4 p-8 text-primary-600">
-                <p>
-                    <%= work_process.description %>
-                </p>
-                <ol class="list-decimal list-inside space-y-1" role="list">
-                    <% work_process.competencies.each do |competency| %>
-                        <li><%= strip_tags competency.title %></li>
-                    <% end %>
-                </ol>
-            </div>
+            <% if work_process.description.present? || work_process.competencies.any? %>
+              <div class="accordion-content space-y-4 p-8 text-primary-600">
+                  <p>
+                      <%= work_process.description %>
+                  </p>
+                  <ol class="list-decimal list-inside space-y-1" role="list">
+                      <% work_process.competencies.each do |competency| %>
+                          <li><%= strip_tags competency.title %></li>
+                      <% end %>
+                  </ol>
+              </div>
+            <% end %>
         </details>
     <% end %>
 </div>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -1,38 +1,30 @@
 <% work_processes.each do |work_process| %>
-    <div class="<%= standard_descendants_accordion_class(work_process) %> w-full mx-auto">
+  <div class="<%= standard_descendants_accordion_class(work_process) %> w-full mx-auto">
 
-        <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
-            <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= standard_descendants_toggle_icon(work_process) %>">
-                <div class="flex w-full items-center justify-between">
-                    <div class="space-x-3 flex-col md:flex-row">
-                        <span class="skill-title text-xl text-primary-900 font-bold"><%= work_process.title %></span>
-                        <span class="skill-code text-primary-600"></span>
-                    </div>
+    <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
 
-                    <div class="flex items-center">
-                        <div class="flex flex-col md:flex-row">
-                            <div class="m-1.5 w-28 rounded bg-yonder-100 px-1 py-3 text-center <%= competencies_count_display_class(work_process) %>">
-                                <div class="text-3xl font-bold text-yonder-600"><%= work_process.competencies_count %></div>
-                            </div>
-                            <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center <%= work_process_hours_display_class(work_process) %>">
-                                <div class="text-3xl font-bold text-rust-800"><%= hours_in_human_format(work_process.hours) %></div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </summary>
-            <% if work_process.has_details_to_display? %>
-              <div class="accordion-content space-y-4 p-8 text-primary-600">
-                  <p>
-                      <%= work_process.description %>
-                  </p>
-                  <ol class="list-decimal list-inside space-y-1" role="list">
-                      <% work_process.competencies.each do |competency| %>
-                          <li><%= strip_tags competency.title %></li>
-                      <% end %>
-                  </ol>
-              </div>
-            <% end %>
-        </details>
-    </div>
+      <%= render "accordion_summary", record: work_process do %>
+        <div class="m-1.5 w-28 rounded bg-yonder-100 px-1 py-3 text-center <%= competencies_count_display_class(work_process) %>">
+          <div class="text-3xl font-bold text-yonder-600">
+            <%= work_process.competencies_count %>
+          </div>
+        </div>
+        <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center <%= work_process_hours_display_class(work_process) %>">
+          <div class="text-3xl font-bold text-rust-800">
+            <%= hours_in_human_format(work_process.hours) %>
+          </div>
+        </div>
+      <% end %>
+
+      <%= render "accordion_details", record: work_process do %>
+        <p><%= work_process.description %></p>
+        <ol class="list-decimal list-inside space-y-1" role="list">
+          <% work_process.competencies.each do |competency| %>
+            <li><%= strip_tags competency.title %></li>
+          <% end %>
+        </ol>
+      <% end %>
+
+    </details>
+  </div>
 <% end %>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -1,8 +1,8 @@
-<div class="accordion w-full mx-auto">
-    <% work_processes.each do |work_process| %>
+<% work_processes.each do |work_process| %>
+    <div class="<%= work_process_accordion_class(work_process) %> w-full mx-auto">
 
         <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
-            <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= toggle_icon(work_process) %>">
+            <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= work_process_toggle_icon(work_process) %>">
                 <div class="flex w-full items-center justify-between">
                     <div class="space-x-3 flex-col md:flex-row">
                         <span class="skill-title text-xl text-primary-900 font-bold"><%= work_process.title %></span>
@@ -21,7 +21,7 @@
                     </div>
                 </div>
             </summary>
-            <% if work_process.description.present? || work_process.competencies.any? %>
+            <% if work_process.has_details_to_display? %>
               <div class="accordion-content space-y-4 p-8 text-primary-600">
                   <p>
                       <%= work_process.description %>
@@ -34,5 +34,5 @@
               </div>
             <% end %>
         </details>
-    <% end %>
-</div>
+    </div>
+<% end %>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -2,7 +2,7 @@
     <div class="<%= work_process_accordion_class(work_process) %> w-full mx-auto">
 
         <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
-            <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= work_process_toggle_icon(work_process) %>">
+            <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= standard_descendants_toggle_icon(work_process) %>">
                 <div class="flex w-full items-center justify-between">
                     <div class="space-x-3 flex-col md:flex-row">
                         <span class="skill-title text-xl text-primary-900 font-bold"><%= work_process.title %></span>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -1,5 +1,5 @@
 <% work_processes.each do |work_process| %>
-    <div class="<%= work_process_accordion_class(work_process) %> w-full mx-auto">
+    <div class="<%= standard_descendants_accordion_class(work_process) %> w-full mx-auto">
 
         <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
             <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= standard_descendants_toggle_icon(work_process) %>">

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -14,7 +14,7 @@
                             <div class="m-1.5 w-28 rounded bg-yonder-100 px-1 py-3 text-center <%= competencies_count_display_class(work_process) %>">
                                 <div class="text-3xl font-bold text-yonder-600"><%= work_process.competencies_count %></div>
                             </div>
-                            <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center <%= hours_display_class(work_process) %>">
+                            <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center <%= work_process_hours_display_class(work_process) %>">
                                 <div class="text-3xl font-bold text-rust-800"><%= hours_in_human_format(work_process.hours) %></div>
                             </div>
                         </div>

--- a/app/views/occupation_standards/_ojt_accordion.html.erb
+++ b/app/views/occupation_standards/_ojt_accordion.html.erb
@@ -1,30 +1,27 @@
 <% work_processes.each do |work_process| %>
-  <div class="<%= standard_descendants_accordion_class(work_process) %> w-full mx-auto">
+  <%= render "accordion", record: work_process do %>
 
-    <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
-
-      <%= render "accordion_summary", record: work_process do %>
-        <div class="m-1.5 w-28 rounded bg-yonder-100 px-1 py-3 text-center <%= competencies_count_display_class(work_process) %>">
-          <div class="text-3xl font-bold text-yonder-600">
-            <%= work_process.competencies_count %>
-          </div>
+    <%= render "accordion_summary", record: work_process do %>
+      <div class="m-1.5 w-28 rounded bg-yonder-100 px-1 py-3 text-center <%= competencies_count_display_class(work_process) %>">
+        <div class="text-3xl font-bold text-yonder-600">
+          <%= work_process.competencies_count %>
         </div>
-        <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center <%= work_process_hours_display_class(work_process) %>">
-          <div class="text-3xl font-bold text-rust-800">
-            <%= hours_in_human_format(work_process.hours) %>
-          </div>
+      </div>
+      <div class="m-1.5 w-28 rounded bg-rust-100 px-1 py-3 text-center <%= work_process_hours_display_class(work_process) %>">
+        <div class="text-3xl font-bold text-rust-800">
+          <%= hours_in_human_format(work_process.hours) %>
         </div>
-      <% end %>
+      </div>
+    <% end %>
 
-      <%= render "accordion_details", record: work_process do %>
-        <p><%= work_process.description %></p>
-        <ol class="list-decimal list-inside space-y-1" role="list">
-          <% work_process.competencies.each do |competency| %>
-            <li><%= strip_tags competency.title %></li>
-          <% end %>
-        </ol>
-      <% end %>
+    <%= render "accordion_details", record: work_process do %>
+      <p><%= work_process.description %></p>
+      <ol class="list-decimal list-inside space-y-1" role="list">
+        <% work_process.competencies.each do |competency| %>
+          <li><%= strip_tags competency.title %></li>
+        <% end %>
+      </ol>
+    <% end %>
 
-    </details>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/occupation_standards/_related_instructions_accordion.html.erb
+++ b/app/views/occupation_standards/_related_instructions_accordion.html.erb
@@ -1,5 +1,5 @@
 <% related_instructions.each do |related_instruction| %>
-  <div class="<%= related_instruction_accordion_class(related_instruction) %> w-full mx-auto">
+  <div class="<%= standard_descendants_accordion_class(related_instruction) %> w-full mx-auto">
     <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
       <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= standard_descendants_toggle_icon(related_instruction) %>">
         <div class="flex w-full items-center justify-between">

--- a/app/views/occupation_standards/_related_instructions_accordion.html.erb
+++ b/app/views/occupation_standards/_related_instructions_accordion.html.erb
@@ -1,7 +1,7 @@
-<div class='accordion w-full mx-auto'>
-  <% related_instructions.each do |related_instruction| %>
+<% related_instructions.each do |related_instruction| %>
+  <div class="<%= related_instruction_accordion_class(related_instruction) %> w-full mx-auto">
     <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
-      <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:content-['+'] before:mr-4 before:font-bold before:text-3xl before:text-secondary-600">
+      <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= related_instruction_toggle_icon(related_instruction) %>">
         <div class="flex w-full items-center justify-between">
           <div class="space-x-3 flex-col md:flex-row">
             <span class="skill-title text-xl text-primary-900 font-bold"><%= related_instruction.title %></span>
@@ -10,20 +10,20 @@
 
           <div class="flex items-center">
             <div class="flex flex-col md:flex-row">
-              <% unless related_instruction.hours.nil? %>
-                <div class="m-1.5 w-28 rounded bg-pear-100 px-1 py-3 text-center">
-                  <div class="text-3xl font-bold text-pear-700"><%= hours_in_human_format(related_instruction.hours) %></div>
-                </div>
-              <% end %>
+              <div class="m-1.5 w-28 rounded bg-pear-100 px-1 py-3 text-center <%= related_instruction_hours_display_class(related_instruction) %>">
+                <div class="text-3xl font-bold text-pear-700"><%= hours_in_human_format(related_instruction.hours) %></div>
+              </div>
             </div>
           </div>
         </div>
       </summary>
-      <div class="accordion-content space-y-4 p-8 text-primary-600">
-        <p>
-          <%= related_instruction.description %>
-        </p>
-      </div>
+      <% if related_instruction.has_details_to_display? %>
+        <div class="accordion-content space-y-4 p-8 text-primary-600">
+          <p>
+            <%= related_instruction.description %>
+          </p>
+        </div>
+      <% end %>
     </details>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/occupation_standards/_related_instructions_accordion.html.erb
+++ b/app/views/occupation_standards/_related_instructions_accordion.html.erb
@@ -1,7 +1,7 @@
 <% related_instructions.each do |related_instruction| %>
   <div class="<%= related_instruction_accordion_class(related_instruction) %> w-full mx-auto">
     <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
-      <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= related_instruction_toggle_icon(related_instruction) %>">
+      <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= standard_descendants_toggle_icon(related_instruction) %>">
         <div class="flex w-full items-center justify-between">
           <div class="space-x-3 flex-col md:flex-row">
             <span class="skill-title text-xl text-primary-900 font-bold"><%= related_instruction.title %></span>

--- a/app/views/occupation_standards/_related_instructions_accordion.html.erb
+++ b/app/views/occupation_standards/_related_instructions_accordion.html.erb
@@ -1,29 +1,19 @@
 <% related_instructions.each do |related_instruction| %>
   <div class="<%= standard_descendants_accordion_class(related_instruction) %> w-full mx-auto">
     <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
-      <summary class="w-full items-center bg-seafoam-200 flex space-x-4 px-4 py-2 before:mr-4 before:font-bold before:text-3xl before:text-secondary-600 <%= standard_descendants_toggle_icon(related_instruction) %>">
-        <div class="flex w-full items-center justify-between">
-          <div class="space-x-3 flex-col md:flex-row">
-            <span class="skill-title text-xl text-primary-900 font-bold"><%= related_instruction.title %></span>
-            <span class="skill-code text-primary-600"></span>
-          </div>
 
-          <div class="flex items-center">
-            <div class="flex flex-col md:flex-row">
-              <div class="m-1.5 w-28 rounded bg-pear-100 px-1 py-3 text-center <%= related_instruction_hours_display_class(related_instruction) %>">
-                <div class="text-3xl font-bold text-pear-700"><%= hours_in_human_format(related_instruction.hours) %></div>
-              </div>
-            </div>
+      <%= render "accordion_summary", record: related_instruction do %>
+        <div class="m-1.5 w-28 rounded bg-pear-100 px-1 py-3 text-center <%= related_instruction_hours_display_class(related_instruction) %>">
+          <div class="text-3xl font-bold text-pear-700">
+            <%= hours_in_human_format(related_instruction.hours) %>
           </div>
-        </div>
-      </summary>
-      <% if related_instruction.has_details_to_display? %>
-        <div class="accordion-content space-y-4 p-8 text-primary-600">
-          <p>
-            <%= related_instruction.description %>
-          </p>
         </div>
       <% end %>
+
+      <%= render "accordion_details", record: related_instruction do %>
+        <p><%= related_instruction.description %></p>
+      <% end %>
+
     </details>
   </div>
 <% end %>

--- a/app/views/occupation_standards/_related_instructions_accordion.html.erb
+++ b/app/views/occupation_standards/_related_instructions_accordion.html.erb
@@ -1,19 +1,17 @@
 <% related_instructions.each do |related_instruction| %>
-  <div class="<%= standard_descendants_accordion_class(related_instruction) %> w-full mx-auto">
-    <details class="w-full bg-white border-b-2 border-seafoam-300 cursor-pointer">
+  <%= render "accordion", record: related_instruction do %>
 
-      <%= render "accordion_summary", record: related_instruction do %>
-        <div class="m-1.5 w-28 rounded bg-pear-100 px-1 py-3 text-center <%= related_instruction_hours_display_class(related_instruction) %>">
-          <div class="text-3xl font-bold text-pear-700">
-            <%= hours_in_human_format(related_instruction.hours) %>
-          </div>
+    <%= render "accordion_summary", record: related_instruction do %>
+      <div class="m-1.5 w-28 rounded bg-pear-100 px-1 py-3 text-center <%= related_instruction_hours_display_class(related_instruction) %>">
+        <div class="text-3xl font-bold text-pear-700">
+          <%= hours_in_human_format(related_instruction.hours) %>
         </div>
-      <% end %>
+      </div>
+    <% end %>
 
-      <%= render "accordion_details", record: related_instruction do %>
-        <p><%= related_instruction.description %></p>
-      <% end %>
+    <%= render "accordion_details", record: related_instruction do %>
+      <p><%= related_instruction.description %></p>
+    <% end %>
 
-    </details>
-  </div>
+  <% end %>
 <% end %>

--- a/spec/helpers/occupation_standards_helper_spec.rb
+++ b/spec/helpers/occupation_standards_helper_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe OccupationStandardsHelper, type: :helper do
     end
   end
 
+  describe "#standard_descendants_accordion_class" do
+    it "returns nil if related_instruction has no details to display" do
+      related_instruction = build(:related_instruction)
+      allow(related_instruction).to receive(:has_details_to_display?).and_return(false)
+
+      expect(helper.standard_descendants_accordion_class(related_instruction)).to be_nil
+    end
+
+    it "returns 'accordion' if related_instruction has details to display" do
+      related_instruction = build(:related_instruction)
+      allow(related_instruction).to receive(:has_details_to_display?).and_return(true)
+
+      expect(helper.standard_descendants_accordion_class(related_instruction)).to eq "accordion"
+    end
+  end
+
   describe "#standard_descendants_toggle_icon" do
     it "returns nil if related_instruction has no details to display" do
       related_instruction = build(:related_instruction)

--- a/spec/helpers/occupation_standards_helper_spec.rb
+++ b/spec/helpers/occupation_standards_helper_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe OccupationStandardsHelper, type: :helper do
     end
   end
 
+  describe "#standard_descendants_toggle_icon" do
+    it "returns nil if related_instruction has no details to display" do
+      related_instruction = build(:related_instruction)
+      allow(related_instruction).to receive(:has_details_to_display?).and_return(false)
+
+      expect(helper.standard_descendants_toggle_icon(related_instruction)).to be_nil
+    end
+
+    it "returns before content if related_instruction has details to display" do
+      related_instruction = build(:related_instruction)
+      allow(related_instruction).to receive(:has_details_to_display?).and_return(true)
+
+      expect(helper.standard_descendants_toggle_icon(related_instruction)).to eq "before:content-['+']"
+    end
+  end
+
   describe "#filters_class" do
     it "returns hidden if no filter params" do
       expect(helper.filters_class).to eq "hidden"

--- a/spec/helpers/related_instructions_helper_spec.rb
+++ b/spec/helpers/related_instructions_helper_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+# Specs in this file have access to a helper object that includes
+# the RelatedInstructionsHelper. For example:
+#
+# describe RelatedInstructionsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe RelatedInstructionsHelper, type: :helper do
+  describe "#related_instruction_hours_display_class" do
+    it "returns invisible if related_instruction hours field is nil" do
+      related_instruction = build(:related_instruction, hours: nil)
+
+      expect(helper.related_instruction_hours_display_class(related_instruction)).to eq "invisible"
+    end
+
+    it "returns invisible if related_instruction hours is 0" do
+      related_instruction = build(:related_instruction, hours: 0)
+
+      expect(helper.related_instruction_hours_display_class(related_instruction)).to eq "invisible"
+    end
+
+    it "returns visible if related_instruction hours is > 0" do
+      related_instruction = build(:related_instruction, hours: 5)
+
+      expect(helper.related_instruction_hours_display_class(related_instruction)).to eq "visible"
+    end
+  end
+end

--- a/spec/helpers/related_instructions_helper_spec.rb
+++ b/spec/helpers/related_instructions_helper_spec.rb
@@ -11,6 +11,38 @@ require "rails_helper"
 #   end
 # end
 RSpec.describe RelatedInstructionsHelper, type: :helper do
+  describe "#related_instruction_accordion_class" do
+    it "returns nil if related_instruction has no details to display" do
+      related_instruction = build(:related_instruction)
+      allow(related_instruction).to receive(:has_details_to_display?).and_return(false)
+
+      expect(helper.related_instruction_accordion_class(related_instruction)).to be_nil
+    end
+
+    it "returns 'accordion' if related_instruction has details to display" do
+      related_instruction = build(:related_instruction)
+      allow(related_instruction).to receive(:has_details_to_display?).and_return(true)
+
+      expect(helper.related_instruction_accordion_class(related_instruction)).to eq "accordion"
+    end
+  end
+
+  describe "#related_instruction_toggle_icon" do
+    it "returns nil if related_instruction has no details to display" do
+      related_instruction = build(:related_instruction)
+      allow(related_instruction).to receive(:has_details_to_display?).and_return(false)
+
+      expect(helper.related_instruction_toggle_icon(related_instruction)).to be_nil
+    end
+
+    it "returns before content if related_instruction has details to display" do
+      related_instruction = build(:related_instruction)
+      allow(related_instruction).to receive(:has_details_to_display?).and_return(true)
+
+      expect(helper.related_instruction_toggle_icon(related_instruction)).to eq "before:content-['+']"
+    end
+  end
+
   describe "#related_instruction_hours_display_class" do
     it "returns invisible if related_instruction hours field is nil" do
       related_instruction = build(:related_instruction, hours: nil)

--- a/spec/helpers/related_instructions_helper_spec.rb
+++ b/spec/helpers/related_instructions_helper_spec.rb
@@ -27,22 +27,6 @@ RSpec.describe RelatedInstructionsHelper, type: :helper do
     end
   end
 
-  describe "#related_instruction_toggle_icon" do
-    it "returns nil if related_instruction has no details to display" do
-      related_instruction = build(:related_instruction)
-      allow(related_instruction).to receive(:has_details_to_display?).and_return(false)
-
-      expect(helper.related_instruction_toggle_icon(related_instruction)).to be_nil
-    end
-
-    it "returns before content if related_instruction has details to display" do
-      related_instruction = build(:related_instruction)
-      allow(related_instruction).to receive(:has_details_to_display?).and_return(true)
-
-      expect(helper.related_instruction_toggle_icon(related_instruction)).to eq "before:content-['+']"
-    end
-  end
-
   describe "#related_instruction_hours_display_class" do
     it "returns invisible if related_instruction hours field is nil" do
       related_instruction = build(:related_instruction, hours: nil)

--- a/spec/helpers/related_instructions_helper_spec.rb
+++ b/spec/helpers/related_instructions_helper_spec.rb
@@ -11,22 +11,6 @@ require "rails_helper"
 #   end
 # end
 RSpec.describe RelatedInstructionsHelper, type: :helper do
-  describe "#related_instruction_accordion_class" do
-    it "returns nil if related_instruction has no details to display" do
-      related_instruction = build(:related_instruction)
-      allow(related_instruction).to receive(:has_details_to_display?).and_return(false)
-
-      expect(helper.related_instruction_accordion_class(related_instruction)).to be_nil
-    end
-
-    it "returns 'accordion' if related_instruction has details to display" do
-      related_instruction = build(:related_instruction)
-      allow(related_instruction).to receive(:has_details_to_display?).and_return(true)
-
-      expect(helper.related_instruction_accordion_class(related_instruction)).to eq "accordion"
-    end
-  end
-
   describe "#related_instruction_hours_display_class" do
     it "returns invisible if related_instruction hours field is nil" do
       related_instruction = build(:related_instruction, hours: nil)

--- a/spec/helpers/work_processes_helper_spec.rb
+++ b/spec/helpers/work_processes_helper_spec.rb
@@ -102,12 +102,12 @@ RSpec.describe WorkProcessesHelper, type: :helper do
     end
   end
 
-  describe "#hours_display_class" do
+  describe "#work_process_hours_display_class" do
     it "returns invisible if work_process hours field is blank" do
       work_process = build(:work_process)
       allow(work_process).to receive(:hours).and_return(nil)
 
-      expect(helper.hours_display_class(work_process)).to eq "invisible"
+      expect(helper.work_process_hours_display_class(work_process)).to eq "invisible"
     end
 
     it "returns invisible if work_process hours is present but the total work process hours is 0" do
@@ -115,7 +115,7 @@ RSpec.describe WorkProcessesHelper, type: :helper do
       allow(work_process).to receive(:hours).and_return(5)
       allow(work_process).to receive(:occupation_standard_work_processes_hours).and_return(0)
 
-      expect(helper.hours_display_class(work_process)).to eq "invisible"
+      expect(helper.work_process_hours_display_class(work_process)).to eq "invisible"
     end
 
     it "returns visible if work_process hours is present and the total work process hours is > 0" do
@@ -123,7 +123,7 @@ RSpec.describe WorkProcessesHelper, type: :helper do
       allow(work_process).to receive(:hours).and_return(5)
       allow(work_process).to receive(:occupation_standard_work_processes_hours).and_return(5)
 
-      expect(helper.hours_display_class(work_process)).to eq "visible"
+      expect(helper.work_process_hours_display_class(work_process)).to eq "visible"
     end
   end
 end

--- a/spec/helpers/work_processes_helper_spec.rb
+++ b/spec/helpers/work_processes_helper_spec.rb
@@ -55,24 +55,24 @@ RSpec.describe WorkProcessesHelper, type: :helper do
     end
   end
 
-  describe "#toggle_icon" do
+  describe "#work_process_toggle_icon" do
     it "returns nil if work_process description is blank and there are no competencies" do
       work_process = build(:work_process, description: nil)
 
-      expect(helper.toggle_icon(work_process)).to be_nil
+      expect(helper.work_process_toggle_icon(work_process)).to be_nil
     end
 
     it "returns before content if work_process description is present but there are no competencies" do
       work_process = build(:work_process, description: "desc")
 
-      expect(helper.toggle_icon(work_process)).to eq "before:content-['+']"
+      expect(helper.work_process_toggle_icon(work_process)).to eq "before:content-['+']"
     end
 
     it "returns before content if work_process description is blank but there are competencies" do
       competency = build(:competency)
       work_process = build_stubbed(:work_process, description: nil, competencies: [competency])
 
-      expect(helper.toggle_icon(work_process)).to eq "before:content-['+']"
+      expect(helper.work_process_toggle_icon(work_process)).to eq "before:content-['+']"
     end
   end
 

--- a/spec/helpers/work_processes_helper_spec.rb
+++ b/spec/helpers/work_processes_helper_spec.rb
@@ -56,21 +56,16 @@ RSpec.describe WorkProcessesHelper, type: :helper do
   end
 
   describe "#work_process_toggle_icon" do
-    it "returns nil if work_process description is blank and there are no competencies" do
-      work_process = build(:work_process, description: nil)
+    it "returns nil if work_process has no details to display" do
+      work_process = build(:work_process)
+      allow(work_process).to receive(:has_details_to_display?).and_return(false)
 
       expect(helper.work_process_toggle_icon(work_process)).to be_nil
     end
 
-    it "returns before content if work_process description is present but there are no competencies" do
-      work_process = build(:work_process, description: "desc")
-
-      expect(helper.work_process_toggle_icon(work_process)).to eq "before:content-['+']"
-    end
-
-    it "returns before content if work_process description is blank but there are competencies" do
-      competency = build(:competency)
-      work_process = build_stubbed(:work_process, description: nil, competencies: [competency])
+    it "returns before content if work_process has details to display" do
+      work_process = build(:work_process)
+      allow(work_process).to receive(:has_details_to_display?).and_return(true)
 
       expect(helper.work_process_toggle_icon(work_process)).to eq "before:content-['+']"
     end

--- a/spec/helpers/work_processes_helper_spec.rb
+++ b/spec/helpers/work_processes_helper_spec.rb
@@ -75,4 +75,44 @@ RSpec.describe WorkProcessesHelper, type: :helper do
       expect(helper.toggle_icon(work_process)).to eq "before:content-['+']"
     end
   end
+
+  describe "#competencies_count_display_class" do
+    it "returns invisible if competencies count is 0" do
+      work_process = build(:work_process)
+
+      expect(helper.competencies_count_display_class(work_process)).to eq "invisible"
+    end
+
+    it "returns visible if competencies count is > 0" do
+      competency = build(:competency)
+      work_process = create(:work_process, competencies: [competency])
+
+      expect(helper.competencies_count_display_class(work_process)).to eq "visible"
+    end
+  end
+
+  describe "#hours_display_class" do
+    it "returns invisible if work_process hours field is blank" do
+      work_process = build(:work_process)
+      allow(work_process).to receive(:hours).and_return(nil)
+
+      expect(helper.hours_display_class(work_process)).to eq "invisible"
+    end
+
+    it "returns invisible if work_process hours is present but the total work process hours is 0" do
+      work_process = build(:work_process)
+      allow(work_process).to receive(:hours).and_return(5)
+      allow(work_process).to receive(:occupation_standard_work_processes_hours).and_return(0)
+
+      expect(helper.hours_display_class(work_process)).to eq "invisible"
+    end
+
+    it "returns visible if work_process hours is present and the total work process hours is > 0" do
+      work_process = build(:work_process)
+      allow(work_process).to receive(:hours).and_return(5)
+      allow(work_process).to receive(:occupation_standard_work_processes_hours).and_return(5)
+
+      expect(helper.hours_display_class(work_process)).to eq "visible"
+    end
+  end
 end

--- a/spec/helpers/work_processes_helper_spec.rb
+++ b/spec/helpers/work_processes_helper_spec.rb
@@ -54,4 +54,25 @@ RSpec.describe WorkProcessesHelper, type: :helper do
       expect(helper.hours_in_human_format(144)).to eq "140"
     end
   end
+
+  describe "#toggle_icon" do
+    it "returns nil if work_process description is blank and there are no competencies" do
+      work_process = build(:work_process, description: nil)
+
+      expect(helper.toggle_icon(work_process)).to be_nil
+    end
+
+    it "returns before content if work_process description is present but there are no competencies" do
+      work_process = build(:work_process, description: "desc")
+
+      expect(helper.toggle_icon(work_process)).to eq "before:content-['+']"
+    end
+
+    it "returns before content if work_process description is blank but there are competencies" do
+      competency = build(:competency)
+      work_process = build_stubbed(:work_process, description: nil, competencies: [competency])
+
+      expect(helper.toggle_icon(work_process)).to eq "before:content-['+']"
+    end
+  end
 end

--- a/spec/helpers/work_processes_helper_spec.rb
+++ b/spec/helpers/work_processes_helper_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe WorkProcessesHelper, type: :helper do
     end
   end
 
+  describe "#work_process_accordion_class" do
+    it "returns nil if work_process has no details to display" do
+      work_process = build(:work_process)
+      allow(work_process).to receive(:has_details_to_display?).and_return(false)
+
+      expect(helper.work_process_accordion_class(work_process)).to be_nil
+    end
+
+    it "returns 'accordion' if work_process has details to display" do
+      work_process = build(:work_process)
+      allow(work_process).to receive(:has_details_to_display?).and_return(true)
+
+      expect(helper.work_process_accordion_class(work_process)).to eq "accordion"
+    end
+  end
+
   describe "#work_process_toggle_icon" do
     it "returns nil if work_process has no details to display" do
       work_process = build(:work_process)

--- a/spec/helpers/work_processes_helper_spec.rb
+++ b/spec/helpers/work_processes_helper_spec.rb
@@ -55,22 +55,6 @@ RSpec.describe WorkProcessesHelper, type: :helper do
     end
   end
 
-  describe "#work_process_accordion_class" do
-    it "returns nil if work_process has no details to display" do
-      work_process = build(:work_process)
-      allow(work_process).to receive(:has_details_to_display?).and_return(false)
-
-      expect(helper.work_process_accordion_class(work_process)).to be_nil
-    end
-
-    it "returns 'accordion' if work_process has details to display" do
-      work_process = build(:work_process)
-      allow(work_process).to receive(:has_details_to_display?).and_return(true)
-
-      expect(helper.work_process_accordion_class(work_process)).to eq "accordion"
-    end
-  end
-
   describe "#competencies_count_display_class" do
     it "returns invisible if competencies count is 0" do
       work_process = build(:work_process)

--- a/spec/helpers/work_processes_helper_spec.rb
+++ b/spec/helpers/work_processes_helper_spec.rb
@@ -71,22 +71,6 @@ RSpec.describe WorkProcessesHelper, type: :helper do
     end
   end
 
-  describe "#work_process_toggle_icon" do
-    it "returns nil if work_process has no details to display" do
-      work_process = build(:work_process)
-      allow(work_process).to receive(:has_details_to_display?).and_return(false)
-
-      expect(helper.work_process_toggle_icon(work_process)).to be_nil
-    end
-
-    it "returns before content if work_process has details to display" do
-      work_process = build(:work_process)
-      allow(work_process).to receive(:has_details_to_display?).and_return(true)
-
-      expect(helper.work_process_toggle_icon(work_process)).to eq "before:content-['+']"
-    end
-  end
-
   describe "#competencies_count_display_class" do
     it "returns invisible if competencies count is 0" do
       work_process = build(:work_process)

--- a/spec/models/related_instruction_spec.rb
+++ b/spec/models/related_instruction_spec.rb
@@ -18,4 +18,24 @@ RSpec.describe RelatedInstruction, type: :model do
     new_related_instruction.code = "T002"
     expect(new_related_instruction).to be_valid
   end
+
+  describe "#has_details_to_display?" do
+    it "is false if description is nil" do
+      related_instruction = build(:related_instruction, description: nil)
+
+      expect(related_instruction).to_not have_details_to_display
+    end
+
+    it "is false if description is empty" do
+      related_instruction = build(:related_instruction, description: "")
+
+      expect(related_instruction).to_not have_details_to_display
+    end
+
+    it "is true if description not blank" do
+      related_instruction = build(:related_instruction, description: "desc")
+
+      expect(related_instruction).to have_details_to_display
+    end
+  end
 end

--- a/spec/models/work_process_spec.rb
+++ b/spec/models/work_process_spec.rb
@@ -26,4 +26,25 @@ RSpec.describe WorkProcess, type: :model do
       expect(work_process.hours).to eq nil
     end
   end
+
+  describe "#has_details_to_display?" do
+    it "returns false if work_process description is blank and there are no competencies" do
+      work_process = build(:work_process, description: nil)
+
+      expect(work_process).to_not have_details_to_display
+    end
+
+    it "returns true if work_process description is present but there are no competencies" do
+      work_process = build(:work_process, description: "desc")
+
+      expect(work_process).to have_details_to_display
+    end
+
+    it "returns true if work_process description is blank but there are competencies" do
+      competency = build(:competency)
+      work_process = build_stubbed(:work_process, description: nil, competencies: [competency])
+
+      expect(work_process).to have_details_to_display
+    end
+  end
 end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1205982289180738/f)

Currently when viewing an occupation standard, the work process and related instruction sections will show the red plus icon to toggle content, even when there is no content to display:

<img width="580" alt="Screenshot 2023-12-04 at 9 29 50 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/87a7ee16-33e9-411c-a978-b2d5bf03a1f5">

This PR refactors the word processes and related instructions tabs to use more of the same code, and does not display empty `details` in the HTML details/summary element when there is nothing to display.

<img width="667" alt="Screenshot 2023-12-04 at 9 31 23 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/fa000e93-192f-4662-9e73-f20d92bb86a9">

<img width="1295" alt="Screenshot 2023-12-04 at 9 32 34 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/0c948b15-1752-47ef-8034-b20552b81209">

