### PR TITLE
Do not convert doc files until source file has been committed

### DIFF
--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -9,7 +9,7 @@ class SourceFile < ApplicationRecord
   enum :status, [:pending, :completed, :needs_support, :needs_human_review, :archived]
   enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true
 
-  after_create :convert_doc_file_to_pdf
+  after_create_commit :convert_doc_file_to_pdf
 
   PDF_CONTENT_TYPE = "application/pdf"
 


### PR DESCRIPTION
We are getting errors that the source file
is not yet available when attempting
to convert the docx file to pdf. This
modifies the job to wait until `after_commit`
to ensure that the source file will be
available.

Fixes [Rollbar error](https://app.rollbar.com/a/apprenticeship-standards-stag/fix/item/apprenticeship-standards-stag/36)
