### PR TITLE
Update document when importing completed

### DIFF
--- a/app/jobs/process_data_import_job.rb
+++ b/app/jobs/process_data_import_job.rb
@@ -47,5 +47,9 @@ class ProcessDataImportJob < ApplicationJob
     if last_file
       data_import.source_file.completed!
     end
+
+    # We need to reload the occupation prior to update ES for the application to have all the updated data
+    occupation_standard.reload
+    occupation_standard.update_document
   end
 end

--- a/app/models/concerns/elasticsearchable.rb
+++ b/app/models/concerns/elasticsearchable.rb
@@ -9,14 +9,18 @@ module Elasticsearchable
     end
 
     after_commit on: [:update] do
-      unless elasticsearch_disabled?
-        __elasticsearch__.update_document
-      end
+      update_document
     end
 
     after_commit on: [:destroy] do
       unless elasticsearch_disabled?
         __elasticsearch__.delete_document
+      end
+    end
+
+    def update_document
+      unless elasticsearch_disabled?
+        __elasticsearch__.update_document
       end
     end
   end

--- a/spec/jobs/process_data_import_job_spec.rb
+++ b/spec/jobs/process_data_import_job_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe ProcessDataImportJob, type: :job do
       ).and_return(work_processes_mock)
       expect(work_processes_mock).to receive(:call)
 
+      expect_any_instance_of(OccupationStandard).to receive(:update_document).twice
+
       described_class.new.perform(data_import: data_import)
 
       expect(data_import.source_file).to be_pending


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206163711596811/f)

When importing an Occupation Standard, we add the entry to ElasticSearch the first time we create the occupation, but we never updated.

This PR add a call to update_document to make sure we reindex the Occupation Standard with the updated information
