### PR TITLE
Flipper updates

### DIFF
--- a/db/migrate/20231218194224_change_flipper_gates_value_to_text.rb
+++ b/db/migrate/20231218194224_change_flipper_gates_value_to_text.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ChangeFlipperGatesValueToText < ActiveRecord::Migration[7.1]
+  def up
+    # Ensure this incremental update migration is idempotent
+    return unless connection.column_exists? :flipper_gates, :value, :string
+
+    if index_exists? :flipper_gates, [:feature_key, :key, :value]
+      remove_index :flipper_gates, [:feature_key, :key, :value]
+    end
+    change_column :flipper_gates, :value, :text
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: {value: 255}
+  end
+
+  def down
+    change_column :flipper_gates, :value, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_30_195553) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_18_194224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -115,7 +115,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_195553) do
   create_table "flipper_gates", force: :cascade do |t|
     t.string "feature_key", null: false
     t.string "key", null: false
-    t.string "value"
+    t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true


### PR DESCRIPTION
After upgrading Flipper gem, getting following message:

Your database needs migrated to use the latest Flipper features.
Run `rails generate flipper:update` and `rails db:migrate`.

