### PR TITLE
Only create source files on standards_import update

### DIFF
--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -1,7 +1,7 @@
 class StandardsImport < ApplicationRecord
   has_many_attached :files
 
-  after_save_commit :create_source_files
+  after_update_commit :create_source_files
 
   enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true
 

--- a/spec/models/standards_import_spec.rb
+++ b/spec/models/standards_import_spec.rb
@@ -130,10 +130,11 @@ RSpec.describe StandardsImport, type: :model do
   end
 
   describe "#create_source_files" do
-    it "calls CreateSourceFiles background job" do
+    it "calls CreateSourceFiles background job on update only" do
       expect(CreateSourceFilesJob).to receive(:perform_later).with(kind_of(StandardsImport))
 
-      create(:standards_import)
+      si = create(:standards_import)
+      si.update!(name: "Mickey Mouse")
     end
   end
 


### PR DESCRIPTION
Because standards import records have files attached to them, 
the record is marked as updated after
the last file has been attached. This means that
the CreateSourceFilesJob is called twice in
quick succession, sometimes resulting in
duplicate source files. Since we only need
to run this job if files have been attached,
it is sufficient to run it on after_update.

Originally, the source file creation happened
as an `after_create` on the `ActiveStorage::Attachment`
record itself, but that changed with the Rails 7.1 upgrade.
b150ee2a49e5c9922a4768fa743c96dc931338ab

