### PR TITLE
SourceFile associated occupation standards should be unique

### DIFF
--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -3,7 +3,7 @@ class SourceFile < ApplicationRecord
   belongs_to :assignee, class_name: "User", optional: true
   belongs_to :original_source_file, class_name: "SourceFile", optional: true
   has_many :data_imports, -> { includes(:occupation_standard, file_attachment: :blob) }
-  has_many :associated_occupation_standards, through: :data_imports, source: :occupation_standard
+  has_many :associated_occupation_standards, -> { distinct }, through: :data_imports, source: :occupation_standard
   has_one_attached :redacted_source_file
 
   enum :status, [:pending, :completed, :needs_support, :needs_human_review, :archived]

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -113,6 +113,17 @@ RSpec.describe SourceFile, type: :model do
     end
   end
 
+  describe "#associated_occupation_standards" do
+    it "returns unique occupation standards" do
+      source_file = create(:source_file)
+      data_import = create(:data_import, source_file: source_file)
+      occupation_standard = data_import.occupation_standard
+      create(:data_import, source_file: source_file, occupation_standard: occupation_standard)
+
+      expect(source_file.associated_occupation_standards).to eq [occupation_standard]
+    end
+  end
+
   describe "#needs_courtesy_notification?" do
     it "is false if status is pending" do
       source_file = build(:source_file, :pending)


### PR DESCRIPTION
Some source_files have multiple data_imports that
link to the same import file, resulting in
duplicate occupation standards getting returned.

Related to [Asana ticket](https://app.asana.com/0/1203289004376659/1205982289180740/f)

Fixes:
<img width="805" alt="Screenshot 2024-02-06 at 1 36 43 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/2d941ba5-ce8a-4f93-99d7-8505c45e62fa">
