### PR TITLE
Add macOS Sonoma to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -522,6 +522,7 @@ PLATFORMS
   arm64-darwin-22
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
When running `bundle install`, this gets added if you are using macOS Sonoma
