### PR TITLE
Add bin/elasticsearch script

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: bin/rails server -p 3000
 css: bin/rails tailwindcss:watch
-elasticsearch:  elasticsearch
+elasticsearch: bin/elasticsearch
 mailcatcher: mailcatcher --foreground

--- a/bin/elasticsearch
+++ b/bin/elasticsearch
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if curl -s localhost:9200 >> /dev/null; then
+  echo "elasticsearch already running. Not attempting to start"
+  tail -f /dev/null
+else
+  elasticsearch
+fi


### PR DESCRIPTION
Just a super tiny script to detect if ES is already running before attempting to start it. I've been running ES in docker but commenting out that line of `Procfile.dev` to avoid a conflict. Hopefully this simplifies things a bit for future devs! 


