### PR TITLE
Convert remaining word files to pdf

### DIFF
--- a/app/jobs/create_source_file_job.rb
+++ b/app/jobs/create_source_file_job.rb
@@ -33,11 +33,15 @@ class CreateSourceFileJob < ApplicationJob
     end
 
     if original_source_file.present?
-      source_file.update!(original_source_file:)
+      source_file.update!(
+        original_source_file:,
+        assignee: original_source_file.assignee
+      )
       original_source_file.update!(
         link_to_pdf_filename: nil,
         status: :archived,
-        courtesy_notification: :not_required
+        courtesy_notification: :not_required,
+        assignee: nil
       )
     end
   end

--- a/lib/tasks/deployment/20240321171227_convert_remaining_word_files_to_pdf.rake
+++ b/lib/tasks/deployment/20240321171227_convert_remaining_word_files_to_pdf.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc "Deployment task: convert_remaining_word_files_to_pdf"
+  task convert_remaining_word_files_to_pdf: :environment do
+    puts "Running deploy task 'convert_remaining_word_files_to_pdf'"
+
+    StandardsImport.find_each do |standard_import|
+      standard_import.source_files.each do |source_file|
+        DocToPdfConverterJob.perform_later(source_file)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/scraper.rake
+++ b/lib/tasks/scraper.rake
@@ -18,7 +18,7 @@ namespace :scraper do
   task doc_to_pdf: :environment do
     StandardsImport.find_each do |standard_import|
       standard_import.source_files.each do |source_file|
-        DocToPdfConverterJob.perform_now(source_file)
+        DocToPdfConverterJob.perform_later(source_file)
       end
     end
   end

--- a/lib/tasks/scraper.rake
+++ b/lib/tasks/scraper.rake
@@ -13,13 +13,4 @@ namespace :scraper do
       puts "Use FORCE=true to force this task"
     end
   end
-
-  desc "one-off task to convert any remaining doc files to pdf"
-  task doc_to_pdf: :environment do
-    StandardsImport.find_each do |standard_import|
-      standard_import.source_files.each do |source_file|
-        DocToPdfConverterJob.perform_later(source_file)
-      end
-    end
-  end
 end

--- a/lib/tasks/scraper.rake
+++ b/lib/tasks/scraper.rake
@@ -13,21 +13,4 @@ namespace :scraper do
       puts "Use FORCE=true to force this task"
     end
   end
-
-  desc "one-off task to extract attachments from bulletins"
-  task back_extract_bulletins: :environment do
-    # Checking for bulletin: false since we want to back extract Bulletins
-    # that existed before we added that flag.
-    StandardsImport.where(bulletin: false).where("notes LIKE ?", "%BulletinsJob%").find_each do |standards_import|
-      standards_import.source_files.each do |source_file|
-        if source_file.docx?
-          Scraper::ExportFileAttachmentsJob.perform_now(source_file)
-        end
-        source_file.update!(assignee: nil)
-        standards_import.update!(bulletin: true)
-      rescue => e
-        Rails.error.report(e)
-      end
-    end
-  end
 end

--- a/lib/tasks/scraper.rake
+++ b/lib/tasks/scraper.rake
@@ -13,4 +13,13 @@ namespace :scraper do
       puts "Use FORCE=true to force this task"
     end
   end
+
+  desc "one-off task to convert any remaining doc files to pdf"
+  task doc_to_pdf: :environment do
+    StandardsImport.find_each do |standard_import|
+      standard_import.source_files.each do |source_file|
+        DocToPdfConverterJob.perform_now(source_file)
+      end
+    end
+  end
 end

--- a/spec/jobs/create_source_file_job_spec.rb
+++ b/spec/jobs/create_source_file_job_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe CreateSourceFileJob, "#perform", type: :job do
       pdf_file = file_fixture("pixel1x1.pdf")
       import = create(:standards_import, files: [docx_file, pdf_file], courtesy_notification: :pending, name: "Mickey", email: "mouse@example.com")
       docx = import.source_files.find(&:word?)
-      docx.update!(link_to_pdf_filename: "pixel1x1.pdf")
+      assignee = create(:admin)
+      docx.update!(link_to_pdf_filename: "pixel1x1.pdf", assignee: assignee)
 
       pdf = import.source_files.find(&:pdf?)
       attachment = pdf.active_storage_attachment
@@ -94,10 +95,12 @@ RSpec.describe CreateSourceFileJob, "#perform", type: :job do
       expect(docx.reload).to have_attributes(
         status: "archived",
         link_to_pdf_filename: nil,
-        courtesy_notification: "not_required"
+        courtesy_notification: "not_required",
+        assignee: nil
       )
       pdf = import.source_files.find(&:pdf?)
       expect(pdf.original_source_file_id).to eql(docx.id)
+      expect(pdf.assignee).to eql(assignee)
     end
   end
 end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206663256915727/f)

This ensures that any assignee on a word source file is transferred to the converted pdf file, and that the assignee is cleared from the now-archived word file.

This also adds a one-time rake task to loop through all StandardsImports and convert any remaining word files to pdf.
