### PR TITLE
Changes to ExportFileAttachmentsJob

### DIFF
--- a/app/jobs/scraper/export_file_attachments_job.rb
+++ b/app/jobs/scraper/export_file_attachments_job.rb
@@ -44,16 +44,23 @@ class Scraper::ExportFileAttachmentsJob < ApplicationJob
     return if file_names.empty?
 
     standards_import = source_file.standards_import
+    existing_file_names = standards_import.files.map(&:filename)
 
-    file_names.each do |file|
-      standards_import.files.attach(io: File.open(file), filename: File.basename(file))
+    file_names.each do |file_name|
+      basename = File.basename(file_name)
+      next if existing_file_names.include?(basename)
+
+      standards_import.files.attach(
+        io: File.open(file_name),
+        filename: basename
+      )
     end
   end
 
   def delete_extracted_files(file_names, temp_file)
     temp_file.unlink
-    file_names.each do |file|
-      File.delete(file)
+    file_names.each do |file_name|
+      File.delete(file_name)
     end
   end
 end

--- a/spec/jobs/scraper/export_file_attachments_job_spec.rb
+++ b/spec/jobs/scraper/export_file_attachments_job_spec.rb
@@ -2,29 +2,49 @@ require "rails_helper"
 
 RSpec.describe Scraper::ExportFileAttachmentsJob do
   describe "#perform" do
-    it "creates a StandardImport and 6 files attached to it" do
-      import = create(:standards_import, :with_docx_file_with_attachments)
-      CreateSourceFileJob.perform_now(import.files.last)
-      source_file = SourceFile.last
-
-      perform_enqueued_jobs do
-        allow(DocToPdfConverter).to receive(:convert).and_return(nil)
-        expect { described_class.new.perform(source_file) }
-          .to change { StandardsImport.count }.by(1)
-          .and change { StandardsImport.last.files.count }.by(6)
-      end
-    end
-
-    context "with file that doesn't have attachments" do
-      it "does not create a StandardImport" do
-        import = create(:standards_import, :with_files)
-        CreateSourceFileJob.perform_now(import.files.last)
+    context "with file that has attachments" do
+      it "attaches 7 files to original standards_import file and marks original source_file as archived" do
+        # When viewing this file it looks to only have 6 attachments, but when
+        # the files are extracted, there are 2 Word docs and 5 PDFs. Not sure
+        # why only 4 PDFs are visible when viewing the doc.
+        standards_import = create(:standards_import, :with_docx_file_with_attachments)
         source_file = SourceFile.last
 
         perform_enqueued_jobs do
           allow(DocToPdfConverter).to receive(:convert).and_return(nil)
           expect { described_class.new.perform(source_file) }
             .to change { StandardsImport.count }.by(0)
+          expect(standards_import.files.count).to eq 8
+          expect(source_file.reload).to be_archived
+        end
+      end
+    end
+
+    context "with file that doesn't have attachments" do
+      it "does not attach any files to the StandardImport and marks original source_file as archived" do
+        standards_import = create(:standards_import, :with_files)
+        source_file = SourceFile.last
+
+        perform_enqueued_jobs do
+          allow(DocToPdfConverter).to receive(:convert).and_return(nil)
+          expect { described_class.new.perform(source_file) }
+            .to change { standards_import.files.count }.by(0)
+          expect(source_file.reload).to be_archived
+        end
+      end
+    end
+
+    context "with already archived source file" do
+      it "exits without creating new files" do
+        standards_import = create(:standards_import, :with_docx_file_with_attachments)
+        source_file = SourceFile.last
+        source_file.archived!
+
+        perform_enqueued_jobs do
+          allow(DocToPdfConverter).to receive(:convert).and_return(nil)
+          expect { described_class.new.perform(source_file) }
+            .to change { StandardsImport.count }.by(0)
+          expect(standards_import.files.count).to eq 1
         end
       end
     end

--- a/spec/jobs/scraper/export_file_attachments_job_spec.rb
+++ b/spec/jobs/scraper/export_file_attachments_job_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Scraper::ExportFileAttachmentsJob do
   describe "#perform" do
     context "with file that has attachments" do
-      it "attaches 7 files to original standards_import file and marks original source_file as archived" do
+      it "attaches 7 files to original standards_import file, marks original source_file as archived, and is idempotent" do
         # When viewing this file it looks to only have 6 attachments, but when
         # the files are extracted, there are 2 Word docs and 5 PDFs. Not sure
         # why only 4 PDFs are visible when viewing the doc.
@@ -14,8 +14,19 @@ RSpec.describe Scraper::ExportFileAttachmentsJob do
 
           expect { described_class.new.perform(source_file) }
             .to change { StandardsImport.count }.by(0)
+            .and change { ActiveStorage::Attachment.count }.by(7)
           expect(standards_import.files.count).to eq 8
           expect(source_file.reload).to be_archived
+
+          # Simulate something breaking in the middle of the job where the files
+          # got attached but the source_file never got marked as archived. If
+          # the job is run again, do not re-attach the embedded files.
+          source_file.pending!
+
+          expect { described_class.new.perform(source_file) }
+            .to change { StandardsImport.count }.by(0)
+            .and change { ActiveStorage::Attachment.count }.by(0)
+          expect(standards_import.files.count).to eq 8
         end
       end
     end

--- a/spec/jobs/scraper/export_file_attachments_job_spec.rb
+++ b/spec/jobs/scraper/export_file_attachments_job_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Scraper::ExportFileAttachmentsJob do
         # When viewing this file it looks to only have 6 attachments, but when
         # the files are extracted, there are 2 Word docs and 5 PDFs. Not sure
         # why only 4 PDFs are visible when viewing the doc.
-        standards_import = create(:standards_import, :with_docx_file_with_attachments)
-        source_file = SourceFile.last
-
         perform_enqueued_jobs do
           allow(DocToPdfConverter).to receive(:convert).and_return(nil)
+          standards_import = create(:standards_import, :with_docx_file_with_attachments)
+          source_file = SourceFile.last
+
           expect { described_class.new.perform(source_file) }
             .to change { StandardsImport.count }.by(0)
           expect(standards_import.files.count).to eq 8
@@ -22,11 +22,11 @@ RSpec.describe Scraper::ExportFileAttachmentsJob do
 
     context "with file that doesn't have attachments" do
       it "does not attach any files to the StandardImport and marks original source_file as archived" do
-        standards_import = create(:standards_import, :with_files)
-        source_file = SourceFile.last
-
         perform_enqueued_jobs do
           allow(DocToPdfConverter).to receive(:convert).and_return(nil)
+          standards_import = create(:standards_import, :with_files)
+          source_file = SourceFile.last
+
           expect { described_class.new.perform(source_file) }
             .to change { standards_import.files.count }.by(0)
           expect(source_file.reload).to be_archived
@@ -36,12 +36,12 @@ RSpec.describe Scraper::ExportFileAttachmentsJob do
 
     context "with already archived source file" do
       it "exits without creating new files" do
-        standards_import = create(:standards_import, :with_docx_file_with_attachments)
-        source_file = SourceFile.last
-        source_file.archived!
-
         perform_enqueued_jobs do
           allow(DocToPdfConverter).to receive(:convert).and_return(nil)
+          standards_import = create(:standards_import, :with_docx_file_with_attachments)
+          source_file = SourceFile.last
+          source_file.archived!
+
           expect { described_class.new.perform(source_file) }
             .to change { StandardsImport.count }.by(0)
           expect(standards_import.files.count).to eq 1


### PR DESCRIPTION
## Description of changes
When extracting attachments from a Word doc, the existing code creates a new StandardsImport to hold the attachments, but there is actually no reason for this, and it would be better to keep all the related attachments connected to the initial StandardsImport record.

This PR makes the following changes to the `ExportFileAttachmentsJob`:
- Archive docx source file after attachments are extracted. This file never has anything useful and will not be needed.
- Link the new files to the **original** StandardsImport record
- Exit from job if source file is marked as archived

## Notes
The fixture file used in the spec appears to have only 6 attachments:

<img width="568" alt="Screenshot 2024-02-15 at 3 44 33 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/a58eba44-8208-41c2-9afc-e10bfca29d3d">

but when the files are extracted, there are clearly 7:

```bash
spec/fixtures/files/word/embeddings]$ ls
Microsoft_Word_Document.docx	oleObject1.pdf			oleObject3.pdf			oleObject5.pdf
Microsoft_Word_Document1.docx	oleObject2.pdf			oleObject4.pdf
```

I think the original spec was erroneously passing since it was counting the change in files from `StandardsImport.last` (the first StandardsImport record which had 1 attachment) to `StandardsImport.last` (the just-created StandardsImport record which has 7 attachments), making a change in count of 6.