### PR TITLE
Add bulletin field to source_files table and populate

### DIFF
--- a/app/dashboards/source_file_dashboard.rb
+++ b/app/dashboards/source_file_dashboard.rb
@@ -25,6 +25,7 @@ class SourceFileDashboard < Administrate::BaseDashboard
     original_source_file: Field::BelongsTo,
     converted_source_file: Field::BelongsTo,
     standards_import: GenericRecordField,
+    bulletin: Field::Boolean,
     plain_text_version: Field::Text
 
   }.freeze
@@ -55,6 +56,7 @@ class SourceFileDashboard < Administrate::BaseDashboard
     converted_source_file
     associated_occupation_standards
     standards_import
+    bulletin
     plain_text_version
     created_at
     updated_at

--- a/app/jobs/scraper/apprenticeship_bulletins_job.rb
+++ b/app/jobs/scraper/apprenticeship_bulletins_job.rb
@@ -34,7 +34,8 @@ class Scraper::ApprenticeshipBulletinsJob < ApplicationJob
           source_file.update!(
             metadata: {
               date: row["Date"]
-            }
+            },
+            bulletin: true
           )
           if source_file.docx?
             Scraper::ExportFileAttachmentsJob.perform_later(source_file)

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -10,8 +10,6 @@ class SourceFile < ApplicationRecord
   enum :status, [:pending, :completed, :needs_support, :needs_human_review, :archived]
   enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true
 
-  delegate :bulletin?, to: :standards_import
-
   after_create_commit :convert_doc_file_to_pdf
 
   WORD_FILE_CONTENT_TYPES = [

--- a/db/migrate/20240320194256_add_bulletin_to_source_files.rb
+++ b/db/migrate/20240320194256_add_bulletin_to_source_files.rb
@@ -1,0 +1,5 @@
+class AddBulletinToSourceFiles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :source_files, :bulletin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_13_194108) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_20_194256) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -241,6 +241,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_13_194108) do
     t.datetime "redacted_at"
     t.string "link_to_pdf_filename"
     t.uuid "original_source_file_id"
+    t.boolean "bulletin", default: false, null: false
     t.index ["active_storage_attachment_id"], name: "index_source_files_on_active_storage_attachment_id"
     t.index ["assignee_id"], name: "index_source_files_on_assignee_id"
     t.index ["original_source_file_id"], name: "index_source_files_on_original_source_file_id"

--- a/lib/tasks/deployment/20240320194411_correctly_mark_source_files_as_bulletins.rake
+++ b/lib/tasks/deployment/20240320194411_correctly_mark_source_files_as_bulletins.rake
@@ -1,0 +1,27 @@
+namespace :after_party do
+  desc "Deployment task: correctly_mark_source_files_as_bulletins"
+  task correctly_mark_source_files_as_bulletins: :environment do
+    puts "Running deploy task 'correctly_mark_source_files_as_bulletins'"
+
+    StandardsImport.where(bulletin: true).find_each do |standards_import|
+      standards_import.source_files.each do |source_file|
+        if source_file.filename.to_s.match?(/bulletin/i)
+          if source_file.original_source_file.nil? && source_file.converted_source_file.nil?
+            # File started as a pdf OR it was a docx file with embedded
+            # attachments, so mark it as the bulletin
+            souce_file.update!(bulletin: true)
+          elsif source_file.converted_source_file.present?
+            # This file was originally a doc file that was converted, so mark it
+            # as the bulletin
+            source_file.update!(bulletin: true)
+          end
+        end
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
+++ b/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Scraper::ApprenticeshipBulletinsJob, type: :job do
 
         source_file = SourceFile.last
         expect(source_file.metadata).to eq({"date" => "03/11/16"})
+        expect(source_file).to be_bulletin
       end
     end
   end

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -336,7 +336,7 @@ RSpec.describe SourceFile, type: :model do
     end
 
     it "is false if word file but is marked as a bulletin" do
-      source_file = build(:source_file, :docx, :bulletin)
+      source_file = build(:source_file, :docx, bulletin: true)
 
       expect(source_file.can_be_converted_to_pdf?).to be_falsey
     end


### PR DESCRIPTION
We would like to know which source file was the original source file downloaded through the `Scraper::ApprenticeshipBulletinsJob`, but currently that is not possible as the `bulletin` field is only on the parent `StandardsImport` model and the standards_import record also holds all of the extracted files. This information will be helpful when we write a task to finish converting all word files to pdf, as we can ensure that we can skip any original bulletin files.

This adds a `bulletin` field to the `source_files` table and adds a one-time rake task to populate the field.
