### PR TITLE
Hide archived source files by default

### DIFF
--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -104,6 +104,15 @@ RSpec.describe SourceFile, type: :model do
     end
   end
 
+  describe ".not_archived" do
+    it "returns records which don't have an archived status" do
+      _archived = create(:source_file, status: "archived")
+      pending = create(:source_file, status: "pending")
+
+      expect(described_class.not_archived.pluck(:id)).to eql([pending.id])
+    end
+  end
+
   describe "#needs_courtesy_notification?" do
     it "is false if status is pending" do
       source_file = build(:source_file, :pending)

--- a/spec/requests/admin/source_files_spec.rb
+++ b/spec/requests/admin/source_files_spec.rb
@@ -34,6 +34,30 @@ RSpec.describe "Admin::SourceFiles", type: :request do
           expect(response).to redirect_to new_user_session_path
         end
       end
+
+      it "filters out archived source files by default" do
+        sign_in(create(:admin))
+        archived = create(:source_file, status: "archived")
+        pending = create(:source_file, status: "pending")
+
+        get(admin_source_files_path)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(pending.id)
+        expect(response.body).not_to include(archived.id)
+      end
+
+      it "allows filtering by status" do
+        sign_in(create(:admin))
+        pending = create(:source_file, status: "pending")
+        archived = create(:source_file, status: "archived")
+
+        get(admin_source_files_path(search: "archived"))
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(archived.id)
+        expect(response.body).not_to include(pending.id)
+      end
     end
 
     context "on non-admin subdomain" do


### PR DESCRIPTION
On the admin source files index page, archived files are now hidden unless you explicitly search for them.

[Asana ticket](https://app.asana.com/0/1203289004376659/1206228142308915)
