### PR TITLE
Indenting fix for Work Process/Related Instructions

### DIFF
--- a/app/helpers/occupation_standards_helper.rb
+++ b/app/helpers/occupation_standards_helper.rb
@@ -12,6 +12,8 @@ module OccupationStandardsHelper
   def standard_descendants_toggle_icon(record)
     if record.has_details_to_display?
       "before:content-['+']"
+    else
+      "before:content-['•']"
     end
   end
 

--- a/spec/helpers/occupation_standards_helper_spec.rb
+++ b/spec/helpers/occupation_standards_helper_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe OccupationStandardsHelper, type: :helper do
   end
 
   describe "#standard_descendants_toggle_icon" do
-    it "returns nil if related_instruction has no details to display" do
+    it "returns bullet before content if related_instruction has no details to display" do
       related_instruction = build(:related_instruction)
       allow(related_instruction).to receive(:has_details_to_display?).and_return(false)
 
-      expect(helper.standard_descendants_toggle_icon(related_instruction)).to be_nil
+      expect(helper.standard_descendants_toggle_icon(related_instruction)).to eq "before:content-['•']"
     end
 
-    it "returns before content if related_instruction has details to display" do
+    it "returns plus sign before content if related_instruction has details to display" do
       related_instruction = build(:related_instruction)
       allow(related_instruction).to receive(:has_details_to_display?).and_return(true)
 


### PR DESCRIPTION
There is a slight indenting issue for Work Processes or Related Instructions that do not have descriptions as compared with those that do:

<img width="855" alt="Screenshot 2023-12-04 at 11 37 58 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/92d20cf9-5605-48db-bf4f-6199d35ce64b">

This changes uses a bullet as `before-content` for the work processes and related instructions with no description so text
lines up.

I am unable to see the bullet change on my development environment, but believe it is due to a caching
issue or similar. When pushed to staging, the change is visible:

<img width="821" alt="Screenshot 2023-12-04 at 11 47 16 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/de3de485-4745-4b03-8a31-ba20d404324c">


[Asana ticket](https://app.asana.com/0/1203289004376659/1205982289180738/f)
