### PR TITLE
Upgrade pagy to 7.0.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,7 @@ GEM
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
     orm_adapter (0.5.0)
-    pagy (6.4.4)
+    pagy (7.0.11)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -87,12 +87,12 @@
   font-weight: bold;
 }
 
-.pagy-nav.pagination a {
+.pagy-nav.pagination a[href] {
   text-decoration: none;
   color: #066B6E;
 }
 
-.pagy-nav.pagination a:hover {
+.pagy-nav.pagination a[href]:hover {
   color: #018083;
 }
 

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,3 +1,8 @@
 require "pagy/extras/overflow"
 require "pagy/extras/elasticsearch_rails"
 Pagy::DEFAULT[:overflow] = :last_page
+Pagy::DEFAULT[:size] = [1, 4, 4, 1]
+
+Pagy::I18n.load(
+  { locale: 'en', filepath: 'config/locales/pagy.yml' }
+)

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -4,5 +4,5 @@ Pagy::DEFAULT[:overflow] = :last_page
 Pagy::DEFAULT[:size] = [1, 4, 4, 1]
 
 Pagy::I18n.load(
-  { locale: 'en', filepath: 'config/locales/pagy.yml' }
+  {locale: "en", filepath: "config/locales/pagy.yml"}
 )

--- a/config/locales/pagy.yml
+++ b/config/locales/pagy.yml
@@ -1,0 +1,20 @@
+en:
+  pagy:
+    aria_label:
+      nav:
+        one: "Page"
+        other: "Pages"
+      previous: "Previous"
+      next: "Next"
+    prev: "&lt; Prev"
+    next: "Next &gt;"
+    gap: "&hellip;"
+    item_name:
+      one: "item"
+      other: "items"
+    info:
+      no_items: "No %{item_name} found"
+      single_page: "Displaying <b>%{count}</b> %{item_name}"
+      multiple_pages: "Displaying %{item_name} <b>%{from}-%{to}</b> of <b>%{count}</b> in total"
+    combo_nav_js: "<label>Page %{page_input} of %{pages}</label>"
+    items_selector_js: "<label>Show %{items_input} %{item_name} per page</label>"


### PR DESCRIPTION
* Override stylesheet to only apply styles to link that have an href
* Replace < and > with < Prev and Next >
* Use old default for page size

[Asana ticket](https://app.asana.com/0/1203289004376659/1206669784920080/f)


Dependabot PR view:

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/87e150f8-8c20-4595-a854-e0d1ef1b36f3)

With Pagy updated and changes on this PR:

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/eea2bf99-6781-42d5-8a6e-9f7c38f5c836)


Current view:

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/782f2479-8b9f-4555-bd79-6f5a2f098a62)

