### PR TITLE
Add RAPIDS::API#documents

### DIFF
--- a/app/services/rapids/api.rb
+++ b/app/services/rapids/api.rb
@@ -4,7 +4,7 @@ module RAPIDS
   class API
     BASE_URL = "https://#{ENV["RAPIDS_SERVER_DOMAIN"]}".freeze
     TOKEN_URL = "#{BASE_URL}/suite/authorization/oauth/token".freeze
-    BASE_PATH = "/suite/webapi/rapids/data-sharing/sponsor"
+    BASE_PATH = "/suite/webapi/rapids/data-sharing"
 
     def self.call
       new
@@ -22,7 +22,13 @@ module RAPIDS
     end
 
     def work_processes(params = {})
-      get("/wps", params)
+      get("/sponsor/wps", params)
+    end
+
+    def documents(wps_id:)
+      post("/documents/wps/#{wps_id}")
+    rescue OAuth2::Error
+      nil
     end
 
     private
@@ -33,6 +39,10 @@ module RAPIDS
 
     def get(path, params = {})
       @access.get("#{BASE_URL}#{BASE_PATH}#{path}", params: params)
+    end
+
+    def post(path)
+      @access.post("#{BASE_URL}#{BASE_PATH}#{path}")
     end
 
     def get_token!

--- a/spec/services/rapids/api_spec.rb
+++ b/spec/services/rapids/api_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RAPIDS::API do
 
         result = described_class.call
 
-        expect(result).to receive(:get).with("/wps", {})
+        expect(result).to receive(:get).with("/sponsor/wps", {})
         result.work_processes
       end
     end
@@ -26,8 +26,34 @@ RSpec.describe RAPIDS::API do
         stub_get_token!
 
         result = described_class.call
-        expect(result).to receive(:get).with("/wps", {batchSize: 50, startIndex: 10})
+        expect(result).to receive(:get).with("/sponsor/wps", {batchSize: 50, startIndex: 10})
         result.work_processes(batchSize: 50, startIndex: 10)
+      end
+    end
+  end
+
+  describe "#documents" do
+    context "when standards has document available" do
+      it "calls the correct end-point" do
+        stub_get_token!
+        wps_id = 123456
+
+        result = described_class.call
+        expect(result).to receive(:post).with("/documents/wps/#{wps_id}")
+        result.documents(wps_id: wps_id)
+      end
+    end
+
+    context "when standard does not have associated document" do
+      it "returns nil" do
+        stub_get_token!
+        wps_id = 500
+
+        result = described_class.call
+        allow(result).to receive(:post).with("/documents/wps/#{wps_id}").and_raise(OAuth2::Error, "internal server error")
+
+        document = result.documents(wps_id: wps_id)
+        expect(document).to be_nil
       end
     end
   end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206821917760866/f)

Add `documents` method to fetch from RAPIDS API. Documents must be consumed using a POST request, as per API docs

This method will be used during RAPIDS import process to attach this document to its occupation standard
