### PR TITLE
Allow manual uploading of files to StandardsImport record

### DIFF
--- a/app/controllers/admin/standards_imports_controller.rb
+++ b/app/controllers/admin/standards_imports_controller.rb
@@ -3,10 +3,22 @@ module Admin
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #
-    # def update
-    #   super
-    #   send_foo_updated_email(requested_resource)
-    # end
+    def update
+      if requested_resource.update(resource_params)
+        if params.dig(:standards_import, :files).present?
+          requested_resource.files.attach(params[:standards_import][:files].compact_blank)
+        end
+        redirect_to(
+          after_resource_updated_path(requested_resource),
+          notice: translate_with_resource("update.success"),
+          status: :see_other
+        )
+      else
+        render :edit, locals: {
+          page: Administrate::Page::Form.new(dashboard, requested_resource)
+        }, status: :unprocessable_entity
+      end
+    end
 
     # Override this method to specify custom lookup behavior.
     # This will be used to set the resource for the `show`, `edit`, and `update`

--- a/app/dashboards/standards_import_dashboard.rb
+++ b/app/dashboards/standards_import_dashboard.rb
@@ -8,6 +8,7 @@ class StandardsImportDashboard < Administrate::BaseDashboard
     name: Field::String,
     notes: Field::Text,
     organization: Field::String,
+    files: Field::ActiveStorage,
     source_files: HasManySourceFilesField,
     courtesy_notification: EnumField.with_options(searchable: false),
     created_at: Field::DateTime,
@@ -39,6 +40,7 @@ class StandardsImportDashboard < Administrate::BaseDashboard
     email
     organization
     notes
+    files
     bulletin
     courtesy_notification
   ].freeze

--- a/spec/system/admin/standards_imports/edit_spec.rb
+++ b/spec/system/admin/standards_imports/edit_spec.rb
@@ -13,4 +13,23 @@ RSpec.describe "admin/standards_imports/edit" do
 
     expect(page).to have_content "Pending"
   end
+
+  it "allows admin to add new files without removing the old ones", :admin do
+    perform_enqueued_jobs do
+      import = create(:standards_import, :with_files)
+      admin = create(:admin)
+
+      login_as admin
+      visit edit_admin_standards_import_path(import)
+
+      file = file_fixture("pixel1x1.jpg")
+      find("#standards_import_files").click
+      find("#standards_import_files").attach_file(file.to_path)
+
+      click_on "Update"
+
+      import.reload
+      expect(import.files.map(&:filename).map(&:to_s)).to contain_exactly("pixel1x1.jpg", "pixel1x1.pdf")
+    end
+  end
 end


### PR DESCRIPTION
There are a couple of docx files with attachments
that are failing to get extracted when run through
the attachment extraction job, but which we are
able to extract the files manually. This change
allows us to manually add files to a StandardsImport record.

