### PR TITLE
Attach documents from RAPIDS API

### DIFF
--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -8,7 +8,6 @@ class ImportDataFromRAPIDSJob < ApplicationJob
     start_index = 1
 
     loop do
-      Rails.logger.info "Processing batchSize: #{PER_PAGE_SIZE}, startIndex: #{start_index}"
       response = service.work_processes(
         batchSize: PER_PAGE_SIZE,
         startIndex: start_index

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -30,7 +30,7 @@ class OccupationStandard < ApplicationRecord
   validates :title, :ojt_type, presence: true
   validates :registration_agency, presence: true
 
-  attr_accessor :inner_hits
+  attr_accessor :inner_hits, :external_id
 
   MAX_SIMILAR_PROGRAMS_TO_DISPLAY = 5
   MAX_RECENTLY_ADDED_OCCUPATIONS_TO_DISPLAY = 4

--- a/app/models/rapids/occupation_standard.rb
+++ b/app/models/rapids/occupation_standard.rb
@@ -18,7 +18,8 @@ module RAPIDS
           registration_agency: find_registration_agency_by_sponsor_number(
             response["sponsorNumber"]
           ),
-          occupation: find_occupation(rapids_code, onet_code)
+          occupation: find_occupation(rapids_code, onet_code),
+          external_id: extract_wps_id(response["wpsDocument"])
         )
       end
 
@@ -72,6 +73,11 @@ module RAPIDS
         return if rapids_code.blank?
 
         rapids_code.gsub(/[A-Za-z]+\z/, "").ljust(4, "0")
+      end
+
+      def extract_wps_id(wps_document_url)
+        result = wps_document_url.match(/.*\/(?<wps_id>\d*)/)
+        result && result[:wps_id]
       end
     end
   end

--- a/app/services/rapids/api.rb
+++ b/app/services/rapids/api.rb
@@ -36,6 +36,8 @@ module RAPIDS
     # Params supported by API:
     # batchSize: The maximum number of items to return in the response. If set to -1, all items will be returned.
     # startIndex: Index of the array in which to start returning values for the subset. Valid values include those greater than zero
+    # rapidsCode: To filter the data based on Unique ID - rapidsCode
+    # onetSocCode: To filter the data based on Unique ID - onetSocCode
 
     def get(path, params = {})
       @access.get("#{BASE_URL}#{BASE_PATH}#{path}", params: params)

--- a/spec/factories/rapids_api/occupation_standards.rb
+++ b/spec/factories/rapids_api/occupation_standards.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     jobDesc { "Operate telephone, radio, or other communication systems to receive and communicate requests for emergency assistance at 9-1-1." }
     jobZone { "Job Zone Two: Some Preparation Needed." }
     isWPSUploaded { false }
-    wpsDocument { "https://entbpmpstg.dol.gov/suite/webapi/rapids/data-sharing/documents/wps/145973" }
+    sequence(:wpsDocument) { |n| "https://entbpmpstg.dol.gov/suite/webapi/rapids/data-sharing/documents/wps/#{n}" }
     dwas { [] }
 
     transient do
@@ -50,6 +50,10 @@ FactoryBot.define do
 
     trait :competency do
       occType { "Competency-Based" }
+    end
+
+    trait :with_wps_document do
+      isWPSUploaded { true }
     end
 
     initialize_with { attributes.stringify_keys }

--- a/spec/jobs/import_data_from_rapids_job_spec.rb
+++ b/spec/jobs/import_data_from_rapids_job_spec.rb
@@ -176,6 +176,113 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
           change(WorkProcess, :count).by(0)
       end
     end
+
+    context "wps document" do
+      context "when document is mark as not uploaded" do
+        it "does not attach a document" do
+          stub_get_token!
+          create_registration_agency_for("MI", agency_type: :oa)
+
+          occupation_standard_response = create_list(
+            :rapids_api_occupation_standard,
+            1,
+            :competency,
+            isWPSUploaded: false
+          )
+          rapids_response = create(:rapids_response, totalCount: 1, wps: occupation_standard_response)
+
+          stub_rapids_api_response(
+            {
+              batchSize: ImportDataFromRAPIDSJob::PER_PAGE_SIZE,
+              startIndex: 1
+            },
+            rapids_response
+          )
+
+          expect {
+            described_class.perform_now
+          }.to change(OccupationStandard, :count).by(1)
+
+          occupation_standard = OccupationStandard.last
+
+          expect(occupation_standard.redacted_document).to_not be_attached
+        end
+      end
+
+      context "when document is mark as uploaded" do
+        context "when response has a document" do
+          it "attaches the document" do
+            stub_get_token!
+            create_registration_agency_for("MI", agency_type: :oa)
+
+            occupation_standard_response = create_list(
+              :rapids_api_occupation_standard,
+              1,
+              :competency,
+              :with_wps_document,
+              wpsDocument: "https://entbpmpstg.dol.gov/suite/webapi/rapids/data-sharing/documents/wps/123456"
+            )
+            rapids_response = create(:rapids_response, totalCount: 1, wps: occupation_standard_response)
+
+            stub_rapids_api_response(
+              {
+                batchSize: ImportDataFromRAPIDSJob::PER_PAGE_SIZE,
+                startIndex: 1
+              },
+              rapids_response
+            )
+
+            document = File.read(Rails.root.join(
+              "spec", "fixtures", "files", "document.docx"
+            ))
+
+            stub_documents_response("123456", document)
+
+            expect {
+              described_class.perform_now
+            }.to change(OccupationStandard, :count).by(1)
+
+            occupation_standard = OccupationStandard.last
+
+            expect(occupation_standard.redacted_document).to be_attached
+          end
+        end
+
+        context "when response does not have a document" do
+          it "skips document attachment" do
+            stub_get_token!
+            create_registration_agency_for("MI", agency_type: :oa)
+
+            occupation_standard_response = create_list(
+              :rapids_api_occupation_standard,
+              1,
+              :competency,
+              :with_wps_document,
+              wpsDocument: "https://entbpmpstg.dol.gov/suite/webapi/rapids/data-sharing/documents/wps/123456"
+            )
+            rapids_response = create(:rapids_response, totalCount: 1, wps: occupation_standard_response)
+
+            stub_rapids_api_response(
+              {
+                batchSize: ImportDataFromRAPIDSJob::PER_PAGE_SIZE,
+                startIndex: 1
+              },
+              rapids_response
+            )
+
+            stub_documents_response("123456", nil)
+
+            expect {
+              described_class.perform_now
+            }.to change(OccupationStandard, :count).by(1)
+
+            occupation_standard = OccupationStandard.last
+
+            expect(occupation_standard.redacted_document).to_not be_attached
+          end
+        end
+      end
+    end
   end
 end
 
@@ -192,6 +299,14 @@ def stub_rapids_api_response(arguments, response)
   allow_any_instance_of(RAPIDS::API).to receive(:get).with("/sponsor/wps", arguments).and_return(
     OpenStruct.new(
       parsed: response
+    )
+  )
+end
+
+def stub_documents_response(wps_id, document)
+  allow_any_instance_of(RAPIDS::API).to receive(:post).with("/documents/wps/#{wps_id}").and_return(
+    OpenStruct.new(
+      body: document
     )
   )
 end

--- a/spec/jobs/import_data_from_rapids_job_spec.rb
+++ b/spec/jobs/import_data_from_rapids_job_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "when receiving a competency-based standard" do
       it "creates the associated records" do
         stub_get_token!
-
-        mi = create(:state, abbreviation: "MI")
-        create(:registration_agency, state: mi, agency_type: :oa)
+        create_registration_agency_for("MI", agency_type: :oa)
 
         occupation_standard_response = create_list(
           :rapids_api_occupation_standard,
@@ -39,9 +37,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "when receiving a time-based standard" do
       it "creates the associated records" do
         stub_get_token!
-
-        mi = create(:state, abbreviation: "MI")
-        create(:registration_agency, state: mi, agency_type: :oa)
+        create_registration_agency_for("MI", agency_type: :oa)
 
         occupation_standard_response = create_list(
           :rapids_api_occupation_standard,
@@ -73,9 +69,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "when receiving a hybrid standard" do
       it "creates the associated records" do
         stub_get_token!
-
-        mi = create(:state, abbreviation: "MI")
-        create(:registration_agency, state: mi, agency_type: :oa)
+        create_registration_agency_for("MI", agency_type: :oa)
 
         occupation_standard_response = create_list(
           :rapids_api_occupation_standard,
@@ -107,10 +101,8 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "pagination" do
       it "performs more than one call with correct arguments when records exceed batch size" do
         stub_get_token!
+        create_registration_agency_for("MI", agency_type: :oa)
         stub_const("ImportDataFromRAPIDSJob::PER_PAGE_SIZE", 1)
-
-        mi = create(:state, abbreviation: "MI")
-        create(:registration_agency, state: mi, agency_type: :oa)
 
         (first_occupation, second_occupation, third_occupation) = create_list(:rapids_api_occupation_standard, 3, :hybrid)
 
@@ -154,9 +146,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "invalid records" do
       it "saves the occupation standard discarding invalid work processes" do
         stub_get_token!
-
-        mi = create(:state, abbreviation: "MI")
-        create(:registration_agency, state: mi, agency_type: :oa)
+        create_registration_agency_for("MI", agency_type: :oa)
 
         invalid_detailed_work_activity = create_list(
           :rapids_api_detailed_work_activity_for_hybrid,
@@ -191,6 +181,11 @@ end
 
 def stub_get_token!
   allow_any_instance_of(RAPIDS::API).to receive(:get_token!).and_return "xxx"
+end
+
+def create_registration_agency_for(state_abbreviation, agency_type:)
+  state = create(:state, abbreviation: "MI")
+  create(:registration_agency, state: state, agency_type: agency_type)
 end
 
 def stub_rapids_api_response(arguments, response)

--- a/spec/models/rapids/occupation_standard_spec.rb
+++ b/spec/models/rapids/occupation_standard_spec.rb
@@ -212,6 +212,17 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           expect(occupation_standard.occupation).to be_nil
         end
       end
+
+      it "extracts external id from wpsDocument value" do
+        occupation_standard_response = build(
+          :rapids_api_occupation_standard,
+          wpsDocument: "https://entbpmpstg.dol.gov/suite/webapi/rapids/data-sharing/documents/wps/111111"
+        )
+
+        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+
+        expect(occupation_standard.external_id).to eq "111111"
+      end
     end
   end
 end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206821917760866/f)

RAPIDS API provides access to occupation standard documents by using their docs end-point with a POST request.

This PR add the ability to determine if a standard has a document and, if available, attaches this document as the redacted file for that specific occupation standard.