### PR TITLE
Finish tying up docx to pdf conversion

### DIFF
--- a/app/controllers/standards_imports_controller.rb
+++ b/app/controllers/standards_imports_controller.rb
@@ -25,7 +25,7 @@ class StandardsImportsController < ApplicationController
   end
 
   def show
-    @standards_import = StandardsImport.includes(files_attachments: :blob).find(params[:id])
+    @standards_import = StandardsImport.includes(files_attachments: [:blob, source_file: :original_source_file]).find(params[:id])
   end
 
   private

--- a/app/jobs/create_source_files_job.rb
+++ b/app/jobs/create_source_files_job.rb
@@ -12,7 +12,7 @@ class CreateSourceFilesJob < ApplicationJob
       courtesy_notification = standards_import.courtesy_notification
       Rails.error.handle do
         SourceFile.transaction do
-          source_file = SourceFile
+          SourceFile
             .create_with(courtesy_notification:)
             .find_or_create_by!(active_storage_attachment_id: file.id)
             .tap { maybe_link_to_original_source_file(_1, linkable_docx_files) }

--- a/app/jobs/create_source_files_job.rb
+++ b/app/jobs/create_source_files_job.rb
@@ -16,7 +16,7 @@ class CreateSourceFilesJob < ApplicationJob
             .create_with(courtesy_notification:)
             .find_or_create_by!(active_storage_attachment_id: file.id)
             .tap { maybe_link_to_original_source_file(_1, linkable_docx_files) }
-          DocToPdfConverter.convert(source_file)
+          DocToPdfConverterJob.perform_later(source_file)
         end
       end
     end

--- a/app/jobs/create_source_files_job.rb
+++ b/app/jobs/create_source_files_job.rb
@@ -12,10 +12,11 @@ class CreateSourceFilesJob < ApplicationJob
       courtesy_notification = standards_import.courtesy_notification
       Rails.error.handle do
         SourceFile.transaction do
-          SourceFile
+          source_file = SourceFile
             .create_with(courtesy_notification:)
             .find_or_create_by!(active_storage_attachment_id: file.id)
             .tap { maybe_link_to_original_source_file(_1, linkable_docx_files) }
+          DocToPdfConverter.convert(source_file)
         end
       end
     end

--- a/app/jobs/create_source_files_job.rb
+++ b/app/jobs/create_source_files_job.rb
@@ -16,7 +16,6 @@ class CreateSourceFilesJob < ApplicationJob
             .create_with(courtesy_notification:)
             .find_or_create_by!(active_storage_attachment_id: file.id)
             .tap { maybe_link_to_original_source_file(_1, linkable_docx_files) }
-          DocToPdfConverterJob.perform_later(source_file)
         end
       end
     end

--- a/app/jobs/create_source_files_job.rb
+++ b/app/jobs/create_source_files_job.rb
@@ -34,7 +34,8 @@ class CreateSourceFilesJob < ApplicationJob
       source_file.update!(original_source_file:)
       original_source_file.update!(
         link_to_pdf_filename: nil,
-        status: :archived
+        status: :archived,
+        courtesy_notification: :not_required
       )
     end
   end

--- a/app/jobs/doc_to_pdf_converter_job.rb
+++ b/app/jobs/doc_to_pdf_converter_job.rb
@@ -1,0 +1,7 @@
+class DocToPdfConverterJob < ApplicationJob
+  queue_as :default
+
+  def perform(source_file)
+    DocToPdfConverter.convert(source_file)
+  end
+end

--- a/app/models/concerns/active_storage_attachment_extension.rb
+++ b/app/models/concerns/active_storage_attachment_extension.rb
@@ -6,6 +6,6 @@ module ActiveStorageAttachmentExtension
   end
 
   def has_linked_original_file?
-    source_file.original_source_file.present?
+    source_file&.original_source_file.present?
   end
 end

--- a/app/models/concerns/active_storage_attachment_extension.rb
+++ b/app/models/concerns/active_storage_attachment_extension.rb
@@ -4,4 +4,8 @@ module ActiveStorageAttachmentExtension
   included do
     has_one :source_file, foreign_key: :active_storage_attachment_id, dependent: :destroy
   end
+
+  def has_linked_original_file?
+    source_file.original_source_file.present?
+  end
 end

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -9,6 +9,8 @@ class SourceFile < ApplicationRecord
   enum :status, [:pending, :completed, :needs_support, :needs_human_review, :archived]
   enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true
 
+  after_create :convert_doc_file_to_pdf
+
   PDF_CONTENT_TYPE = "application/pdf"
 
   def self.pdf_attachment
@@ -97,5 +99,13 @@ class SourceFile < ApplicationRecord
 
   def file_for_redaction
     redacted_source_file.attached? ? redacted_source_file : active_storage_attachment
+  end
+
+  private
+
+  def convert_doc_file_to_pdf
+    if docx?
+      DocToPdfConverterJob.perform_later(self)
+    end
   end
 end

--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -1,7 +1,7 @@
 class StandardsImport < ApplicationRecord
   has_many_attached :files
 
-  after_commit :create_source_files
+  after_save_commit :create_source_files
 
   enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true
 

--- a/app/services/doc_to_pdf_converter.rb
+++ b/app/services/doc_to_pdf_converter.rb
@@ -18,6 +18,7 @@ class DocToPdfConverter
   end
 
   def convert
+    return unless source_file.docx?
     raise DependencyNotFoundError unless Kernel.system("command -v soffice")
     dir = ensure_dir
 

--- a/app/views/standards_imports/show.html.erb
+++ b/app/views/standards_imports/show.html.erb
@@ -51,6 +51,7 @@
           <div class="mb-4">
             <div class="show-label">Files</div>
             <% @standards_import.files.each do |file| %>
+              <% next if file.has_linked_original_file? %>
               <div class="w-full mb-1">
                 <%= link_to file.filename.to_s, url_for(file), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
               </div>

--- a/spec/jobs/create_source_files_job_spec.rb
+++ b/spec/jobs/create_source_files_job_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe CreateSourceFilesJob, "#perform", type: :job do
     expect(source_file2.active_storage_attachment).to eq import.files.last
   end
 
-  it "calls DocToPdfConverter service" do
+  it "calls DocToPdfConverter job" do
     file = file_fixture("document.docx")
     import = create(:standards_import, files: [file])
     SourceFile.destroy_all # Remove source files created from factory
 
-    expect(DocToPdfConverter).to receive(:convert).once
+    expect(DocToPdfConverterJob).to receive(:perform_later).once
 
     described_class.new.perform(import)
   end

--- a/spec/jobs/create_source_files_job_spec.rb
+++ b/spec/jobs/create_source_files_job_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe CreateSourceFilesJob, "#perform", type: :job do
   end
 
   it "links a new pdf source file to its original docx version" do
-    allow(DocToPdfConverter).to receive(:convert).and_return(nil)
     docx_file = file_fixture("document.docx")
     pdf_file = file_fixture("pixel1x1.pdf")
     import = create(:standards_import, files: [docx_file, pdf_file])

--- a/spec/jobs/create_source_files_job_spec.rb
+++ b/spec/jobs/create_source_files_job_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe CreateSourceFilesJob, "#perform", type: :job do
   it "links a new pdf source file to its original docx version" do
     docx_file = file_fixture("document.docx")
     pdf_file = file_fixture("pixel1x1.pdf")
-    import = create(:standards_import, files: [docx_file, pdf_file])
+    import = create(:standards_import, files: [docx_file, pdf_file], courtesy_notification: :pending, name: "Mickey", email: "mouse@example.com")
     docx = import.source_files.find(&:docx?)
     pdf = import.source_files.find(&:pdf?)
     docx.update!(link_to_pdf_filename: "pixel1x1.pdf")
@@ -82,7 +82,8 @@ RSpec.describe CreateSourceFilesJob, "#perform", type: :job do
     expect(import.reload.source_files.size).to eql(2)
     expect(docx.reload).to have_attributes(
       status: "archived",
-      link_to_pdf_filename: nil
+      link_to_pdf_filename: nil,
+      courtesy_notification: "not_required"
     )
     pdf = import.source_files.find(&:pdf?)
     expect(pdf.original_source_file_id).to eql(docx.id)

--- a/spec/jobs/create_source_files_job_spec.rb
+++ b/spec/jobs/create_source_files_job_spec.rb
@@ -17,12 +17,21 @@ RSpec.describe CreateSourceFilesJob, "#perform", type: :job do
     expect(source_file2.active_storage_attachment).to eq import.files.last
   end
 
-  it "calls DocToPdfConverter job" do
+  it "calls DocToPdfConverter job if new record" do
     file = file_fixture("document.docx")
     import = create(:standards_import, files: [file])
     SourceFile.destroy_all # Remove source files created from factory
 
     expect(DocToPdfConverterJob).to receive(:perform_later).once
+
+    described_class.new.perform(import)
+  end
+
+  it "does not call DocToPdfConverter job if source file is persisted" do
+    file = file_fixture("document.docx")
+    import = create(:standards_import, files: [file])
+
+    expect(DocToPdfConverterJob).to_not receive(:perform_later)
 
     described_class.new.perform(import)
   end

--- a/spec/jobs/doc_to_pdf_converter_job_spec.rb
+++ b/spec/jobs/doc_to_pdf_converter_job_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DocToPdfConverterJob, "#perform", type: :job do
   it "calls DocToPdfConverter service" do

--- a/spec/jobs/doc_to_pdf_converter_job_spec.rb
+++ b/spec/jobs/doc_to_pdf_converter_job_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe DocToPdfConverterJob, "#perform", type: :job do
+  it "calls DocToPdfConverter service" do
+    source_file = create(:source_file)
+
+    expect(DocToPdfConverter).to receive(:convert).with(source_file)
+
+    described_class.new.perform(source_file)
+  end
+end

--- a/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
+++ b/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Scraper::ApprenticeshipBulletinsJob, type: :job do
         stub_responses
         expect(Scraper::ExportFileAttachmentsJob).to receive(:perform_later).with(kind_of(SourceFile)).exactly(6).times
         perform_enqueued_jobs do
+          allow(DocToPdfConverter).to receive(:convert).and_return(nil)
           expect {
             described_class.new.perform
           }.to change(StandardsImport, :count).by(6)
@@ -34,6 +35,7 @@ RSpec.describe Scraper::ApprenticeshipBulletinsJob, type: :job do
       stub_responses
       expect(Scraper::ExportFileAttachmentsJob).to receive(:perform_later).with(kind_of(SourceFile)).exactly(5).times
       perform_enqueued_jobs do
+        allow(DocToPdfConverter).to receive(:convert).and_return(nil)
         expect {
           described_class.new.perform
         }.to change(StandardsImport, :count).by(5)

--- a/spec/jobs/scraper/export_file_attachments_job_spec.rb
+++ b/spec/jobs/scraper/export_file_attachments_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Scraper::ExportFileAttachmentsJob do
       source_file = SourceFile.last
 
       perform_enqueued_jobs do
+        allow(DocToPdfConverter).to receive(:convert).and_return(nil)
         expect { described_class.new.perform(source_file) }
           .to change { StandardsImport.count }.by(1)
           .and change { StandardsImport.last.files.count }.by(6)
@@ -19,6 +20,7 @@ RSpec.describe Scraper::ExportFileAttachmentsJob do
         source_file = SourceFile.last
 
         perform_enqueued_jobs do
+          allow(DocToPdfConverter).to receive(:convert).and_return(nil)
           expect { described_class.new.perform(source_file) }
             .to change { StandardsImport.count }.by(0)
         end

--- a/spec/models/active_storage_attachment_spec.rb
+++ b/spec/models/active_storage_attachment_spec.rb
@@ -30,5 +30,12 @@ RSpec.describe ActiveStorage::Attachment, type: :model do
 
       expect(attachment).to_not have_linked_original_file
     end
+
+    it "is false if no linked source file" do
+      source_file = create(:source_file)
+      attachment = source_file.active_storage_attachment
+
+      expect(attachment).to_not have_linked_original_file
+    end
   end
 end

--- a/spec/models/active_storage_attachment_spec.rb
+++ b/spec/models/active_storage_attachment_spec.rb
@@ -13,4 +13,22 @@ RSpec.describe ActiveStorage::Attachment, type: :model do
     expect { attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
     expect { source_file.reload }.to raise_error(ActiveRecord::RecordNotFound)
   end
+
+  describe "#has_linked_original_file?" do
+    it "is true if source file has original_source_file present" do
+      original_source_file = create(:source_file)
+      source_file = create(:source_file)
+      source_file.update!(original_source_file: original_source_file)
+      attachment = source_file.active_storage_attachment
+
+      expect(attachment).to have_linked_original_file
+    end
+
+    it "is false if source file does not have original_source_file present" do
+      source_file = create(:source_file)
+      attachment = source_file.active_storage_attachment
+
+      expect(attachment).to_not have_linked_original_file
+    end
+  end
 end

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -113,6 +113,20 @@ RSpec.describe SourceFile, type: :model do
     end
   end
 
+  describe "#convert_doc_file_to_pdf" do
+    it "calls DocToPdfConverter job on create if docx file" do
+      expect(DocToPdfConverterJob).to receive(:perform_later)
+
+      create(:source_file, :docx)
+    end
+
+    it "does not call DocToPdfConverter job on create if not docx file" do
+      expect(DocToPdfConverterJob).to_not receive(:perform_later)
+
+      create(:source_file, :pdf)
+    end
+  end
+
   describe "#associated_occupation_standards" do
     it "returns unique occupation standards" do
       source_file = create(:source_file)

--- a/spec/services/doc_to_pdf_converter_spec.rb
+++ b/spec/services/doc_to_pdf_converter_spec.rb
@@ -14,15 +14,6 @@ RSpec.describe DocToPdfConverter do
 
       described_class.convert_all
     end
-
-    it "doesn't convert a source file which already had a redacted_source_file" do
-      source_file = create(:source_file, :with_redacted_source_file)
-      expect(described_class::ConvertJob)
-        .not_to receive(:perform_later)
-        .with(source_file)
-
-      described_class.convert_all
-    end
   end
 
   describe ".convert" do

--- a/spec/services/doc_to_pdf_converter_spec.rb
+++ b/spec/services/doc_to_pdf_converter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe DocToPdfConverter do
     end
 
     it "raises if libreoffice not installed" do
-      source_file = create(:source_file)
+      source_file = create(:source_file, :docx)
       stub_soffice_install(installed: false)
 
       expect {
@@ -59,7 +59,7 @@ RSpec.describe DocToPdfConverter do
 
     it "raises if conversion failed" do
       with_tmp_dir do |dir|
-        source_file = create(:source_file)
+        source_file = create(:source_file, :docx)
         allow(DocxFile).to receive(:has_embedded_files?).and_return(false)
         stub_soffice_install
         stub_soffice_conversion(successful: false)

--- a/spec/services/doc_to_pdf_converter_spec.rb
+++ b/spec/services/doc_to_pdf_converter_spec.rb
@@ -3,8 +3,13 @@ require "rails_helper"
 RSpec.describe DocToPdfConverter do
   describe ".convert_all" do
     it "converts docx files" do
+      # Turn off the auto-conversion that happens in the CreateSourceFilesJob
+      # so we can test this service directly
+      allow(described_class).to receive(:convert).and_return(nil)
       pdf = create(:source_file, :pdf)
       docx = create(:source_file, :docx)
+      allow(described_class).to receive(:convert).and_call_original
+
       expect(described_class::ConvertJob)
         .not_to receive(:perform_later)
         .with(pdf)
@@ -19,7 +24,12 @@ RSpec.describe DocToPdfConverter do
   describe ".convert" do
     it "converts a docx to a pdf" do
       with_tmp_dir do |tmp_dir|
+        # Turn off the auto-conversion that happens in the CreateSourceFilesJob
+        # so we can test this service directly
+        allow(described_class).to receive(:convert).and_return(nil)
         source_file = create(:source_file, :docx)
+        allow(described_class).to receive(:convert).and_call_original
+
         import = source_file.standards_import
         attachment = source_file.active_storage_attachment
         stub_soffice_install
@@ -49,7 +59,12 @@ RSpec.describe DocToPdfConverter do
     end
 
     it "raises if libreoffice not installed" do
-      source_file = create(:source_file)
+      # Turn off the auto-conversion that happens in the CreateSourceFilesJob
+      # so we can test this service directly
+      allow(described_class).to receive(:convert).and_return(nil)
+      source_file = create(:source_file, :docx)
+      allow(described_class).to receive(:convert).and_call_original
+
       stub_soffice_install(installed: false)
 
       expect {
@@ -59,7 +74,12 @@ RSpec.describe DocToPdfConverter do
 
     it "raises if conversion failed" do
       with_tmp_dir do |dir|
-        source_file = create(:source_file)
+        # Turn off the auto-conversion that happens in the CreateSourceFilesJob
+        # so we can test this service directly
+        allow(described_class).to receive(:convert).and_return(nil)
+        source_file = create(:source_file, :docx)
+        allow(described_class).to receive(:convert).and_call_original
+
         allow(DocxFile).to receive(:has_embedded_files?).and_return(false)
         stub_soffice_install
         stub_soffice_conversion(successful: false)
@@ -72,7 +92,12 @@ RSpec.describe DocToPdfConverter do
 
     it "does not attempt to convert a docx with attachments" do
       with_tmp_dir do |dir|
+        # Turn off the auto-conversion that happens in the CreateSourceFilesJob
+        # so we can test this service directly
+        allow(described_class).to receive(:convert).and_return(nil)
         source_file = create(:source_file, :docx_with_attachments)
+        allow(described_class).to receive(:convert).and_call_original
+
         stub_soffice_install
 
         described_class.convert(source_file, tmp_dir: dir)

--- a/spec/services/doc_to_pdf_converter_spec.rb
+++ b/spec/services/doc_to_pdf_converter_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe DocToPdfConverter do
       end
     end
 
+    it "will do nothing if non-docx file" do
+      with_tmp_dir do |tmp_dir|
+        source_file = create(:source_file, :pdf)
+        expect_any_instance_of(ActiveStorage::Attachment).to_not receive(:open)
+
+        described_class.convert(source_file, tmp_dir:)
+      end
+    end
+
     it "raises if libreoffice not installed" do
       source_file = create(:source_file)
       stub_soffice_install(installed: false)

--- a/spec/services/doc_to_pdf_converter_spec.rb
+++ b/spec/services/doc_to_pdf_converter_spec.rb
@@ -3,13 +3,8 @@ require "rails_helper"
 RSpec.describe DocToPdfConverter do
   describe ".convert_all" do
     it "converts docx files" do
-      # Turn off the auto-conversion that happens in the CreateSourceFilesJob
-      # so we can test this service directly
-      allow(described_class).to receive(:convert).and_return(nil)
       pdf = create(:source_file, :pdf)
       docx = create(:source_file, :docx)
-      allow(described_class).to receive(:convert).and_call_original
-
       expect(described_class::ConvertJob)
         .not_to receive(:perform_later)
         .with(pdf)
@@ -24,12 +19,7 @@ RSpec.describe DocToPdfConverter do
   describe ".convert" do
     it "converts a docx to a pdf" do
       with_tmp_dir do |tmp_dir|
-        # Turn off the auto-conversion that happens in the CreateSourceFilesJob
-        # so we can test this service directly
-        allow(described_class).to receive(:convert).and_return(nil)
         source_file = create(:source_file, :docx)
-        allow(described_class).to receive(:convert).and_call_original
-
         import = source_file.standards_import
         attachment = source_file.active_storage_attachment
         stub_soffice_install
@@ -59,12 +49,7 @@ RSpec.describe DocToPdfConverter do
     end
 
     it "raises if libreoffice not installed" do
-      # Turn off the auto-conversion that happens in the CreateSourceFilesJob
-      # so we can test this service directly
-      allow(described_class).to receive(:convert).and_return(nil)
-      source_file = create(:source_file, :docx)
-      allow(described_class).to receive(:convert).and_call_original
-
+      source_file = create(:source_file)
       stub_soffice_install(installed: false)
 
       expect {
@@ -74,12 +59,7 @@ RSpec.describe DocToPdfConverter do
 
     it "raises if conversion failed" do
       with_tmp_dir do |dir|
-        # Turn off the auto-conversion that happens in the CreateSourceFilesJob
-        # so we can test this service directly
-        allow(described_class).to receive(:convert).and_return(nil)
-        source_file = create(:source_file, :docx)
-        allow(described_class).to receive(:convert).and_call_original
-
+        source_file = create(:source_file)
         allow(DocxFile).to receive(:has_embedded_files?).and_return(false)
         stub_soffice_install
         stub_soffice_conversion(successful: false)
@@ -92,12 +72,7 @@ RSpec.describe DocToPdfConverter do
 
     it "does not attempt to convert a docx with attachments" do
       with_tmp_dir do |dir|
-        # Turn off the auto-conversion that happens in the CreateSourceFilesJob
-        # so we can test this service directly
-        allow(described_class).to receive(:convert).and_return(nil)
         source_file = create(:source_file, :docx_with_attachments)
-        allow(described_class).to receive(:convert).and_call_original
-
         stub_soffice_install
 
         described_class.convert(source_file, tmp_dir: dir)

--- a/spec/views/standards_import/show_spec.rb
+++ b/spec/views/standards_import/show_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "standards_imports/show", type: :view do
+  it "does not display files that are linked to an original file" do
+    allow_any_instance_of(ActionView::TestCase::TestController).to receive(:current_user).and_return(nil)
+
+    # Simulate a guest user uploading a docx file that gets converted to a pdf
+    # by the time they are shown the standards_imports/show page. We do not want
+    # to display the converted pdf file to them.
+    docx_file = file_fixture("document.docx")
+    pdf_file = file_fixture("pixel1x1.pdf")
+    import = create(:standards_import, files: [docx_file, pdf_file])
+    docx_source_file = SourceFile.all.detect { |sf| sf.docx? }
+    pdf_source_file = SourceFile.all.detect { |sf| sf.pdf? }
+    pdf_source_file.update!(original_source_file: docx_source_file)
+
+    assign :standards_import, import
+
+    render template: "standards_imports/show", layout: "layouts/application"
+
+    expect(rendered).to have_content "document.docx"
+    expect(rendered).to_not have_content "pixel1x1.pdf"
+  end
+end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206305102472876/f)

## Description of changes
- Exits from the `DocToPdfConverter` service if file is not of type `docx`.
- Marks the courtesy notification for the archived docx file as `not_required`. This means a guest user will get an email referencing the `.pdf` file and not their original `.docx` file. Made a [separate ticket](https://app.asana.com/0/1203289004376659/1206556719578104/f) to address this.
- Creates a new background job that calls the `DocToPdfConverter` service after a source file is created. While it is not strictly necessary to create this background job that only calls a service, it greatly simplifies the specs since without the job, many of the specs would have involved stubbing of the `DocToPdfConverter` service.

<img width="1587" alt="Screenshot 2024-02-08 at 3 16 26 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/fc095918-376f-4e15-9435-ebc020659035">

<img width="1597" alt="Screenshot 2024-02-08 at 3 16 33 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/07203720-6b08-41b9-abea-41bcb3d46bee">