### PR TITLE
Fix recently added query

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -219,7 +219,7 @@ class OccupationStandard < ApplicationRecord
 
   scope :with_work_processes, -> { joins(:work_processes).distinct }
 
-  scope :recently_added, -> { where.associated(:work_processes).order(created_at: :desc).limit(MAX_RECENTLY_ADDED_OCCUPATIONS_TO_DISPLAY) }
+  scope :recently_added, -> { where.associated(:work_processes).distinct.order(created_at: :desc).limit(MAX_RECENTLY_ADDED_OCCUPATIONS_TO_DISPLAY) }
 
   class << self
     def industry_count(onet_prefix)

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -125,8 +125,10 @@ class OccupationStandardElasticsearchQuery
               end
             end
           end
-          should do
-            term national_standard_type: "occupational_framework"
+          unless search_params[:sort]
+            should do
+              term national_standard_type: "occupational_framework"
+            end
           end
         end
       end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -223,12 +223,12 @@ RSpec.describe OccupationStandard, type: :model do
       expect(described_class.recently_added).to match [second_occupation, third_occupation, first_occupation]
     end
 
-     it "does not return duplicates" do
-       occupation_standard = create(:occupation_standard)
-       create_pair(:work_process, occupation_standard:  occupation_standard)
+    it "does not return duplicates" do
+      occupation_standard = create(:occupation_standard)
+      create_pair(:work_process, occupation_standard: occupation_standard)
 
       expect(described_class.recently_added).to match [occupation_standard]
-     end
+    end
   end
 
   describe ".industry_count" do

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -222,6 +222,13 @@ RSpec.describe OccupationStandard, type: :model do
 
       expect(described_class.recently_added).to match [second_occupation, third_occupation, first_occupation]
     end
+
+     it "does not return duplicates" do
+       occupation_standard = create(:occupation_standard)
+       create_pair(:work_process, occupation_standard:  occupation_standard)
+
+      expect(described_class.recently_added).to match [occupation_standard]
+     end
   end
 
   describe ".industry_count" do

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -373,9 +373,9 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
 
   it "allows using a field to override default sorting" do
     # Occupations with occupational_framework have a better score by default
-    os1 = create(:occupation_standard, :with_work_processes, :occupational_framework, title: "Technical A", created_at: 3.days.ago)
-    os2 = create(:occupation_standard, :with_work_processes, title: "Technical B", created_at: 2.days.ago)
-    os3 = create(:occupation_standard, :with_work_processes, title: "Something else", created_at: 1.day.ago)
+    os1 = create(:occupation_standard, :with_work_processes, title: "Technical B", created_at: 1.day.ago)
+    os2 = create(:occupation_standard, :with_work_processes, title: "Something else", created_at: 2.day.ago)
+    os3 = create(:occupation_standard, :with_work_processes, :occupational_framework, title: "Technical A", created_at: 3.days.ago)
 
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!
@@ -383,12 +383,12 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     params = {}
     response = described_class.new(search_params: params).call
 
-    expect(response.records.pluck(:id)).to eq [os1.id, os3.id, os2.id]
+    expect(response.records.pluck(:id)).to eq [os3.id, os1.id, os2.id]
 
     # We are sorting only by created_at dismissing the score
     params = {sort: :created_at}
     response = described_class.new(search_params: params).call
 
-    expect(response.records.pluck(:id)).to eq [os3.id, os2.id, os1.id]
+    expect(response.records.pluck(:id)).to eq [os1.id, os2.id, os3.id]
   end
 end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1205982289180736/f)

Fixes `OccupationStandard.recently_added` scope to not return duplicates and updates `OccupationStandardElasticsearchQuery` to ignore a condition when overriding sorting
