### PR TITLE
Change system command to check for existence of libreoffice software

### DIFF
--- a/app/services/doc_to_pdf_converter.rb
+++ b/app/services/doc_to_pdf_converter.rb
@@ -19,7 +19,7 @@ class DocToPdfConverter
 
   def convert
     return unless source_file.docx?
-    raise DependencyNotFoundError unless Kernel.system("command -v soffice")
+    raise DependencyNotFoundError unless Kernel.system("soffice --version")
     dir = ensure_dir
 
     attachment.open do |file|

--- a/spec/services/doc_to_pdf_converter_spec.rb
+++ b/spec/services/doc_to_pdf_converter_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe DocToPdfConverter do
 
   def stub_soffice_install(installed: true)
     allow(Kernel).to receive(:system)
-      .with("command -v soffice")
+      .with("soffice --version")
       .and_return(installed)
   end
 


### PR DESCRIPTION
On Heroku bash, we had:

```
/usr/src/app $ command -v soffice
/usr/bin/soffice
```

but in the console:

```
> Kernel.system("command soffice --version")
=> nil
```

with

```
> $?
=> #<Process::Status: pid 38 exit 127>
```

Not sure why it couldn't be found.

This change returns:

```
> Kernel.system("soffice --version")
LibreOffice 7.4.7.2 40(Build:2)
```

[Asana ticket](https://app.asana.com/0/1203289004376659/1206305102472876/f)
