### PR TITLE
Return valid work processes only

### DIFF
--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -42,10 +42,11 @@ class ImportDataFromRAPIDSJob < ApplicationJob
   end
 
   def process_work_processes(work_processes_response)
-    work_processes_response.map do |work_process_response|
-      RAPIDS::WorkProcess.initialize_from_response(
+    work_processes_response.filter_map do |work_process_response|
+      work_process = RAPIDS::WorkProcess.initialize_from_response(
         work_process_response
       )
+      work_process if work_process.valid?
     end
   end
 end

--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -28,7 +28,8 @@ class ImportDataFromRAPIDSJob < ApplicationJob
       occupation_standard = process_occupation_standard(occupation_standard_response)
 
       occupation_standard.work_processes = process_work_processes(
-        occupation_standard_response["dwas"]
+        occupation_standard_response["dwas"],
+        occupation_standard
       )
 
       occupation_standard
@@ -41,11 +42,12 @@ class ImportDataFromRAPIDSJob < ApplicationJob
     )
   end
 
-  def process_work_processes(work_processes_response)
+  def process_work_processes(work_processes_response, occupation_standard)
     work_processes_response.filter_map do |work_process_response|
       work_process = RAPIDS::WorkProcess.initialize_from_response(
         work_process_response
       )
+      work_process.occupation_standard = occupation_standard
       work_process if work_process.valid?
     end
   end

--- a/spec/jobs/import_data_from_rapids_job_spec.rb
+++ b/spec/jobs/import_data_from_rapids_job_spec.rb
@@ -150,6 +150,42 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         }.to change(OccupationStandard, :count).to eq 3
       end
     end
+
+    context "invalid records" do
+      it "saves the occupation standard discarding invalid work processes" do
+        stub_get_token!
+
+        mi = create(:state, abbreviation: "MI")
+        create(:registration_agency, state: mi, agency_type: :oa)
+
+        invalid_detailed_work_activity = create_list(
+          :rapids_api_detailed_work_activity_for_hybrid,
+          1,
+          title: ""
+        )
+
+        occupation_standard_response = create_list(
+          :rapids_api_occupation_standard,
+          1,
+          :competency,
+          dwas: invalid_detailed_work_activity
+        )
+
+        rapids_response = create(:rapids_response, totalCount: 1, wps: occupation_standard_response)
+
+        stub_rapids_api_response(
+          {
+            batchSize: ImportDataFromRAPIDSJob::PER_PAGE_SIZE,
+            startIndex: 1
+          },
+          rapids_response
+        )
+        expect {
+          described_class.perform_now
+        }.to change(OccupationStandard, :count).by(1).and \
+          change(WorkProcess, :count).by(0)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
When importing from RAPIDS API, we may encounter invalid work processes. This PR discards any invalid Work Process allowing to save the Occupation Standard instead of ignoring the Occupation Standard completely 