### PR TITLE
Add explanatory text to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ We are using [erb_lint][erb_lint] for ERB linting. To check the style of all
 `.erb` files, run:
 
 ```
-bundle exec erblint --lint-all
+bundle exec erblint --lint-all --autocorrect
 ```
 
 [standard]: https://github.com/testdouble/standard

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -17,6 +17,21 @@
     </div>
   </div>
 </section>
+
+<section class="bg-accent-300">
+  <div class="py-8 sm:py-16 px-4 lg:px-6 max-w-screen-xl mx-auto">
+    The Registered Apprenticeship Standards Library is a comprehensive collection
+    of approved apprenticeship programs from across the country. Explore
+    thousands of apprenticeship program training standards and use them as a
+    starting point to accelerate the development of your apprenticeship program.
+    <%= link_to(
+          "Learn more about the library.",
+          about_page_path,
+          class: "font-bold text-accent-50 sm:text-lg"
+        ) %>
+  </div>
+</section>
+
 <section aria-labelledby="section-title" class="bg-accent-300">
   <div class="py-8 sm:py-16 px-4 lg:px-6 max-w-screen-xl mx-auto">
     <h2 class="section-title sr-only">Embedded video to introduce the Registered Apprenticeship Standards Library</h2>


### PR DESCRIPTION
Add a little blurb explaining what the site is. I just copied styles from other sections here so hopefully it all matches

mobile
<img src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/5241003/afa57c88-a0fd-4551-9b89-0bdc112d856c" height=600>

desktop
![Screenshot 2024-01-25 at 5 07 04 PM](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/5241003/cd82865b-cb16-434b-a099-0c1181cb1feb)

[Asana ticket](https://app.asana.com/0/1203289004376659/1206398384307493)
