### PR TITLE
Associate Occupation with Occupation Standard

### DIFF
--- a/app/models/rapids/occupation_standard.rb
+++ b/app/models/rapids/occupation_standard.rb
@@ -12,7 +12,7 @@ module RAPIDS
         onet_code = response["onetSocCode"]
         ::OccupationStandard.new(
           title: fix_encoding(response["occupationTitle"]),
-          onet_code: response["onetSocCode"],
+          onet_code: onet_code,
           rapids_code: rapids_code,
           ojt_type: ojt_type(response["occType"]),
           registration_agency: find_registration_agency_by_sponsor_number(

--- a/app/models/rapids/occupation_standard.rb
+++ b/app/models/rapids/occupation_standard.rb
@@ -8,14 +8,17 @@ module RAPIDS
 
     class << self
       def initialize_from_response(response)
+        rapids_code = sanitize_rapids_code(response["rapidsCode"])
+        onet_code = response["onetSocCode"]
         ::OccupationStandard.new(
           title: fix_encoding(response["occupationTitle"]),
           onet_code: response["onetSocCode"],
-          rapids_code: response["rapidsCode"],
+          rapids_code: rapids_code,
           ojt_type: ojt_type(response["occType"]),
           registration_agency: find_registration_agency_by_sponsor_number(
             response["sponsorNumber"]
-          )
+          ),
+          occupation: find_occupation(rapids_code, onet_code)
         )
       end
 
@@ -47,6 +50,28 @@ module RAPIDS
 
       def fix_encoding(text)
         text.encode("UTF-8", "UTF-8", invalid: :replace, replace: "")
+      end
+
+      def find_occupation(rapids_code, onet_code)
+        find_occupation_by_rapids_code(rapids_code) || find_occupation_by_onet_code(onet_code)
+      end
+
+      def find_occupation_by_rapids_code(rapids_code)
+        Occupation.find_by(rapids_code: rapids_code)
+      end
+
+      def find_occupation_by_onet_code(onet_code)
+        Occupation.includes(:onet).find_by(
+          onet: {
+            code: onet_code
+          }
+        )
+      end
+
+      def sanitize_rapids_code(rapids_code)
+        return if rapids_code.blank?
+
+        rapids_code.gsub(/[A-Za-z]+\z/, "").ljust(4, "0")
       end
     end
   end

--- a/spec/factories/rapids_api/occupation_standards.rb
+++ b/spec/factories/rapids_api/occupation_standards.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     sponsorNumber { "2024-MI-136422" }
     occupationTitle { "ALARM  OPERATOR (Gov Serv) (0870CBV1)" }
     onetSocCode { "43-5031.00" }
-    rapidsCode { "0870CB" }
+    rapidsCode { "0870" }
     jobDesc { "Operate telephone, radio, or other communication systems to receive and communicate requests for emergency assistance at 9-1-1." }
     jobZone { "Job Zone Two: Some Preparation Needed." }
     isWPSUploaded { false }


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206821917760873/f)

Uses either RAPIDS code or ONET code to associate Occupation Standards from RAPIDS API to our own list of Occupations