### PR TITLE
Destroy associated data imports and occupation standards when deleting a source file

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -4,7 +4,7 @@ class DataImport < ApplicationRecord
   belongs_to :user
   belongs_to :source_file
 
-  belongs_to :occupation_standard, optional: true
+  belongs_to :occupation_standard, optional: true, dependent: :destroy
 
   validate :file_presence
   validate :file_mime_type

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -2,7 +2,7 @@ class SourceFile < ApplicationRecord
   belongs_to :active_storage_attachment, class_name: "ActiveStorage::Attachment"
   belongs_to :assignee, class_name: "User", optional: true
   belongs_to :original_source_file, class_name: "SourceFile", optional: true
-  has_many :data_imports, -> { includes(:occupation_standard, file_attachment: :blob) }
+  has_many :data_imports, -> { includes(:occupation_standard, file_attachment: :blob) }, dependent: :destroy
   has_many :associated_occupation_standards, -> { distinct }, through: :data_imports, source: :occupation_standard
   has_one_attached :redacted_source_file
 

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe DataImport, type: :model do
     expect(data_import).to_not be_valid
   end
 
+  it "deletes associated occupation standards when deleted" do
+    os = create(:occupation_standard)
+    data_import = create(:data_import, occupation_standard: os)
+
+    expect {
+      data_import.destroy!
+    }.to change(DataImport, :count).by(-1)
+      .and change(OccupationStandard, :count).by(-1)
+  end
+
   describe ".recent_uploads" do
     it "returns records created the day before by default" do
       travel_to(Time.zone.local(2023, 6, 15)) do


### PR DESCRIPTION
We have many duplicate source files due to the issues outlined in #638. Deleting them should delete the extra data imports and duplicated occupation standards.