### PR TITLE
Fix N+1 issue on occupation_standards#index page

### DIFF
--- a/app/controllers/occupation_standards_controller.rb
+++ b/app/controllers/occupation_standards_controller.rb
@@ -14,7 +14,12 @@ class OccupationStandardsController < ApplicationController
         page: current_page,
         count: es_response.response.aggregations.total.value
       )
-      @occupation_standards = add_inner_hits_from_results(es_response.records)
+      occupation_standards_array = add_inner_hits_from_results(es_response.records)
+      @occupation_standards = OccupationStandard
+        .includes(
+          :organization, :work_processes, :occupation, registration_agency: :state
+        )
+        .where(id: occupation_standards_array.map(&:id))
     else
       @occupation_standards_search = OccupationStandardQuery::Container.new(
         search_term_params: search_term_params

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -83,6 +83,24 @@ RSpec.describe "OccupationStandard", type: :request do
           expect(response).to be_successful
           Flipper.disable :use_elasticsearch_for_search
         end
+
+        it "does not have any N+1 queries" do
+          Flipper.enable :use_elasticsearch_for_search
+
+          org = create(:organization)
+          os = create(:occupation_standard, :with_work_processes, :with_data_import, organization: org)
+          new_wp = build(:work_process, title: os.work_processes.first.title)
+          create(:occupation_standard, :with_data_import, work_processes: [new_wp], organization: org)
+          create(:occupation_standard, :with_work_processes, :with_data_import, organization: org)
+
+          OccupationStandard.import
+          OccupationStandard.__elasticsearch__.refresh_index!
+
+          get occupation_standards_path
+
+          expect(response).to be_successful
+          Flipper.disable :use_elasticsearch_for_search
+        end
       end
     end
 


### PR DESCRIPTION
The inner hits method collects occupation standard records into an array, but then we end up with some N+1 queries. This re-collects the occupation standards in an Active Record relation so we can take advantage of `includes`.