### PR TITLE
Fix more swagger deprecations

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -6,7 +6,7 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join("swagger").to_s
+  config.openapi_root = Rails.root.join("swagger").to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
@@ -14,7 +14,7 @@ RSpec.configure do |config|
   # By default, the operations defined in spec files are added to the first
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
-  config.swagger_docs = {
+  config.openapi_specs = {
     "v1/swagger.yaml" => {
       openapi: "3.0.1",
       info: {
@@ -52,5 +52,5 @@ RSpec.configure do |config|
   # The swagger_docs configuration option has the filename including format in
   # the key, this may want to be changed to avoid putting yaml in json files.
   # Defaults to json. Accepts ':json' and ':yaml'.
-  config.swagger_format = :yaml
+  config.openapi_format = :yaml
 end


### PR DESCRIPTION
Fixes:

```
DEPRECATION WARNING: swagger_root= is deprecated and will be removed from rswag-specs 3.0 (use openapi_root= instead) (called from block in <main> at ApprenticeshipStandardsDotOrg/spec/swagger_helper.rb:9)
DEPRECATION WARNING: swagger_docs= is deprecated and will be removed from rswag-specs 3.0 (use openapi_specs= instead) (called from block in <main> at ApprenticeshipStandardsDotOrg/spec/swagger_helper.rb:17)
DEPRECATION WARNING: swagger_format= is deprecated and will be removed from rswag-specs 3.0 (use openapi_format= instead) (called from block in <main> at ApprenticeshipStandardsDotOrg/spec/swagger_helper.rb:55)
```
