### PR TITLE
Install libreoffice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   tzdata \
   vim \
   yarn \
+  libreoffice \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ brew install mailcatcher
 
 [mailcatcher_brew]: https://formulae.brew.sh/formula/mailcatcher
 
+### Libreoffice
+
+
+If you want to convert doc and docx documents to PDF, you can install install [libreoffice][libreoffice] with [brew][libreoffice_brew]:
+
+```bash
+brew install --cask libreoffice
+```
+
+[libreoffice]: https://www.libreoffice.org/
+[libreoffice_brew]: https://formulae.brew.sh/cask/libreoffice#default
+
 ## Staging access
 [Staging information](https://www.notion.so/Engineering-f05ed81462494b80946bf83df50cb400)
 


### PR DESCRIPTION
libreoffice allows to convert docx to pdf via a command-line utility

```
soffice  --headless --convert-to pdf test.docx --outdir .
```

Once libreoffice is installed, we can do some testing to integrate the `soffice` command-line conversion with Ruby