### PR TITLE
Revert "Fix N+1 issue on occupation_standards#index page (#553)"

### DIFF
--- a/app/controllers/occupation_standards_controller.rb
+++ b/app/controllers/occupation_standards_controller.rb
@@ -14,12 +14,7 @@ class OccupationStandardsController < ApplicationController
         page: current_page,
         count: es_response.response.aggregations.total.value
       )
-      occupation_standards_array = add_inner_hits_from_results(es_response.records)
-      @occupation_standards = OccupationStandard
-        .includes(
-          :organization, :work_processes, :occupation, registration_agency: :state
-        )
-        .where(id: occupation_standards_array.map(&:id))
+      @occupation_standards = add_inner_hits_from_results(es_response.records)
     else
       @occupation_standards_search = OccupationStandardQuery::Container.new(
         search_term_params: search_term_params

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -83,24 +83,6 @@ RSpec.describe "OccupationStandard", type: :request do
           expect(response).to be_successful
           Flipper.disable :use_elasticsearch_for_search
         end
-
-        it "does not have any N+1 queries" do
-          Flipper.enable :use_elasticsearch_for_search
-
-          org = create(:organization)
-          os = create(:occupation_standard, :with_work_processes, :with_data_import, organization: org)
-          new_wp = build(:work_process, title: os.work_processes.first.title)
-          create(:occupation_standard, :with_data_import, work_processes: [new_wp], organization: org)
-          create(:occupation_standard, :with_work_processes, :with_data_import, organization: org)
-
-          OccupationStandard.import
-          OccupationStandard.__elasticsearch__.refresh_index!
-
-          get occupation_standards_path
-
-          expect(response).to be_successful
-          Flipper.disable :use_elasticsearch_for_search
-        end
       end
     end
 


### PR DESCRIPTION
When re-collecting the occupation standards into an Active Record collection, we lose the inner hits data that was collected.

The specs were erroneously passing before because the `similar_programs_elasticsearch` flag was being used to turn that section on or off, and since the flag was not set, it used a DB query to get similar programs, rather than Elasticsearch. But merging #551 caused the specs to start failing.