### PR TITLE
Add libreoffice to final Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ ENV RAILS_SERVE_STATIC_FILES=true
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   google-chrome-stable \
+  libreoffice \
   nodejs \
   postgresql-client \
   tzdata \


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206305102472876/f)

The libreoffice package was only added to the build stage of the Dockerfile, so it was not present in the final image.
