### PR TITLE
RAPIDS API - Import Competencies

### DIFF
--- a/app/models/rapids/work_process.rb
+++ b/app/models/rapids/work_process.rb
@@ -1,11 +1,37 @@
 module RAPIDS
   class WorkProcess
-    def self.initialize_from_response(work_process_data)
-      ::WorkProcess.new(
-        title: work_process_data["title"],
-        minimum_hours: work_process_data["minHours"],
-        maximum_hours: work_process_data["maxHours"]
-      )
+    class << self
+      def initialize_from_response(work_process_data)
+        tasks = work_process_data["tasks"]
+
+        work_process = ::WorkProcess.new(
+          title: work_process_data["title"],
+          minimum_hours: work_process_data["minHours"],
+          maximum_hours: work_process_data["maxHours"]
+        )
+
+        if competencies_available?(tasks)
+          competencies = process_competencies(tasks)
+          work_process.competencies = competencies
+        end
+
+        work_process
+      end
+
+      private
+
+      def competencies_available?(tasks)
+        tasks&.first&.present?
+      end
+
+      def process_competencies(tasks)
+        tasks_titles = tasks.first.split("; ")
+        tasks_titles.map do |task_title|
+          Competency.initialize_from_response({
+            "title" => task_title
+          })
+        end
+      end
     end
   end
 end

--- a/app/models/rapids/work_process.rb
+++ b/app/models/rapids/work_process.rb
@@ -25,7 +25,7 @@ module RAPIDS
       end
 
       def process_competencies(tasks)
-        tasks_titles = tasks.first.split("; ")
+        tasks_titles = tasks.first.split(/\s?;\s?/)
         tasks_titles.map do |task_title|
           Competency.initialize_from_response({
             "title" => task_title

--- a/spec/factories/rapids_api/detailed_work_activities.rb
+++ b/spec/factories/rapids_api/detailed_work_activities.rb
@@ -3,9 +3,23 @@ FactoryBot.define do
     skip_create
 
     sequence(:title) { |n| "Detailed Work Activity #{n}" }
-    sequence(:task) { |n| ["Task #{n}"] }
+    sequence(:tasks) { |n| [""] }
 
     initialize_with { attributes.stringify_keys }
+
+    transient do
+      with_tasks { 0 }
+    end
+
+    after(:create) do |detailed_work_activity, context|
+      if context.with_tasks.positive?
+        detailed_work_activity["tasks"] = [
+          (1..context.with_tasks).map do |n|
+            "Competency #{n}"
+          end.to_sentence(words_connector: "; ", two_words_connector: "; ", last_word_connector: "; ")
+        ]
+      end
+    end
 
     factory :rapids_api_detailed_work_activity_for_hybrid do
       minHours { 200 }

--- a/spec/models/rapids/work_process_spec.rb
+++ b/spec/models/rapids/work_process_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RAPIDS::WorkProcess, type: :model do
     it "returns work process with competencies if available" do
       work_process_response = create(
         :rapids_api_detailed_work_activity,
-        tasks: ["Competency #1; Competency #2; Competency #3"]
+        tasks: ["Competency #1; Competency #2;Competency #3"]
       )
 
       work_process = described_class.initialize_from_response(work_process_response)

--- a/spec/models/rapids/work_process_spec.rb
+++ b/spec/models/rapids/work_process_spec.rb
@@ -32,5 +32,21 @@ RSpec.describe RAPIDS::WorkProcess, type: :model do
       expect(second_competency.title).to eq "Competency #2"
       expect(third_competency.title).to eq "Competency #3"
     end
+
+    it "returns correct number of competencies regardless of extra or missing spacing" do
+      work_process_response = create(
+        :rapids_api_detailed_work_activity,
+        tasks: ["Competency #1 ; Competency #2;Competency #3"]
+      )
+
+      work_process = described_class.initialize_from_response(work_process_response)
+
+      (first_competency, second_competency, third_competency) = work_process.competencies
+
+      expect(work_process.competencies.size).to eq 3
+      expect(first_competency.title).to eq "Competency #1"
+      expect(second_competency.title).to eq "Competency #2"
+      expect(third_competency.title).to eq "Competency #3"
+    end
   end
 end

--- a/spec/models/rapids/work_process_spec.rb
+++ b/spec/models/rapids/work_process_spec.rb
@@ -16,5 +16,21 @@ RSpec.describe RAPIDS::WorkProcess, type: :model do
       expect(work_process.minimum_hours).to eq 20
       expect(work_process.maximum_hours).to eq 200
     end
+
+    it "returns work process with competencies if available" do
+      work_process_response = create(
+        :rapids_api_detailed_work_activity,
+        tasks: ["Competency #1; Competency #2; Competency #3"]
+      )
+
+      work_process = described_class.initialize_from_response(work_process_response)
+
+      (first_competency, second_competency, third_competency) = work_process.competencies
+
+      expect(work_process.competencies.size).to eq 3
+      expect(first_competency.title).to eq "Competency #1"
+      expect(second_competency.title).to eq "Competency #2"
+      expect(third_competency.title).to eq "Competency #3"
+    end
   end
 end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206821917760869/f)

WorkProcesses from RAPIDS API have an attributes "tasks", that maps to our Competency model. It is an array with one string separated by semicolons. It may also be an empty string

```
      "dwas": [
        {
          "title": "Safety",
          "minHours": 2000,
          "maxHours": 3000,
          "tasks": [
            "test 1; test 2; test 3"
          ]
        }
      ]
```