### PR TITLE
Do not include nil source_files for a StandardsImport record

### DIFF
--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -20,7 +20,7 @@ class StandardsImport < ApplicationRecord
   end
 
   def source_files
-    files.includes(source_file: {active_storage_attachment: :blob}).map(&:source_file)
+    files.includes(source_file: {active_storage_attachment: :blob}).map(&:source_file).compact
   end
 
   def has_converted_source_file_in_need_of_notification?

--- a/spec/models/standards_import_spec.rb
+++ b/spec/models/standards_import_spec.rb
@@ -147,15 +147,24 @@ RSpec.describe StandardsImport, type: :model do
 
   describe "#source_files" do
     it "returns source files associated to each file attachment" do
-      file1 = file_fixture("pixel1x1.pdf")
-      file2 = file_fixture("pixel1x1.jpg")
+      perform_enqueued_jobs do
+        file1 = file_fixture("pixel1x1.pdf")
+        file2 = file_fixture("pixel1x1.jpg")
+        file3 = file_fixture("pixel1x1-2.jpg")
 
-      import = create(:standards_import, email: "foo@example.com", name: "Foo", files: [file1, file2], courtesy_notification: :pending)
-      source_file1 = SourceFile.first
-      source_file2 = SourceFile.last
-      create(:source_file)
+        import = create(:standards_import, email: "foo@example.com", name: "Foo", files: [file1, file2, file3], courtesy_notification: :pending)
+        source_file1 = SourceFile.first
+        source_file2 = SourceFile.second
+        source_file3 = SourceFile.last
 
-      expect(import.source_files).to contain_exactly(source_file1, source_file2)
+        # Simulate an active storage attachment that does not have a source file
+        # yet
+        source_file3.destroy!
+
+        create(:source_file)
+
+        expect(import.source_files).to contain_exactly(source_file1, source_file2)
+      end
     end
   end
 

--- a/spec/system/admin/standards_imports/edit_spec.rb
+++ b/spec/system/admin/standards_imports/edit_spec.rb
@@ -15,21 +15,19 @@ RSpec.describe "admin/standards_imports/edit" do
   end
 
   it "allows admin to add new files without removing the old ones", :admin do
-    perform_enqueued_jobs do
-      import = create(:standards_import, :with_files)
-      admin = create(:admin)
+    import = create(:standards_import, :with_files)
+    admin = create(:admin)
 
-      login_as admin
-      visit edit_admin_standards_import_path(import)
+    login_as admin
+    visit edit_admin_standards_import_path(import)
 
-      file = file_fixture("pixel1x1.jpg")
-      find("#standards_import_files").click
-      find("#standards_import_files").attach_file(file.to_path)
+    file = file_fixture("pixel1x1.jpg")
+    find("#standards_import_files").click
+    find("#standards_import_files").attach_file(file.to_path)
 
-      click_on "Update"
+    click_on "Update"
 
-      import.reload
-      expect(import.files.map(&:filename).map(&:to_s)).to contain_exactly("pixel1x1.jpg", "pixel1x1.pdf")
-    end
+    import.reload
+    expect(import.files.map(&:filename).map(&:to_s)).to contain_exactly("pixel1x1.jpg", "pixel1x1.pdf")
   end
 end


### PR DESCRIPTION
When new files are manually added to a StandardsImport record (#700), the associated source file records are not immediately available since they are created in a background job. However, the `source_files` method is returning an array that includes these `nil` source files, causing issues with displaying the list of source files in the Administrate view. 

This change modifies the `source_files` method to not return any nil values.
