### PR TITLE
Add original_source_file link to Admin dashboard

### DIFF
--- a/app/dashboards/source_file_dashboard.rb
+++ b/app/dashboards/source_file_dashboard.rb
@@ -22,6 +22,7 @@ class SourceFileDashboard < Administrate::BaseDashboard
     ),
     redacted_source_file_url: Field::Url.with_options(searchable: false),
     associated_occupation_standards: HasManyAssociatedOccupationStandardsField,
+    original_source_file: Field::BelongsTo,
     standards_import: GenericRecordField,
     plain_text_version: Field::Text
 
@@ -49,6 +50,7 @@ class SourceFileDashboard < Administrate::BaseDashboard
     public_document
     redacted_source_file
     redacted_source_file_url
+    original_source_file
     associated_occupation_standards
     standards_import
     plain_text_version


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206305102472876/f)

PDFs that were generated from Word files are linked to the Word file through the `original_source_file` association. Display this link on the Administrate show page.

<img width="1038" alt="Screenshot 2024-02-13 at 10 43 54 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/d14eb4ab-d188-453f-8eeb-29e807acce8e">



