### PR TITLE
Method of retrieving duplicates depends on using ES for search or not

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -341,9 +341,10 @@ class OccupationStandard < ApplicationRecord
   end
 
   # #duplicates is used in OccupationStandardsController#index
-  # It gets the values from ES collapse if feature flag enabled
+  # It gets the values from ES collapse to display in the Expand Duplicates
+  # section.
   def duplicates
-    if Flipper.enabled?(:similar_programs_elasticsearch)
+    if Flipper.enabled?(:use_elasticsearch_for_search)
       inner_hits&.reject { |hit| hit.id == id } || []
     else
       similar_programs_deprecated

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -441,7 +441,7 @@ RSpec.describe OccupationStandard, type: :model do
   describe "#duplicates" do
     context "with the similar_programs_elasticsearch flag enabled" do
       it "returns from OccupationStandard#inner_hits excluding self" do
-        stub_feature_flag(:similar_programs_elasticsearch, true)
+        stub_feature_flag(:use_elasticsearch_for_search, true)
 
         occupation_standard = create(:occupation_standard)
         duplicate_inner_hit = create(:inner_hit, id: "1", title: "Duplicate")
@@ -456,7 +456,7 @@ RSpec.describe OccupationStandard, type: :model do
 
     context "with the similar_programs_elasticsearch flag disabled" do
       it "returns occupations that match the title regardless of capitalization" do
-        stub_feature_flag(:similar_programs_elasticsearch, false)
+        stub_feature_flag(:use_elasticsearch_for_search, false)
 
         occupation_standard = create(:occupation_standard, title: "Human Resource Specialist")
         similar_program1 = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
@@ -467,7 +467,7 @@ RSpec.describe OccupationStandard, type: :model do
       end
 
       it "returns up to MAX_SIMILAR_PROGRAMS_TO_DISPLAY occupations" do
-        stub_feature_flag(:similar_programs_elasticsearch, false)
+        stub_feature_flag(:use_elasticsearch_for_search, false)
 
         stub_const("OccupationStandard::MAX_SIMILAR_PROGRAMS_TO_DISPLAY", 1)
         occupation_standard = create(:occupation_standard, title: "Human Resource Specialist")
@@ -477,7 +477,7 @@ RSpec.describe OccupationStandard, type: :model do
       end
 
       it "excludes itself" do
-        stub_feature_flag(:similar_programs_elasticsearch, false)
+        stub_feature_flag(:use_elasticsearch_for_search, false)
         occupation_standard = create(:occupation_standard, title: "Human Resource Specialist")
 
         expect(occupation_standard.duplicates).to be_empty

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -811,8 +811,9 @@ RSpec.describe "occupation_standards/index" do
 
     it "expands similar results accordion when accordion button is clicked", js: true do
       Flipper.enable :use_elasticsearch_for_search
-      create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
-      create(:occupation_standard, :with_work_processes, :with_data_import, :program_standard, title: "Mechanic")
+      os = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
+      new_wp = create(:work_process, title: os.work_processes.first.title)
+      create(:occupation_standard, :with_data_import, :program_standard, work_processes: [new_wp], title: "Mechanic")
 
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!
@@ -827,8 +828,9 @@ RSpec.describe "occupation_standards/index" do
 
     it "closes similar results accordion when accordion button is clicked", js: true do
       Flipper.enable :use_elasticsearch_for_search
-      create(:occupation_standard, :with_work_processes, :with_data_import, :program_standard, title: "Mechanic")
-      mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
+      os = create(:occupation_standard, :with_work_processes, :with_data_import, :program_standard, title: "Mechanic")
+      new_wp = create(:work_process, title: os.work_processes.first.title)
+      mechanic = create(:occupation_standard, :with_data_import, work_processes: [new_wp], title: "Mechanic")
 
       OccupationStandard.import
       OccupationStandard.__elasticsearch__.refresh_index!


### PR DESCRIPTION
As we made the Expand Duplicates a permanent feature, the query used to find those duplicates should now depend on whether or not we are using Elasticsearch for search or not. The `similar_programs_elasticsearch` flag is for a separate query to return similar programs to display on the `occupation_standards#show` page.

[Asana ticket](https://app.asana.com/0/1203289004376659/1206186965082982/f)
