### PR TITLE
Add metadata to standards import

### DIFF
--- a/app/jobs/create_source_file_job.rb
+++ b/app/jobs/create_source_file_job.rb
@@ -15,7 +15,8 @@ class CreateSourceFileJob < ApplicationJob
         SourceFile
           .create_with(
             courtesy_notification:,
-            public_document: standards_import.public_document
+            public_document: standards_import.public_document,
+            metadata: standards_import.metadata
           )
           .find_or_create_by!(active_storage_attachment_id: attachment.id)
           .tap { maybe_link_to_original_source_file(_1, linkable_word_files) }

--- a/app/jobs/scraper/apprenticeship_bulletins_job.rb
+++ b/app/jobs/scraper/apprenticeship_bulletins_job.rb
@@ -17,7 +17,8 @@ class Scraper::ApprenticeshipBulletinsJob < ApplicationJob
         notes: "From Scraper::ApprenticeshipBulletinsJob",
         public_document: true,
         source_url: BULLETIN_LIST_URL,
-        bulletin: true
+        bulletin: true,
+        metadata: { date: row["Date"] }
       )
 
       if standards_import.new_record?

--- a/app/jobs/scraper/apprenticeship_bulletins_job.rb
+++ b/app/jobs/scraper/apprenticeship_bulletins_job.rb
@@ -18,7 +18,7 @@ class Scraper::ApprenticeshipBulletinsJob < ApplicationJob
         public_document: true,
         source_url: BULLETIN_LIST_URL,
         bulletin: true,
-        metadata: { date: row["Date"] }
+        metadata: {date: row["Date"]}
       )
 
       if standards_import.new_record?
@@ -33,9 +33,6 @@ class Scraper::ApprenticeshipBulletinsJob < ApplicationJob
           end
 
           source_file.update!(
-            metadata: {
-              date: row["Date"]
-            },
             bulletin: true
           )
           if source_file.docx?

--- a/app/jobs/scraper/hcap_job.rb
+++ b/app/jobs/scraper/hcap_job.rb
@@ -40,13 +40,9 @@ class Scraper::HcapJob < ApplicationJob
 
         if standards_import.new_record?
           standards_import.save!
-
-          if standards_import.files.attach(io: URI.parse(pdf_uri).open, filename: File.basename(pdf_uri))
-            source_file = standards_import.files.last.source_file
-            source_file.update!(
-              metadata: fields
-            )
-          end
+          standards_import.files.attach(
+            io: URI.parse(pdf_uri).open, filename: File.basename(pdf_uri)
+          )
         end
       end
     end

--- a/app/jobs/scraper/hcap_job.rb
+++ b/app/jobs/scraper/hcap_job.rb
@@ -34,7 +34,8 @@ class Scraper::HcapJob < ApplicationJob
           organization: fields["Sponsor"]
         ).first_or_initialize(
           notes: "From Scraper::HcapJob",
-          public_document: true
+          public_document: true,
+          metadata: fields
         )
 
         if standards_import.new_record?

--- a/db/migrate/20240328221229_add_metadata_to_standards_imports.rb
+++ b/db/migrate/20240328221229_add_metadata_to_standards_imports.rb
@@ -1,0 +1,5 @@
+class AddMetadataToStandardsImports < ActiveRecord::Migration[7.1]
+  def change
+    add_column :standards_imports, :metadata, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_20_194256) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_28_221229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -258,6 +258,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_20_194256) do
     t.string "source_url"
     t.integer "courtesy_notification", default: 0
     t.boolean "bulletin", default: false, null: false
+    t.jsonb "metadata", default: {}, null: false
   end
 
   create_table "states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
+++ b/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Scraper::ApprenticeshipBulletinsJob, type: :job do
         expect(standard_import.public_document).to be true
         expect(standard_import.source_url).to eq Scraper::ApprenticeshipBulletinsJob::BULLETIN_LIST_URL
         expect(standard_import).to be_bulletin
+        expect(standard_import.metadata).to eq({"date" => "03/11/16"})
 
         source_file = SourceFile.last
         expect(source_file.metadata).to eq({"date" => "03/11/16"})

--- a/spec/jobs/scraper/hcap_job_spec.rb
+++ b/spec/jobs/scraper/hcap_job_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe Scraper::HcapJob, type: :job do
           expect(standards_import1.organization).to eq "National Center for Healthcare Apprenticeships"
           expect(standards_import1.notes).to eq "From Scraper::HcapJob"
           expect(standards_import1.public_document).to be true
-          source_file1 = standards_import1.files.last.source_file
-          metadata1 = source_file1.metadata
+          metadata1 = standards_import1.metadata
           expect(metadata1["Location"]).to eq "California"
           expect(metadata1["Care Setting"]).to eq "Ambulatory"
           expect(metadata1["Approval Date"]).to eq "Signed in 2017"
@@ -30,6 +29,8 @@ RSpec.describe Scraper::HcapJob, type: :job do
           expect(metadata1["Resource Type"]).to eq "Work Processes, Related Outline"
           expect(metadata1["Occupation"]).to eq "Emergency Medical Technician"
           expect(metadata1["Apprenticeship Type"]).to eq "Competency-based"
+          source_file1 = standards_import1.files.last.source_file
+          expect(source_file1.metadata).to eq standards_import1.metadata
 
           standards_import2 = StandardsImport.second
           expect(standards_import2.files.count).to eq 1
@@ -37,8 +38,7 @@ RSpec.describe Scraper::HcapJob, type: :job do
           expect(standards_import2.organization).to eq "AHIMA Foundation"
           expect(standards_import2.notes).to eq "From Scraper::HcapJob"
           expect(standards_import2.public_document).to be true
-          source_file2 = standards_import2.files.last.source_file
-          metadata2 = source_file2.metadata
+          metadata2 = standards_import2.metadata
           expect(metadata2["Location"]).to eq "No results"
           expect(metadata2["Care Setting"]).to eq "Acute, Ambulatory"
           expect(metadata2["Approval Date"]).to eq "Signed in 2018"
@@ -49,6 +49,8 @@ RSpec.describe Scraper::HcapJob, type: :job do
           expect(metadata2["Resource Type"]).to eq "Work Processes, Related Outline"
           expect(metadata2["Occupation"]).to eq "Health Information Management Business Analyst"
           expect(metadata2["Apprenticeship Type"]).to eq "Competency-based"
+          source_file2 = standards_import2.files.last.source_file
+          expect(source_file2.metadata).to eq standards_import2.metadata
 
           standards_import3 = StandardsImport.third
           expect(standards_import3.files.count).to eq 1
@@ -56,8 +58,7 @@ RSpec.describe Scraper::HcapJob, type: :job do
           expect(standards_import3.organization).to eq "Institute for Wellness Education"
           expect(standards_import3.notes).to eq "From Scraper::HcapJob"
           expect(standards_import3.public_document).to be true
-          source_file3 = standards_import3.files.last.source_file
-          metadata3 = source_file3.metadata
+          metadata3 = standards_import3.metadata
           expect(metadata3["Location"]).to eq "New Jersey"
           expect(metadata3["Care Setting"]).to eq "Ambulatory"
           expect(metadata3["Approval Date"]).to eq "Signed in 2013"
@@ -67,6 +68,8 @@ RSpec.describe Scraper::HcapJob, type: :job do
           expect(metadata3["Resource Type"]).to eq "Work Processes, Related Outline"
           expect(metadata3["Occupation"]).to eq "Wellness Coach"
           expect(metadata3["Apprenticeship Type"]).to eq "Hybrid"
+          source_file3 = standards_import3.files.last.source_file
+          expect(source_file3.metadata).to eq standards_import3.metadata
         end
       end
     end


### PR DESCRIPTION
In an effort to reduce bugs related to race conditions, we no longer want to wait for a SourceFile to be present to assign metadata. Instead, we will assign the metadata to the parent StandardsImport record and copy this field to the SourceFile when it is created.

Note that in the Bulletins scraper task, we are still waiting for the SourceFile to be created before we mark the source_file as a bulletin, but this behavior will be modified in a future PR.

