### PR TITLE
Use stub feature flag method

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,3 +278,6 @@ You can turn on a feature flag by running:
 and check if it's enabled with:
 
 `Flipper.enabled?(:search) # true`
+
+When writing specs, there is a helper method to use:
+`stub_feature_flag(:my_feature_flag, <boolean value>)`.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -80,4 +80,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.flipper.strict = false
 end

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -34,8 +34,6 @@ describe Rack::Attack do
 
   describe "throttle excessive ip requests" do
     it "changes the request status to 429 when higher than limit" do
-      Flipper.enable(:updated_home)
-
       travel_to Time.current do
         300.times do |i|
           get "/", {}, {"REMOTE_ADDR" => "103.1.3.1}"}
@@ -48,8 +46,6 @@ describe Rack::Attack do
         expect(last_response.status).to eq(429)
         expect(last_response.body).to include("Retry later")
       end
-
-      Flipper.disable(:updated_home)
     end
   end
 

--- a/spec/requests/contact_requests_spec.rb
+++ b/spec/requests/contact_requests_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "ContactRequest", type: :request do
   describe "POST /create" do
     context "with valid params and decent Google recaptcha score" do
       it "creates a contact_request record" do
-        Flipper.enable :recaptcha
+        stub_feature_flag(:recaptcha, true)
         stub_recaptcha_high_score
 
         expect {
@@ -32,13 +32,12 @@ RSpec.describe "ContactRequest", type: :request do
         expect(contact.organization).to eq "Disney"
         expect(contact.message).to eq "We are happy"
         expect(response).to redirect_to guest_root_path
-        Flipper.disable :recaptcha
       end
     end
 
     context "with valid params and recaptcha flag false" do
       it "creates a contact_request record" do
-        Flipper.disable :recaptcha
+        stub_feature_flag(:recaptcha, false)
 
         expect {
           post contact_requests_path, params: {
@@ -62,7 +61,7 @@ RSpec.describe "ContactRequest", type: :request do
 
     context "with valid params and poor Google recaptcha score" do
       it "does not create a contact_request record" do
-        Flipper.enable :recaptcha
+        stub_feature_flag(:recaptcha, true)
         stub_recaptcha_low_score
 
         expect {
@@ -78,13 +77,12 @@ RSpec.describe "ContactRequest", type: :request do
         }.to_not change(ContactRequest, :count)
 
         expect(response).to redirect_to guest_root_path
-        Flipper.disable :recaptcha
       end
     end
 
     context "with valid params and unsuccessful recaptcha score" do
       it "does not create a contact_request record and reports error" do
-        Flipper.enable :recaptcha
+        stub_feature_flag(:recaptcha, true)
         stub_recaptcha_failure
 
         expect_any_instance_of(ErrorSubscriber).to receive(:report).and_call_original
@@ -101,13 +99,12 @@ RSpec.describe "ContactRequest", type: :request do
         }.to_not change(ContactRequest, :count)
 
         expect(response).to redirect_to guest_root_path
-        Flipper.disable :recaptcha
       end
     end
 
     context "with invalid params" do
       it "does not creates a contact_request record" do
-        Flipper.enable :recaptcha
+        stub_feature_flag(:recaptcha, true)
         stub_recaptcha_high_score
 
         expect {
@@ -123,7 +120,6 @@ RSpec.describe "ContactRequest", type: :request do
         }.to_not change(ContactRequest, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
-        Flipper.disable :recaptcha
       end
     end
   end

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -15,18 +15,17 @@ RSpec.describe "OccupationStandard", type: :request do
 
       context "with ES search", :elasticsearch do
         it "makes one Elasticsearch query if no search params" do
-          Flipper.enable :use_elasticsearch_for_search
+          stub_feature_flag(:use_elasticsearch_for_search, true)
           create(:occupation_standard, :with_work_processes, :with_data_import)
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
           get occupation_standards_path
 
           expect(response).to be_successful
-          Flipper.disable :use_elasticsearch_for_search
         end
 
         it "makes one Elasticsearch query if only filter params" do
-          Flipper.enable :use_elasticsearch_for_search
+          stub_feature_flag(:use_elasticsearch_for_search, true)
           state = create(:state)
           ra = create(:registration_agency, state: state)
           create(:occupation_standard, :with_work_processes, :with_data_import, registration_agency: ra)
@@ -35,44 +34,40 @@ RSpec.describe "OccupationStandard", type: :request do
           get occupation_standards_path(state_id: state.id)
 
           expect(response).to be_successful
-          Flipper.disable :use_elasticsearch_for_search
         end
 
         it "makes one Elasticsearch query if search params does not start with letter" do
-          Flipper.enable :use_elasticsearch_for_search
+          stub_feature_flag(:use_elasticsearch_for_search, true)
           create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "15-1234.00")
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
           get occupation_standards_path(q: "15")
 
           expect(response).to be_successful
-          Flipper.disable :use_elasticsearch_for_search
         end
 
         it "makes two Elasticsearch queries if search params start with letter" do
-          Flipper.enable :use_elasticsearch_for_search
+          stub_feature_flag(:use_elasticsearch_for_search, true)
           create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).twice.and_call_original
           get occupation_standards_path(q: "Mechanic")
 
           expect(response).to be_successful
-          Flipper.disable :use_elasticsearch_for_search
         end
 
         it "makes one Elasticsearch query if search params start with letter but onet_prefix is included in the search params" do
-          Flipper.enable :use_elasticsearch_for_search
+          stub_feature_flag(:use_elasticsearch_for_search, true)
           create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
           get occupation_standards_path(q: "Mechanic", onet_prefix: "15-1234")
 
           expect(response).to be_successful
-          Flipper.disable :use_elasticsearch_for_search
         end
 
         it "does not include onet_prefix in 2nd query if first hit has no onet code" do
-          Flipper.enable :use_elasticsearch_for_search
+          stub_feature_flag(:use_elasticsearch_for_search, true)
           create(:occupation_standard, :with_work_processes, :with_data_import, onet_code: nil, title: "Mechanic")
 
           search_params = ActionController::Parameters.new({q: "Mechanic"}).permit!
@@ -81,7 +76,6 @@ RSpec.describe "OccupationStandard", type: :request do
           get occupation_standards_path(q: "Mechanic")
 
           expect(response).to be_successful
-          Flipper.disable :use_elasticsearch_for_search
         end
       end
     end

--- a/spec/requests/standards_imports_spec.rb
+++ b/spec/requests/standards_imports_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "StandardsImports", type: :request do
     context "with valid parameters and decent Google recaptcha score" do
       context "when guest" do
         it "creates new standards import record, redirects to show page, and notifies admin" do
-          Flipper.enable :recaptcha
+          stub_feature_flag(:recaptcha, true)
           stub_recaptcha_high_score
 
           expect_any_instance_of(StandardsImport).to receive(:notify_admin)
@@ -47,13 +47,12 @@ RSpec.describe "StandardsImports", type: :request do
           expect(source_file).to be_courtesy_notification_pending
 
           expect(response).to redirect_to standards_import_path(si)
-          Flipper.disable :recaptcha
         end
       end
 
       context "when admin", :admin do
         it "creates new standards import record, redirects to source files page, and does not notify admin" do
-          Flipper.enable :recaptcha
+          stub_feature_flag(:recaptcha, true)
           admin = create(:admin)
 
           sign_in admin
@@ -88,7 +87,6 @@ RSpec.describe "StandardsImports", type: :request do
           expect(source_file).to be_courtesy_notification_not_required
 
           expect(response).to redirect_to admin_source_files_path
-          Flipper.disable :recaptcha
         end
       end
     end
@@ -96,7 +94,7 @@ RSpec.describe "StandardsImports", type: :request do
     context "with valid parameters and poor Google recaptcha score" do
       context "when guest" do
         it "does not create new standards import record" do
-          Flipper.enable :recaptcha
+          stub_feature_flag(:recaptcha, true)
           stub_recaptcha_low_score
 
           expect_any_instance_of(StandardsImport).to_not receive(:notify_admin)
@@ -114,7 +112,6 @@ RSpec.describe "StandardsImports", type: :request do
           }.to_not change(StandardsImport, :count)
 
           expect(response).to redirect_to guest_root_path
-          Flipper.disable :recaptcha
         end
       end
     end
@@ -122,7 +119,7 @@ RSpec.describe "StandardsImports", type: :request do
     context "with valid parameters and unsuccessful recaptcha score" do
       context "when guest" do
         it "does not create new standards import record and reports error" do
-          Flipper.enable :recaptcha
+          stub_feature_flag(:recaptcha, true)
           stub_recaptcha_failure
 
           expect_any_instance_of(StandardsImport).to_not receive(:notify_admin)
@@ -141,14 +138,13 @@ RSpec.describe "StandardsImports", type: :request do
           }.to_not change(StandardsImport, :count)
 
           expect(response).to redirect_to guest_root_path
-          Flipper.disable :recaptcha
         end
       end
     end
 
     context "with invalid parameters" do
       it "does not create new standards import record and renders new" do
-        Flipper.enable :recaptcha
+        stub_feature_flag(:recaptcha, true)
         stub_recaptcha_high_score
 
         expect {
@@ -163,7 +159,6 @@ RSpec.describe "StandardsImports", type: :request do
         }.to_not change(StandardsImport, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
-        Flipper.disable :recaptcha
       end
     end
   end

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -4,6 +4,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     Flipper.add(:use_elasticsearch_for_search)
     Flipper.add(:show_recently_added_section)
+    Flipper.add(:recaptcha)
   end
 
   config.include Helpers::StubFeatureFlags

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -3,6 +3,7 @@ require "./spec/support/helpers/stub_feature_flags"
 RSpec.configure do |config|
   config.before(:suite) do
     Flipper.add(:use_elasticsearch_for_search)
+    Flipper.add(:show_recently_added_section)
   end
 
   config.include Helpers::StubFeatureFlags

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -2,9 +2,10 @@ require "./spec/support/helpers/stub_feature_flags"
 
 RSpec.configure do |config|
   config.before(:suite) do
-    Flipper.add(:use_elasticsearch_for_search)
-    Flipper.add(:show_recently_added_section)
     Flipper.add(:recaptcha)
+    Flipper.add(:show_recently_added_section)
+    Flipper.add(:similar_programs_elasticsearch)
+    Flipper.add(:use_elasticsearch_for_search)
   end
 
   config.include Helpers::StubFeatureFlags

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -1,5 +1,9 @@
 require "./spec/support/helpers/stub_feature_flags"
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    Flipper.add(:use_elasticsearch_for_search)
+  end
+
   config.include Helpers::StubFeatureFlags
 end

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -1,12 +1,5 @@
 require "./spec/support/helpers/stub_feature_flags"
 
 RSpec.configure do |config|
-  config.before(:suite) do
-    Flipper.add(:recaptcha)
-    Flipper.add(:show_recently_added_section)
-    Flipper.add(:similar_programs_elasticsearch)
-    Flipper.add(:use_elasticsearch_for_search)
-  end
-
   config.include Helpers::StubFeatureFlags
 end

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe "occupation_standards/index" do
 
   context "when using elasticsearch for search", :elasticsearch do
     it "displays pagination correctly when no collapsed items" do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       default_items = Pagy::DEFAULT[:items]
       Pagy::DEFAULT[:items] = 2
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR Specialist")
@@ -343,7 +343,6 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_text "HR Specialist"
 
       Pagy::DEFAULT[:items] = default_items
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "displays pagination correctly when there are collapsed items" do
@@ -384,7 +383,7 @@ RSpec.describe "occupation_standards/index" do
     end
 
     it "filters standards based on search term" do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       dental = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Dental Assistant", onet_code: "12-3456.01")
       medical = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Medical Assistant", onet_code: "12-9876.00")
       create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Other Assistant With Different ONET Code Prefix", onet_code: "13-9876.00")
@@ -406,11 +405,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_link "Medical Assistant", href: occupation_standard_path(medical)
       expect(page).to_not have_link "Pipe Fitter"
       expect(page).to_not have_link "Other Assistant"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "can handle a search that returns no results" do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
 
       OccupationStandard.import
@@ -425,12 +423,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_text "Showing Results for Assistant"
       expect(page).to have_field("q", with: "Assistant")
       expect(page).to_not have_link "Mechanic"
-
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "filters standards based on rapids_code search term" do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", rapids_code: "1234")
       pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", rapids_code: "1234CB")
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR", rapids_code: "9876")
@@ -450,11 +446,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_link "Mechanic", href: occupation_standard_path(mechanic)
       expect(page).to have_link "Pipe Fitter", href: occupation_standard_path(pipe_fitter)
       expect(page).to_not have_link "HR"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "filters standards based on onet_code search term" do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR", onet_code: "12.34")
@@ -474,11 +469,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_link "Mechanic", href: occupation_standard_path(mechanic)
       expect(page).to have_link "Pipe Fitter", href: occupation_standard_path(pipe_fitter)
       expect(page).to_not have_link "HR"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "filters standards based on onet_code search term and state filter", :js do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       wa = create(:state, name: "Washington")
       ra = create(:registration_agency, state: wa)
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
@@ -503,11 +497,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_link "Mechanic", href: occupation_standard_path(mechanic)
       expect(page).to_not have_link "Pipe Fitter"
       expect(page).to_not have_link "HR"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "filters standards based on onet_code search term and national_standard_type filter", :js do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       mechanic = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :guideline_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -537,11 +530,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_link "Medical Assistant", href: occupation_standard_path(medical_assistant)
       expect(page).to_not have_link "Pipe Fitter"
       expect(page).to_not have_link "HR"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "filters standards based on onet_code search term and ojt_type filter", :js do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -570,11 +562,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_link "Medical Assistant", href: occupation_standard_path(medical_assistant)
       expect(page).to_not have_link "Pipe Fitter"
       expect(page).to_not have_link "HR"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "filters standards with state shortcode" do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       washington = create(:state, name: "Washington", abbreviation: "WA")
       washington_registration_agency = create(:registration_agency, state: washington)
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: washington_registration_agency)
@@ -596,11 +587,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_link "Mechanic", href: occupation_standard_path(mechanic)
       expect(page).to_not have_link "Pipe Fitter"
       expect(page).to_not have_link "HR"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "filters standards with national_standard_type shortcode" do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       mechanic = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       create(:occupation_standard, :with_work_processes, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :guideline_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -623,11 +613,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "Medical Assistant"
       expect(page).to_not have_link "Pipe Fitter"
       expect(page).to_not have_link "HR"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "filters standards with ojt_type shortcode" do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       create(:occupation_standard, :with_work_processes, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -648,11 +637,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_link "Medical Assistant"
       expect(page).to_not have_link "Pipe Fitter"
       expect(page).to_not have_link "HR"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "can clear form", :js do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       wa = create(:state, name: "Washington")
       ra = create(:registration_agency, state: wa)
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
@@ -722,11 +710,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_link "Mechanic", href: occupation_standard_path(mechanic)
       expect(page).to have_link "Medical Assistant", href: occupation_standard_path(medical_assistant)
       expect(page).to have_link "Pipe Fitter"
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "shows suggestions based on occupation title", :js do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       mechanic = create(:occupation, title: "Mechanic")
       pipe_fitter = create(:occupation, title: "Pipe Fitter")
       pippen_apple_collector = create(:occupation, title: "Pippen Apple Collector")
@@ -759,11 +746,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to_not have_selector "div", class: "tt-suggestion", text: mechanic.display_for_typeahead
       expect(page).to have_selector "div", class: "tt-suggestion", text: pipe_fitter.display_for_typeahead
       expect(page).to_not have_selector "div", class: "tt-suggestion", text: pippen_apple_collector.display_for_typeahead
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "shows suggestions based on onet code", :js do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       mechanic_onet = create(:onet, code: "12-1234")
       mechanic = create(:occupation, title: "Mechanic", onet: mechanic_onet)
       pipe_fitter_onet = create(:onet, code: "51-6789")
@@ -780,11 +766,10 @@ RSpec.describe "occupation_standards/index" do
 
       expect(page).to have_selector "div", class: "tt-suggestion", text: mechanic.display_for_typeahead
       expect(page).to_not have_selector "div", class: "tt-suggestion", text: pipe_fitter.display_for_typeahead
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "shows suggestions based on rapids code", :js do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       mechanic = create(:occupation, title: "Mechanic", rapids_code: "9108")
       pipe_fitter = create(:occupation, title: "Pipe Fitter", rapids_code: "1582")
 
@@ -799,12 +784,10 @@ RSpec.describe "occupation_standards/index" do
 
       expect(page).to have_selector "div", class: "tt-suggestion", text: mechanic.display_for_typeahead
       expect(page).to_not have_selector "div", class: "tt-suggestion", text: pipe_fitter.display_for_typeahead
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     xit "adds onet prefix to search when clicking on typeahead result", :js do
-      Flipper.enable :use_elasticsearch_for_search
-      Flipper.enable :similar_programs_elasticsearch
+      stub_feature_flag(:use_elasticsearch_for_search, true)
 
       mechanic_onet = create(:onet, code: "12-3456")
       mechanic = create(:occupation, title: "Mechanic", onet: mechanic_onet)
@@ -842,12 +825,10 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_no_text "Mechanic One"
       expect(page).to have_text "Mechanic Two"
       expect(page).to have_no_text "Mechanic Three"
-      Flipper.disable :use_elasticsearch_for_search
-      Flipper.disable :similar_programs_elasticsearch
     end
 
     it "expands similar results accordion when accordion button is clicked", js: true do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       os = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
       new_wp = create(:work_process, title: os.work_processes.first.title)
       create(:occupation_standard, :with_data_import, :program_standard, work_processes: [new_wp], title: "Mechanic")
@@ -860,11 +841,10 @@ RSpec.describe "occupation_standards/index" do
       find('button[data-action="click->accordion#changeVisibility"]', match: :first).click
 
       expect(page).to have_selector(:button, "Collapse duplicates")
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "closes similar results accordion when accordion button is clicked", js: true do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       os = create(:occupation_standard, :with_work_processes, :with_data_import, :program_standard, title: "Mechanic")
       new_wp = create(:work_process, title: os.work_processes.first.title)
       mechanic = create(:occupation_standard, :with_data_import, work_processes: [new_wp], title: "Mechanic")
@@ -878,11 +858,10 @@ RSpec.describe "occupation_standards/index" do
       click_on "Collapse duplicates"
 
       expect(page).not_to have_selector("#accordion-#{mechanic.id}")
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "displays toolip on hover", js: true do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       occupation = create(:occupation, time_based_hours: 2000)
       occupation_standard = create(:occupation_standard, :with_data_import, occupation: occupation)
       create(:work_process, maximum_hours: 1000, occupation_standard: occupation_standard)
@@ -895,7 +874,6 @@ RSpec.describe "occupation_standards/index" do
       find("button[data-tooltip-target='hours-alert-#{occupation_standard.id}']").hover
 
       expect(page).to have_text "Hours do not meet minimum OA standard for this occupation"
-      Flipper.disable :use_elasticsearch_for_search
     end
   end
 end

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe "occupation_standards/index" do
     end
 
     it "displays pagination correctly when there are collapsed items" do
-      Flipper.enable :use_elasticsearch_for_search
+      stub_feature_flag(:use_elasticsearch_for_search, true)
       default_items = Pagy::DEFAULT[:items]
       Pagy::DEFAULT[:items] = 2
 
@@ -379,7 +379,6 @@ RSpec.describe "occupation_standards/index" do
       expect(page).to have_text "Dental Assistant"
 
       Pagy::DEFAULT[:items] = default_items
-      Flipper.disable :use_elasticsearch_for_search
     end
 
     it "filters standards based on search term" do

--- a/spec/system/pages/home_spec.rb
+++ b/spec/system/pages/home_spec.rb
@@ -109,10 +109,9 @@ RSpec.describe "pages/home" do
   end
 
   context "with Elasticsearch enabled", :elasticsearch do
-    around(:each) do |example|
-      Flipper.enable(:use_elasticsearch_for_search)
-      example.run
-      Flipper.disable(:use_elasticsearch_for_search)
+    before(:each) do |example|
+      stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_recently_added_section, true)
     end
 
     it "filters occupations based on search term" do
@@ -279,9 +278,13 @@ RSpec.describe "pages/home" do
   end
 
   describe "Recently Added" do
-    it "displays a link to a search of occupation standards sorted by creation date" do
-      Flipper.enable :show_recently_added_section
+    before(:each) do |example|
+      stub_feature_flag(:show_recently_added_section, true)
+      stub_feature_flag(:similar_programs_elasticsearch, false)
+      stub_feature_flag(:use_elasticsearch_for_search, false)
+    end
 
+    it "displays a link to a search of occupation standards sorted by creation date" do
       create(:occupation_standard, :with_work_processes, :with_data_import, national_standard_type: :guideline_standard, title: "Mechanic")
 
       visit home_page_path
@@ -289,13 +292,9 @@ RSpec.describe "pages/home" do
       click_link("See All", href: "/occupation_standards?sort=created_at")
 
       expect(page).to have_text "Mechanic"
-
-      Flipper.disable :show_recently_added_section
     end
 
     it "displays a link to latest occupation standard" do
-      Flipper.enable :show_recently_added_section
-
       create(:occupation_standard, :with_work_processes, :with_data_import, national_standard_type: :guideline_standard, title: "Mechanic")
 
       visit home_page_path
@@ -303,7 +302,6 @@ RSpec.describe "pages/home" do
       click_on("Mechanic")
 
       expect(page).to have_text "Mechanic"
-      Flipper.disable :show_recently_added_section
     end
   end
 end


### PR DESCRIPTION
There is a `stub_feature_flag` that is not being used. This method avoids extra hits to the database. This also turns off warnings about feature flags not being pre-defined in the system for test environment.