### PR TITLE
Call perform_later directly on ActiveJob class

### DIFF
--- a/app/jobs/scraper/apprenticeship_bulletins_job.rb
+++ b/app/jobs/scraper/apprenticeship_bulletins_job.rb
@@ -29,7 +29,7 @@ class Scraper::ApprenticeshipBulletinsJob < ApplicationJob
               date: row["Date"]
             }
           )
-          Scraper::ExportFileAttachmentsJob.new.perform_later(source_file)
+          Scraper::ExportFileAttachmentsJob.perform_later(source_file)
         end
       end
     end

--- a/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
+++ b/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe Scraper::ApprenticeshipBulletinsJob, type: :job do
     context "when files have not been downloaded previously" do
       it "downloads any file to a standards import record" do
         stub_responses
-        service = double("service", perform_later: nil)
-        expect(Scraper::ExportFileAttachmentsJob).to receive(:new).and_return(service).exactly(6)
-        expect(service).to receive(:perform_later).with(kind_of(SourceFile))
+        expect(Scraper::ExportFileAttachmentsJob).to receive(:perform_later).with(kind_of(SourceFile)).exactly(6).times
         perform_enqueued_jobs do
           expect {
             described_class.new.perform
@@ -34,9 +32,7 @@ RSpec.describe Scraper::ApprenticeshipBulletinsJob, type: :job do
         name: "https://www.apprenticeship.gov/sites/default/files/bulletins/Bulletin_2016-22.pdf",
         organization: "Wildland Fire Fighter Specialist")
       stub_responses
-      service = double("service", perform_later: nil)
-      expect(Scraper::ExportFileAttachmentsJob).to receive(:new).and_return(service).exactly(5)
-      expect(service).to receive(:perform_later).with(kind_of(SourceFile))
+      expect(Scraper::ExportFileAttachmentsJob).to receive(:perform_later).with(kind_of(SourceFile)).exactly(5).times
       perform_enqueued_jobs do
         expect {
           described_class.new.perform


### PR DESCRIPTION
For ActiveJobs, we should call `perform_now` or `perform_later` directly on the class method.
