### PR TITLE
Fix empty pages of results getting returned

### DIFF
--- a/app/controllers/occupation_standards_controller.rb
+++ b/app/controllers/occupation_standards_controller.rb
@@ -9,10 +9,10 @@ class OccupationStandardsController < ApplicationController
         search_params: search_term_params,
         offset: offset
       ).call
-      @pagy = Pagy.new_from_elasticsearch_rails(
-        es_response,
+      @pagy = Pagy.new(
         items: Pagy::DEFAULT[:items],
-        page: current_page
+        page: current_page,
+        count: es_response.response.aggregations.total.value
       )
       @occupation_standards = add_inner_hits_from_results(es_response.records)
     else

--- a/app/queries/occupation_standard_elasticsearch_query.rb
+++ b/app/queries/occupation_standard_elasticsearch_query.rb
@@ -29,6 +29,9 @@ class OccupationStandardElasticsearchQuery
           by :created_at, order: :desc
         end
       end
+      aggregation :total do
+        cardinality field: "headline"
+      end
       query do
         bool do
           must match_all: {}

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -369,6 +369,8 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     expect(response.results[0].inner_hits.children.first[1].hits[0]._id).to eq os2.id
     expect(response.results[0].inner_hits.children.first[1].hits[1]._id).to eq os1.id
     expect(response.results[1].inner_hits.children.first[1].hits[0]._id).to eq os3.id
+    expect(response.response.hits.total.value).to eq 3
+    expect(response.response.aggregations.total.value).to eq 2
   end
 
   it "allows using a field to override default sorting" do

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe "occupation_standards/index" do
   end
 
   context "when using elasticsearch for search", :elasticsearch do
-    it "displays pagination" do
+    it "displays pagination correctly when no collapsed items" do
       Flipper.enable :use_elasticsearch_for_search
       default_items = Pagy::DEFAULT[:items]
       Pagy::DEFAULT[:items] = 2
@@ -341,6 +341,43 @@ RSpec.describe "occupation_standards/index" do
         click_on "2"
       end
       expect(page).to have_text "HR Specialist"
+
+      Pagy::DEFAULT[:items] = default_items
+      Flipper.disable :use_elasticsearch_for_search
+    end
+
+    it "displays pagination correctly when there are collapsed items" do
+      Flipper.enable :use_elasticsearch_for_search
+      default_items = Pagy::DEFAULT[:items]
+      Pagy::DEFAULT[:items] = 2
+
+      # 2nd page
+      create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR Specialist")
+      create(:occupation_standard, :with_work_processes, :with_data_import, title: "Dental Assistant")
+
+      # 1st page
+      create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter")
+      os1 = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
+      new_wp = create(:work_process, title: os1.work_processes.first.title)
+      os2 = create(:occupation_standard, :with_data_import, work_processes: [new_wp], title: "Mechanic")
+
+      OccupationStandard.import
+      OccupationStandard.__elasticsearch__.refresh_index!
+
+      visit occupation_standards_path
+
+      expect(page).to have_text "Mechanic"
+      expect(page).to have_text "Pipe Fitter"
+      expect(page).to_not have_text "HR Specialist"
+      expect(page).to_not have_text "Dental Assistant"
+
+      within(".pagy-nav") do
+        expect(page).to have_link "2", href: occupation_standards_path(page: 2)
+        expect(page).to_not have_link "3"
+        click_on "2"
+      end
+      expect(page).to have_text "HR Specialist"
+      expect(page).to have_text "Dental Assistant"
 
       Pagy::DEFAULT[:items] = default_items
       Flipper.disable :use_elasticsearch_for_search

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe "occupation_standards/index" do
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter")
       os1 = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
       new_wp = create(:work_process, title: os1.work_processes.first.title)
-      os2 = create(:occupation_standard, :with_data_import, work_processes: [new_wp], title: "Mechanic")
+      _os2 = create(:occupation_standard, :with_data_import, work_processes: [new_wp], title: "Mechanic")
 
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1205789710514920/f)

Several blank pages of results are getting displayed in the UI due to the usage of the `collapse` feature. The total `hits` value is getting used as the count of total records, but that `hits` value does not account for records that have been collapsed. Instead, aggregating on the `headline` field gives us the correct total records.

Since the only Elasticsearch-related code in the Pagy `new_from_elasticsearch_rails` method is code used to compute the total number of pages from the `hits` value, we can replace that call with just instantiating a new `Pagy` instance instead, passing the correct aggregated total.