### PR TITLE
Scraper source files should be public

### DIFF
--- a/app/jobs/create_source_file_job.rb
+++ b/app/jobs/create_source_file_job.rb
@@ -13,7 +13,10 @@ class CreateSourceFileJob < ApplicationJob
     Rails.error.handle do
       SourceFile.transaction do
         SourceFile
-          .create_with(courtesy_notification:)
+          .create_with(
+            courtesy_notification:,
+            public_document: standards_import.public_document
+          )
           .find_or_create_by!(active_storage_attachment_id: attachment.id)
           .tap { maybe_link_to_original_source_file(_1, linkable_docx_files) }
       end

--- a/lib/tasks/deployment/20240229230433_mark_scraper_source_files_as_public.rake
+++ b/lib/tasks/deployment/20240229230433_mark_scraper_source_files_as_public.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc "Deployment task: mark_scraper_source_files_as_public"
+  task mark_scraper_source_files_as_public: :environment do
+    puts "Running deploy task 'mark_scraper_source_files_as_public'"
+
+    StandardsImport.where(public_document: true).find_each do |import|
+      next unless import.notes.match?(/Scraper/)
+
+      import.source_files.compact.each do |source_file|
+        source_file.update!(public_document: true)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/jobs/create_source_file_job_spec.rb
+++ b/spec/jobs/create_source_file_job_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe CreateSourceFileJob, "#perform", type: :job do
     described_class.new.perform(source_file.active_storage_attachment)
   end
 
+  it "sets public_document field to match standards_import field" do
+    import = create(:standards_import, :with_files, public_document: true)
+    attachment = import.files.first
+
+    described_class.new.perform(attachment)
+
+    source_file = SourceFile.last
+    expect(source_file).to be_public_document
+  end
+
   it "marks source_file courtesy_notification as pending if import courtesy notification is pending" do
     import = create(:standards_import, :with_files, email: "foo@example.com", name: "Foo", courtesy_notification: :pending)
     attachment = import.files.first


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206716543725436/f)

The `StandardsImport` record created from the scraper jobs are getting marked with `public_document: true`, but that field was not getting transferred to the `source_file` record that was created from the attachment.

This sets the `public_document` field on source files to match its standards_import record, and adds a rake task to backpopulate previously scraped documents.
