### PR TITLE
Handle documents for standards without data import or source file

### DIFF
--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -254,7 +254,7 @@ class OccupationStandard < ApplicationRecord
   end
 
   def public_document?
-    !!(source_file&.public_document || standards_import&.public_document)
+    (source_file&.public_document || standards_import&.public_document).present?
   end
 
   def original_file_url

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -250,11 +250,11 @@ class OccupationStandard < ApplicationRecord
   end
 
   def source_file
-    data_import.source_file
+    data_import&.source_file
   end
 
   def public_document?
-    source_file.public_document || standards_import.public_document
+    !!(source_file&.public_document || standards_import&.public_document)
   end
 
   def original_file_url

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -265,6 +265,12 @@ RSpec.describe OccupationStandard, type: :model do
 
       expect(occupation_standard.source_file).to eq source_file
     end
+
+    it "returns nil if standard does not have an associated data import" do
+      occupation_standard = build(:occupation_standard)
+
+      expect(occupation_standard.source_file).to be_nil
+    end
   end
 
   describe "#compentencies_count" do
@@ -569,6 +575,12 @@ RSpec.describe OccupationStandard, type: :model do
       allow_any_instance_of(StandardsImport).to receive(:public_document).and_return(true)
 
       expect(occupation_standard.public_document?).to be true
+    end
+
+    it "returns false if no source_file or standard_import is associated to the occupation standard" do
+      occupation_standard = build(:occupation_standard)
+
+      expect(occupation_standard.public_document?).to be false
     end
   end
 


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206498816477316/f)


Occupation Standards created from RAPIDS API do not have any source file or standard import associated. This PR handles this case to make `OccupationStandard#public_document?` and `OccupationStandard#source_file` work