### PR TITLE
The system makes clear the list of source files that need to be redacted

### DIFF
--- a/app/controllers/admin/source_files_controller.rb
+++ b/app/controllers/admin/source_files_controller.rb
@@ -1,7 +1,11 @@
 module Admin
   class SourceFilesController < Admin::ApplicationController
     def scoped_resource
-      SourceFile.includes(:assignee, :data_imports, active_storage_attachment: [:blob, :record]).order(created_at: :desc)
+      if params[:ready_for_redaction]
+        SourceFile.preload(active_storage_attachment: [:record]).ready_for_redaction
+      else
+        SourceFile.includes(:assignee, :data_imports, active_storage_attachment: [:blob, :record]).order(created_at: :desc)
+      end
     end
 
     def after_resource_updated_path(resource)

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -8,6 +8,8 @@ class SourceFile < ApplicationRecord
   enum :status, [:pending, :completed, :needs_support, :needs_human_review]
   enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true
 
+  PDF_CONTENT_TYPE = "application/pdf"
+
   def filename
     active_storage_attachment.blob.filename
   end
@@ -43,7 +45,7 @@ class SourceFile < ApplicationRecord
   end
 
   def pdf?
-    active_storage_attachment.blob.content_type == "application/pdf"
+    active_storage_attachment.blob.content_type == PDF_CONTENT_TYPE
   end
 
   def redacted_source_file_url
@@ -59,6 +61,16 @@ class SourceFile < ApplicationRecord
       redacted_at: (
         start_time..end_time
       )
+    )
+  end
+
+  def self.pdf_attachment
+    includes(active_storage_attachment: :blob).where(
+      active_storage_attachment: {
+        active_storage_blobs: {
+          content_type: PDF_CONTENT_TYPE
+        }
+      }
     )
   end
 end

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -81,4 +81,8 @@ class SourceFile < ApplicationRecord
       }
     )
   end
+
+  def self.ready_for_redaction
+    completed.not_redacted.pdf_attachment
+  end
 end

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -73,4 +73,12 @@ class SourceFile < ApplicationRecord
       }
     )
   end
+
+  def self.not_redacted
+    includes(:redacted_source_file_attachment).where(
+      redacted_source_file_attachment: {
+        id: nil
+      }
+    )
+  end
 end

--- a/app/policies/source_file_policy.rb
+++ b/app/policies/source_file_policy.rb
@@ -23,9 +23,9 @@ class SourceFilePolicy < ApplicationPolicy
 
   def permitted_attributes
     if user.converter?
-      [:status, :assignee_id]
+      [:status, :assignee_id, :ready_for_redaction]
     else
-      [:status, :assignee_id, :metadata, :public_document, :courtesy_notification]
+      [:status, :assignee_id, :metadata, :public_document, :courtesy_notification, :ready_for_redaction]
     end
   end
 end

--- a/app/views/admin/source_files/_index_header.html.erb
+++ b/app/views/admin/source_files/_index_header.html.erb
@@ -17,7 +17,7 @@
   <% else %>
     <%= link_to(
           "Only show files ready for redaction",
-          admin_source_files_path(ready_for_redaction: true),
+          url_for(ready_for_redaction: true),
           class: "button"
         ) %>
     <% end %>

--- a/app/views/admin/source_files/_index_header.html.erb
+++ b/app/views/admin/source_files/_index_header.html.erb
@@ -7,6 +7,22 @@
     <%= content_for(:title) %>
   </h1>
 
+  <div>
+    <% if params[:ready_for_redaction] %>
+      <%= link_to(
+            "Show all files",
+            admin_source_files_path,
+            class: "button"
+          ) %>
+  <% else %>
+    <%= link_to(
+          "Only show files ready for redaction",
+          admin_source_files_path(ready_for_redaction: true),
+          class: "button"
+        ) %>
+    <% end %>
+  </div>
+
   <% if show_search_bar %>
     <%= render(
           "search",
@@ -24,5 +40,4 @@
           ) %>
     <% end %>
   </div>
-
 </header>

--- a/spec/factories/source_files.rb
+++ b/spec/factories/source_files.rb
@@ -26,5 +26,19 @@ FactoryBot.define do
         ).first
       end
     end
+
+    trait :without_redacted_source_file do
+      redacted_source_file { nil }
+    end
+
+    trait :with_redacted_source_file do
+      redacted_source_file {
+        Rack::Test::UploadedFile.new(
+          Rails.root.join(
+            "spec", "fixtures", "files", "pixel1x1.pdf"
+          )
+        )
+      }
+    end
   end
 end

--- a/spec/factories/source_files.rb
+++ b/spec/factories/source_files.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
 
     trait :with_pdf_attachment do
       initialize_with do
-        standards_import = create(:standards_import, :with_pdf_file_with_attachments)
+        standards_import = create(:standards_import, :with_pdf_file)
         SourceFile.where(
           active_storage_attachment: standards_import.files.first
         ).first

--- a/spec/factories/source_files.rb
+++ b/spec/factories/source_files.rb
@@ -8,5 +8,23 @@ FactoryBot.define do
         active_storage_attachment: standards_import.files.first
       ).first
     end
+
+    trait :with_docx_attachment do
+      initialize_with do
+        standards_import = create(:standards_import, :with_docx_file_with_attachments)
+        SourceFile.where(
+          active_storage_attachment: standards_import.files.first
+        ).first
+      end
+    end
+
+    trait :with_pdf_attachment do
+      initialize_with do
+        standards_import = create(:standards_import, :with_pdf_file_with_attachments)
+        SourceFile.where(
+          active_storage_attachment: standards_import.files.first
+        ).first
+      end
+    end
   end
 end

--- a/spec/factories/standards_imports.rb
+++ b/spec/factories/standards_imports.rb
@@ -8,6 +8,10 @@ FactoryBot.define do
       files { [Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "docx_file_attachments.docx"))] }
     end
 
+    trait :with_pdf_file_with_attachments do
+      files { [Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"))] }
+    end
+
     to_create do |obj, _context|
       obj.save!
       CreateSourceFilesJob.perform_now(obj)

--- a/spec/factories/standards_imports.rb
+++ b/spec/factories/standards_imports.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
       files { [Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "docx_file_attachments.docx"))] }
     end
 
-    trait :with_pdf_file_with_attachments do
+    trait :with_pdf_file do
       files { [Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"))] }
     end
 

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -168,4 +168,13 @@ RSpec.describe SourceFile, type: :model do
       expect(described_class.pdf_attachment).to match_array [source_file_with_pdf_attachment]
     end
   end
+
+  describe ".not_redacted" do
+    it "returns only source file without redacted source file" do
+      create(:source_file, :with_redacted_source_file)
+      source_file_without_redacted_source_file = create(:source_file, :without_redacted_source_file)
+
+      expect(described_class.not_redacted).to match_array [source_file_without_redacted_source_file]
+    end
+  end
 end

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -159,4 +159,13 @@ RSpec.describe SourceFile, type: :model do
       expect(described_class.recently_redacted(start_time: start_time, end_time: end_time)).to match_array recent_records
     end
   end
+
+  describe ".pdf_attachment" do
+    it "returns only source file with pdf as attachment" do
+      create(:source_file, :with_docx_attachment)
+      source_file_with_pdf_attachment = create(:source_file, :with_pdf_attachment)
+
+      expect(described_class.pdf_attachment).to match_array [source_file_with_pdf_attachment]
+    end
+  end
 end

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -177,4 +177,30 @@ RSpec.describe SourceFile, type: :model do
       expect(described_class.not_redacted).to match_array [source_file_without_redacted_source_file]
     end
   end
+
+  describe ".ready_for_redaction" do
+    it "returns only source files without attachment, completed and pdf files" do
+      source_file_with_all_conditions = create(:source_file,
+        :with_pdf_attachment,
+        :without_redacted_source_file,
+        :completed)
+
+      _source_file_not_complete = create(:source_file,
+        :with_pdf_attachment,
+        :without_redacted_source_file,
+        :pending)
+
+      _source_file_with_docx_attachment = create(:source_file,
+        :with_docx_attachment,
+        :without_redacted_source_file,
+        :completed)
+
+      _source_file_with_redacted_source_file = create(:source_file,
+        :with_pdf_attachment,
+        :with_redacted_source_file,
+        :completed)
+
+      expect(described_class.ready_for_redaction).to match_array [source_file_with_all_conditions]
+    end
+  end
 end

--- a/spec/system/admin/source_files/index_spec.rb
+++ b/spec/system/admin/source_files/index_spec.rb
@@ -253,5 +253,87 @@ RSpec.describe "admin/source_files/index", :admin do
       expect(page).to have_text "Amy Applebaum"
       expect(page).to_not have_button "Claim"
     end
+
+    it "shows a link to filter files ready for redaction" do
+      source_file_with_all_conditions = create(:source_file,
+        :with_pdf_attachment,
+        :without_redacted_source_file,
+        :completed)
+
+      source_file_not_complete = create(:source_file,
+        :with_pdf_attachment,
+        :without_redacted_source_file,
+        :pending)
+
+      source_file_with_docx_attachment = create(:source_file,
+        :with_docx_attachment,
+        :without_redacted_source_file,
+        :completed)
+
+      source_file_with_redacted_source_file = create(:source_file,
+        :with_pdf_attachment,
+        :with_redacted_source_file,
+        :completed)
+
+      admin = create(:user, :converter)
+
+      login_as admin
+      visit admin_source_files_path
+
+      expect(page).to have_link(
+        source_file_with_all_conditions.filename,
+        href: admin_source_file_path(source_file_with_all_conditions.id)
+      )
+      expect(page).to have_link(
+        source_file_not_complete.filename,
+        href: admin_source_file_path(source_file_not_complete.id)
+      )
+      expect(page).to have_link(
+        source_file_with_docx_attachment.filename,
+        href: admin_source_file_path(source_file_with_docx_attachment.id)
+      )
+      expect(page).to have_link(
+        source_file_with_redacted_source_file.filename,
+        href: admin_source_file_path(source_file_with_redacted_source_file.id)
+      )
+
+      click_link "Only show files ready for redaction"
+
+      expect(page).to have_link(
+        source_file_with_all_conditions.filename,
+        href: admin_source_file_path(source_file_with_all_conditions.id)
+      )
+      expect(page).to_not have_link(
+        source_file_not_complete.filename,
+        href: admin_source_file_path(source_file_not_complete.id)
+      )
+      expect(page).to_not have_link(
+        source_file_with_docx_attachment.filename,
+        href: admin_source_file_path(source_file_with_docx_attachment.id)
+      )
+      expect(page).to_not have_link(
+        source_file_with_redacted_source_file.filename,
+        href: admin_source_file_path(source_file_with_redacted_source_file.id)
+      )
+
+      click_link "Show all files"
+
+      expect(page).to have_link(
+        source_file_with_all_conditions.filename,
+        href: admin_source_file_path(source_file_with_all_conditions.id)
+      )
+      expect(page).to have_link(
+        source_file_not_complete.filename,
+        href: admin_source_file_path(source_file_not_complete.id)
+      )
+      expect(page).to have_link(
+        source_file_with_docx_attachment.filename,
+        href: admin_source_file_path(source_file_with_docx_attachment.id)
+      )
+      expect(page).to have_link(
+        source_file_with_redacted_source_file.filename,
+        href: admin_source_file_path(source_file_with_redacted_source_file.id)
+      )
+    end
   end
 end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206305102472868/f)

* Add a link in Source File admin dashboard to filter sources files that have a PDF file, are completed, and don't have a redacted file version yet

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/b2372c7f-9a9b-407c-9598-7a356f739a9a)

