### PR TITLE
Add default sorting options for all admin resources

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -18,5 +18,13 @@ module Admin
       flash[:alert] = "You are not authorized to perform this action."
       redirect_back(fallback_location: root_path)
     end
+
+    def default_sorting_attribute
+      :created_at
+    end
+
+    def default_sorting_direction
+      :desc
+    end
   end
 end

--- a/app/controllers/admin/onets_controller.rb
+++ b/app/controllers/admin/onets_controller.rb
@@ -1,4 +1,13 @@
 module Admin
   class OnetsController < Admin::ApplicationController
+    private
+
+    def default_sorting_attribute
+      :code
+    end
+
+    def default_sorting_direction
+      :asc
+    end
   end
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,4 +1,13 @@
 module Admin
   class OrganizationsController < Admin::ApplicationController
+    private
+
+    def default_sorting_attribute
+      :title
+    end
+
+    def default_sorting_direction
+      :asc
+    end
   end
 end

--- a/app/controllers/admin/synonyms_controller.rb
+++ b/app/controllers/admin/synonyms_controller.rb
@@ -40,5 +40,13 @@ module Admin
       end
       redirect_to after_resource_destroyed_path(requested_resource)
     end
+
+    def default_sorting_attribute
+      :word
+    end
+
+    def default_sorting_direction
+      :asc
+    end
   end
 end

--- a/app/dashboards/onet_dashboard.rb
+++ b/app/dashboards/onet_dashboard.rb
@@ -5,18 +5,21 @@ class OnetDashboard < Administrate::BaseDashboard
     id: Field::String,
     code: Field::String,
     title: Field::String,
+    version: Field::String,
     related_job_titles: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[
+    version
     code
     title
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[
     id
+    version
     code
     title
     related_job_titles

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,10 +35,10 @@ Rails.application.routes.draw do
         resources :data_imports, except: [:index]
         delete :redacted_source_file, on: :member, action: :destroy_redacted_source_file
       end
+      resources :standards_imports
       resources :occupation_standards, only: [:index, :show, :edit, :update]
       resources :occupations, only: [:index, :show, :edit, :update]
       resources :organizations, only: [:index, :show, :edit, :update]
-      resources :standards_imports
       resources :work_processes, only: [:show, :edit, :update]
       resources :competencies, only: [:show, :edit, :update]
       resources :competency_options, only: [:show, :edit, :update]


### PR DESCRIPTION
This sorts all the the admin pages by `created_at: :desc` except for a few exceptions. Also moves the StandardsImports resource next to the SourceFiles.
