### PR TITLE
Move registration agency creation to factory

### DIFF
--- a/spec/factories/registration_agencies.rb
+++ b/spec/factories/registration_agencies.rb
@@ -3,21 +3,20 @@ FactoryBot.define do
     traits_for_enum :agency_type, RegistrationAgency.agency_types
 
     agency_type { :oa }
-
-    trait :for_national_program do
-      state { nil }
-    end
+    state {
+      if for_state_abbreviation
+        build(:state, abbreviation: for_state_abbreviation)
+      else
+        build(:state)
+      end
+    }
 
     transient do
       for_state_abbreviation { nil }
     end
 
-    after(:build) do |registration_agency, context|
-      registration_agency.state ||= if (context.for_state_abbreviation)
-        FactoryBot.build(:state, abbreviation: context.for_state_abbreviation)
-      else
-        FactoryBot.build(:state)
-      end
+    trait :for_national_program do
+      state { nil }
     end
   end
 end

--- a/spec/factories/registration_agencies.rb
+++ b/spec/factories/registration_agencies.rb
@@ -2,11 +2,22 @@ FactoryBot.define do
   factory :registration_agency do
     traits_for_enum :agency_type, RegistrationAgency.agency_types
 
-    state
     agency_type { :oa }
 
     trait :for_national_program do
       state { nil }
+    end
+
+    transient do
+      for_state_abbreviation { nil }
+    end
+
+    after(:build) do |registration_agency, context|
+      registration_agency.state ||= if (context.for_state_abbreviation)
+        FactoryBot.build(:state, abbreviation: context.for_state_abbreviation)
+      else
+        FactoryBot.build(:state)
+      end
     end
   end
 end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -13,13 +13,12 @@ require "rails_helper"
 RSpec.describe PagesHelper, type: :helper do
   describe "#standards_by_state_count" do
     it "returns count of standards in passed state" do
-      wa = create(:state, name: "Washington")
-      ra = create(:registration_agency, state: wa)
+      ra = create(:registration_agency, for_state_abbreviation: "WA")
       create(:occupation_standard, registration_agency: ra)
       create(:occupation_standard, registration_agency: ra)
       create(:occupation_standard)
 
-      expect(helper.standards_by_state_count(wa)).to eq 2
+      expect(helper.standards_by_state_count(ra.state)).to eq 2
     end
   end
 end

--- a/spec/jobs/import_data_from_rapids_job_spec.rb
+++ b/spec/jobs/import_data_from_rapids_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "when receiving a competency-based standard" do
       it "creates the associated records" do
         stub_get_token!
-        create_registration_agency_for("MI", agency_type: :oa)
+        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
 
         occupation_standard_response = create_list(
           :rapids_api_occupation_standard,
@@ -37,7 +37,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "when receiving a time-based standard" do
       it "creates the associated records" do
         stub_get_token!
-        create_registration_agency_for("MI", agency_type: :oa)
+        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
 
         occupation_standard_response = create_list(
           :rapids_api_occupation_standard,
@@ -69,7 +69,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "when receiving a hybrid standard" do
       it "creates the associated records" do
         stub_get_token!
-        create_registration_agency_for("MI", agency_type: :oa)
+        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
 
         occupation_standard_response = create_list(
           :rapids_api_occupation_standard,
@@ -101,7 +101,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "pagination" do
       it "performs more than one call with correct arguments when records exceed batch size" do
         stub_get_token!
-        create_registration_agency_for("MI", agency_type: :oa)
+        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
         stub_const("ImportDataFromRAPIDSJob::PER_PAGE_SIZE", 1)
 
         (first_occupation, second_occupation, third_occupation) = create_list(:rapids_api_occupation_standard, 3, :hybrid)
@@ -146,7 +146,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "invalid records" do
       it "saves the occupation standard discarding invalid work processes" do
         stub_get_token!
-        create_registration_agency_for("MI", agency_type: :oa)
+        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
 
         invalid_detailed_work_activity = create_list(
           :rapids_api_detailed_work_activity_for_hybrid,
@@ -181,7 +181,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
       context "when document is mark as not uploaded" do
         it "does not attach a document" do
           stub_get_token!
-          create_registration_agency_for("MI", agency_type: :oa)
+          create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
 
           occupation_standard_response = create_list(
             :rapids_api_occupation_standard,
@@ -213,7 +213,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         context "when response has a document" do
           it "attaches the document" do
             stub_get_token!
-            create_registration_agency_for("MI", agency_type: :oa)
+            create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
 
             occupation_standard_response = create_list(
               :rapids_api_occupation_standard,
@@ -251,7 +251,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         context "when response does not have a document" do
           it "skips document attachment" do
             stub_get_token!
-            create_registration_agency_for("MI", agency_type: :oa)
+            create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
 
             occupation_standard_response = create_list(
               :rapids_api_occupation_standard,
@@ -288,11 +288,6 @@ end
 
 def stub_get_token!
   allow_any_instance_of(RAPIDS::API).to receive(:get_token!).and_return "xxx"
-end
-
-def create_registration_agency_for(state_abbreviation, agency_type:)
-  state = create(:state, abbreviation: "MI")
-  create(:registration_agency, state: state, agency_type: agency_type)
 end
 
 def stub_rapids_api_response(arguments, response)

--- a/spec/jobs/import_data_from_rapids_job_spec.rb
+++ b/spec/jobs/import_data_from_rapids_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "when receiving a competency-based standard" do
       it "creates the associated records" do
         stub_get_token!
-        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
+        create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
 
         occupation_standard_response = create_list(
           :rapids_api_occupation_standard,
@@ -37,7 +37,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "when receiving a time-based standard" do
       it "creates the associated records" do
         stub_get_token!
-        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
+        create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
 
         occupation_standard_response = create_list(
           :rapids_api_occupation_standard,
@@ -69,7 +69,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "when receiving a hybrid standard" do
       it "creates the associated records" do
         stub_get_token!
-        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
+        create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
 
         occupation_standard_response = create_list(
           :rapids_api_occupation_standard,
@@ -101,7 +101,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "pagination" do
       it "performs more than one call with correct arguments when records exceed batch size" do
         stub_get_token!
-        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
+        create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
         stub_const("ImportDataFromRAPIDSJob::PER_PAGE_SIZE", 1)
 
         (first_occupation, second_occupation, third_occupation) = create_list(:rapids_api_occupation_standard, 3, :hybrid)
@@ -146,7 +146,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
     context "invalid records" do
       it "saves the occupation standard discarding invalid work processes" do
         stub_get_token!
-        create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
+        create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
 
         invalid_detailed_work_activity = create_list(
           :rapids_api_detailed_work_activity_for_hybrid,
@@ -181,7 +181,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
       context "when document is mark as not uploaded" do
         it "does not attach a document" do
           stub_get_token!
-          create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
+          create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
 
           occupation_standard_response = create_list(
             :rapids_api_occupation_standard,
@@ -213,7 +213,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         context "when response has a document" do
           it "attaches the document" do
             stub_get_token!
-            create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
+            create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
 
             occupation_standard_response = create_list(
               :rapids_api_occupation_standard,
@@ -251,7 +251,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         context "when response does not have a document" do
           it "skips document attachment" do
             stub_get_token!
-            create(:registration_agency,  for_state_abbreviation: "MI", agency_type: :oa)
+            create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
 
             occupation_standard_response = create_list(
               :rapids_api_occupation_standard,

--- a/spec/jobs/process_data_import_job_spec.rb
+++ b/spec/jobs/process_data_import_job_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 RSpec.describe ProcessDataImportJob, type: :job do
   describe "#perform" do
     it "calls the separate services to process each tab of the file" do
-      ca = create(:state, abbreviation: "CA")
-      create(:registration_agency, state: ca, agency_type: :oa)
+      create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
       data_import = create(:data_import, :pending)
       create(:industry, prefix: "13")
 
@@ -38,8 +37,7 @@ RSpec.describe ProcessDataImportJob, type: :job do
     end
 
     it "deletes old related instructions, wage schedules, work processes when editing" do
-      ca = create(:state, abbreviation: "CA")
-      create(:registration_agency, state: ca, agency_type: :oa)
+      create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
       data_import = create(:data_import)
       occupation_standard = data_import.occupation_standard
       create(:related_instruction, occupation_standard: occupation_standard, sort_order: 99)
@@ -62,8 +60,7 @@ RSpec.describe ProcessDataImportJob, type: :job do
     end
 
     it "marks the associated source file as complete if last_file is true, marks the occupation standard as in_review, and marks data_import as completed" do
-      ca = create(:state, abbreviation: "CA")
-      create(:registration_agency, state: ca, agency_type: :oa)
+      create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
       data_import = create(:data_import, :pending)
       create(:industry, prefix: "13")
 

--- a/spec/models/rapids/occupation_standard_spec.rb
+++ b/spec/models/rapids/occupation_standard_spec.rb
@@ -78,9 +78,8 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
 
       context "when sponsorNumber contains the name of the state" do
         it "sets OA registration agency for that specific state" do
-          california = create(:state, name: "California", abbreviation: "CA")
-          oa_registration_agency_for_california = create(:registration_agency, state: california, agency_type: "oa")
-          _saa_registration_agency_for_california = create(:registration_agency, state: california, agency_type: "saa")
+          oa_registration_agency_for_california = create(:registration_agency, for_state_abbreviation: "CA", agency_type: "oa")
+          _saa_registration_agency_for_california = create(:registration_agency, for_state_abbreviation: "CA", agency_type: "saa")
 
           occupation_standard_response = create(
             :rapids_api_occupation_standard,

--- a/spec/models/similar_occupation_standards_spec.rb
+++ b/spec/models/similar_occupation_standards_spec.rb
@@ -3,10 +3,8 @@ require "rails_helper"
 RSpec.describe SimilarOccupationStandards, type: :model do
   describe ".similar_to", :elasticsearch do
     it "returns records that are similar to the passed occupation standard" do
-      wa = create(:state, name: "Washington", abbreviation: "WA")
-      al = create(:state, name: "Alabama", abbreviation: "AL")
-      wa_reg_agency = create(:registration_agency, state: wa)
-      al_reg_agency = create(:registration_agency, state: al)
+      al_reg_agency = create(:registration_agency, for_state_abbreviation: "AL")
+      wa_reg_agency = create(:registration_agency, for_state_abbreviation: "WA")
 
       os1 = create(:occupation_standard, :time, title: "Childcare worker", registration_agency: wa_reg_agency)
       create(:work_process, title: "Principles of Child Growth and Development", occupation_standard: os1)

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -9,23 +9,18 @@ RSpec.describe State, type: :model do
 
   describe "#occupation_standards_count" do
     it "returns an occupation standards count by state" do
-      state = create(:state)
-      registration_agency = create(:registration_agency, state: state)
+      registration_agency = create(:registration_agency)
       create_list(:occupation_standard, 3, :with_work_processes, registration_agency: registration_agency)
 
-      expect(state.occupation_standards_count).to eq(3)
+      expect(registration_agency.state.occupation_standards_count).to eq(3)
     end
   end
 
   describe ".popular" do
     it "returns a list of states by number of occupation standards" do
-      ca = create(:state)
-      va = create(:state, name: "Virginia", abbreviation: "VA")
-      nc = create(:state, name: "North Carolina", abbreviation: "NC")
-
-      ca_agency = create(:registration_agency, state: ca)
-      va_agency = create(:registration_agency, state: va)
-      nc_agency = create(:registration_agency, state: nc)
+      ca_agency = create(:registration_agency, for_state_abbreviation: "CA")
+      va_agency = create(:registration_agency, for_state_abbreviation: "VA")
+      nc_agency = create(:registration_agency, for_state_abbreviation: "NC")
 
       create_list(:occupation_standard, 3, :with_work_processes, registration_agency: ca_agency)
       create(:occupation_standard, :with_work_processes, registration_agency: va_agency)

--- a/spec/queries/occupation_standard_elasticsearch_query_spec.rb
+++ b/spec/queries/occupation_standard_elasticsearch_query_spec.rb
@@ -174,10 +174,8 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
   end
 
   it "allows filtering occupation standards by state id" do
-    ca = create(:state)
-    wa = create(:state)
-    ra_ca = create(:registration_agency, state: ca)
-    ra_wa = create(:registration_agency, state: wa)
+    ra_ca = create(:registration_agency, for_state_abbreviation: "CA")
+    ra_wa = create(:registration_agency, for_state_abbreviation: "WA")
     os1 = create(:occupation_standard, :with_work_processes, registration_agency: ra_ca)
     os2 = create(:occupation_standard, :with_work_processes, registration_agency: ra_ca)
     create(:occupation_standard, :with_work_processes, registration_agency: ra_wa)
@@ -185,17 +183,15 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!
 
-    params = {state_id: ca.id}
+    params = {state_id: ra_ca.state.id}
     response = described_class.new(search_params: params).call
 
     expect(response.records.pluck(:id)).to contain_exactly(os1.id, os2.id)
   end
 
   it "allows filtering occupation standards by state abbreviation" do
-    ca = create(:state, abbreviation: "CA")
-    wa = create(:state, abbreviation: "WA")
-    ra_ca = create(:registration_agency, state: ca)
-    ra_wa = create(:registration_agency, state: wa)
+    ra_ca = create(:registration_agency, for_state_abbreviation: "CA")
+    ra_wa = create(:registration_agency, for_state_abbreviation: "WA")
     os1 = create(:occupation_standard, :with_work_processes, registration_agency: ra_ca)
     os2 = create(:occupation_standard, :with_work_processes, registration_agency: ra_ca)
     create(:occupation_standard, :with_work_processes, registration_agency: ra_wa)
@@ -203,7 +199,7 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
     OccupationStandard.import
     OccupationStandard.__elasticsearch__.refresh_index!
 
-    params = {state: ca.abbreviation}
+    params = {state: ra_ca.state.abbreviation}
     response = described_class.new(search_params: params).call
 
     expect(response.records.pluck(:id)).to contain_exactly(os1.id, os2.id)
@@ -248,10 +244,8 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
   end
 
   it "allows searching by title and filtering occupation standards by state and national_standard_type and ojt_type" do
-    ca = create(:state)
-    wa = create(:state)
-    ra_ca = create(:registration_agency, state: ca)
-    ra_wa = create(:registration_agency, state: wa)
+    ra_ca = create(:registration_agency, for_state_abbreviation: "CA")
+    ra_wa = create(:registration_agency, for_state_abbreviation: "WA")
 
     os1 = create(:occupation_standard, :with_work_processes, :program_standard, :hybrid, registration_agency: ra_wa, title: "Pipe Fitter")
     create(:occupation_standard, :with_work_processes, :program_standard, :hybrid, registration_agency: ra_wa, title: "HR")
@@ -264,7 +258,7 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
 
     params = {
       q: "pipe",
-      state_id: wa.id,
+      state_id: ra_wa.state_id,
       national_standard_type: {program_standard: "1"},
       ojt_type: {hybrid: "1"}
     }
@@ -343,8 +337,7 @@ RSpec.describe OccupationStandardElasticsearchQuery, :elasticsearch do
   end
 
   it "collapses search results across headline" do
-    state = create(:state)
-    agency = create(:registration_agency, state: state)
+    agency = create(:registration_agency)
 
     os1 = create(:occupation_standard, :time, registration_agency: agency, title: "Pipe Fitter")
     create(:work_process, occupation_standard: os1, sort_order: 2, title: "fox jumps over", maximum_hours: 100)

--- a/spec/queries/occupation_standard_query_spec.rb
+++ b/spec/queries/occupation_standard_query_spec.rb
@@ -42,15 +42,14 @@ RSpec.describe OccupationStandardQuery do
   end
 
   it "allows filtering occupation standards by state" do
-    ca = create(:state)
-    wa = create(:state)
-    ra_ca = create(:registration_agency, state: ca)
-    ra_wa = create(:registration_agency, state: wa)
+    ra_ca = create(:registration_agency, for_state_abbreviation: "CA")
+    ra_wa = create(:registration_agency, for_state_abbreviation: "WA")
+
     os1 = create(:occupation_standard, registration_agency: ra_ca)
     os2 = create(:occupation_standard, registration_agency: ra_ca)
     create(:occupation_standard, registration_agency: ra_wa)
 
-    params = {state_id: ca.id}
+    params = {state_id: ra_ca.state_id}
 
     occupation_standard_search = OccupationStandardQuery.run(
       OccupationStandard.all, params
@@ -60,15 +59,14 @@ RSpec.describe OccupationStandardQuery do
   end
 
   it "allows filtering occupation standards by state abbreviation" do
-    ca = create(:state, abbreviation: "CA")
-    wa = create(:state, abbreviation: "WA")
-    ra_ca = create(:registration_agency, state: ca)
-    ra_wa = create(:registration_agency, state: wa)
+    ra_ca = create(:registration_agency, for_state_abbreviation: "CA")
+    ra_wa = create(:registration_agency, for_state_abbreviation: "WA")
+
     os1 = create(:occupation_standard, registration_agency: ra_ca)
     os2 = create(:occupation_standard, registration_agency: ra_ca)
     create(:occupation_standard, registration_agency: ra_wa)
 
-    params = {state: ca.abbreviation}
+    params = {state: ra_ca.state.abbreviation}
 
     occupation_standard_search = OccupationStandardQuery.run(
       OccupationStandard.all, params
@@ -116,10 +114,8 @@ RSpec.describe OccupationStandardQuery do
   end
 
   it "allows searching by title and filtering occupation standards by state and national_standard_type and ojt_type" do
-    ca = create(:state)
-    wa = create(:state)
-    ra_ca = create(:registration_agency, state: ca)
-    ra_wa = create(:registration_agency, state: wa)
+    ra_ca = create(:registration_agency, for_state_abbreviation: "CA")
+    ra_wa = create(:registration_agency, for_state_abbreviation: "WA")
 
     os1 = create(:occupation_standard, :program_standard, :hybrid, registration_agency: ra_wa, title: "Mechanic")
     create(:occupation_standard, :program_standard, :hybrid, registration_agency: ra_wa, title: "HR")
@@ -129,7 +125,7 @@ RSpec.describe OccupationStandardQuery do
 
     params = {
       q: "mech",
-      state_id: wa.id,
+      state_id: ra_wa.state_id,
       national_standard_type: {program_standard: "1"},
       ojt_type: {hybrid: "1"}
     }

--- a/spec/requests/api/v1/standards_spec.rb
+++ b/spec/requests/api/v1/standards_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe "api/v1/standards", type: :request do
       let(:user) { create(:user) }
       let(:token) { user.create_api_access_token!.jwt_token }
       let(:Authorization) { "Bearer #{token}" }
-      let(:ca_state) { create(:state, name: "California") }
-      let(:registration_agency) { create(:registration_agency, agency_type: :saa, state: ca_state) }
+      let(:registration_agency) { create(:registration_agency, agency_type: :saa, for_state_abbreviation: "CA") }
       let!(:standard1) {
         create(
           :occupation_standard,
@@ -453,8 +452,7 @@ RSpec.describe "api/v1/standards", type: :request do
         let(:user) { create(:user) }
         let(:token) { user.create_api_access_token!.jwt_token }
         let(:Authorization) { "Bearer #{token}" }
-        let(:ca_state) { create(:state, name: "California") }
-        let(:registration_agency) { create(:registration_agency, agency_type: :saa, state: ca_state) }
+        let(:registration_agency) { create(:registration_agency, agency_type: :saa, for_state_abbreviation: "CA") }
         let!(:standard) {
           create(
             :occupation_standard,

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -26,12 +26,11 @@ RSpec.describe "OccupationStandard", type: :request do
 
         it "makes one Elasticsearch query if only filter params" do
           stub_feature_flag(:use_elasticsearch_for_search, true)
-          state = create(:state)
-          ra = create(:registration_agency, state: state)
+          ra = create(:registration_agency)
           create(:occupation_standard, :with_work_processes, :with_data_import, registration_agency: ra)
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
-          get occupation_standards_path(state_id: state.id)
+          get occupation_standards_path(state_id: ra.state_id)
 
           expect(response).to be_successful
         end

--- a/spec/services/import_occupation_standard_details_spec.rb
+++ b/spec/services/import_occupation_standard_details_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 RSpec.describe ImportOccupationStandardDetails do
   describe "#call" do
     it "returns an occupation standards record" do
-      ca = create(:state, abbreviation: "CA")
-      create(:registration_agency, state: ca, agency_type: :oa)
+      create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
       create(:industry, prefix: "13")
 
       data_import = create(:data_import, :pending)
@@ -15,9 +14,8 @@ RSpec.describe ImportOccupationStandardDetails do
 
     context "when data_import has no occupation_standard associated" do
       it "creates an occupation standards record for time-based" do
-        ca = create(:state, abbreviation: "CA")
-        ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
-        _ca_saa = create(:registration_agency, state: ca, agency_type: :saa)
+        ca_oa = create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
+        _ca_saa = create(:registration_agency, for_state_abbreviation: "CA", agency_type: :saa)
         onet = create(:onet, code: "13-1071.01")
         industry = create(:industry, prefix: "13")
 
@@ -53,8 +51,7 @@ RSpec.describe ImportOccupationStandardDetails do
       end
 
       it "creates an occupation standards record for competency-based" do
-        ca = create(:state, abbreviation: "CA")
-        ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
+        ca_oa = create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
 
         create(:onet, code: "13-1071.01")
         industry = create(:industry, prefix: "13")
@@ -87,8 +84,7 @@ RSpec.describe ImportOccupationStandardDetails do
       end
 
       it "creates an occupation standards record when there is no RAPIDS code" do
-        ca = create(:state, abbreviation: "CA")
-        ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
+        ca_oa = create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
 
         onet = create(:onet, code: "31-1071.01")
         industry = create(:industry, prefix: "31")
@@ -152,8 +148,7 @@ RSpec.describe ImportOccupationStandardDetails do
       end
 
       it "uses occupation's RAPIDS code if no RAPIDS code" do
-        ca = create(:state, abbreviation: "CA")
-        create(:registration_agency, state: ca, agency_type: :oa)
+        create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
 
         onet = create(:onet, code: "31-1071.01")
         create(:industry, prefix: "31")
@@ -170,8 +165,7 @@ RSpec.describe ImportOccupationStandardDetails do
       end
 
       it "does not set RAPIDS code if blank and occupation does not exist" do
-        ca = create(:state, abbreviation: "CA")
-        create(:registration_agency, state: ca, agency_type: :oa)
+        create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
         create(:industry, prefix: "31")
 
         data_import = create(:data_import, :no_rapids, :pending)
@@ -185,8 +179,7 @@ RSpec.describe ImportOccupationStandardDetails do
       end
 
       it "uses occupation's ONET code if no ONET code" do
-        ca = create(:state, abbreviation: "CA")
-        create(:registration_agency, state: ca, agency_type: :oa)
+        create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
 
         onet = create(:onet, code: "13-1081.01")
         create(:industry, prefix: "13")
@@ -203,8 +196,7 @@ RSpec.describe ImportOccupationStandardDetails do
       end
 
       it "does not set ONET code if blank and occupation does not exist" do
-        ca = create(:state, abbreviation: "CA")
-        create(:registration_agency, state: ca, agency_type: :oa)
+        create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
 
         data_import = create(:data_import, :no_onet, :pending)
 
@@ -217,8 +209,7 @@ RSpec.describe ImportOccupationStandardDetails do
       end
 
       it "finds and updates the occupation standard record linked to the same source file with the same name if one exists" do
-        ca = create(:state, abbreviation: "CA")
-        ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
+        ca_oa = create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
 
         create(:onet, code: "13-1071.01")
         industry = create(:industry, prefix: "13")
@@ -259,8 +250,7 @@ RSpec.describe ImportOccupationStandardDetails do
 
     context "when data_import already has an occupation_standard associated" do
       it "updates the occupation standards record" do
-        ca = create(:state, abbreviation: "CA")
-        ca_oa = create(:registration_agency, state: ca, agency_type: :oa)
+        ca_oa = create(:registration_agency, for_state_abbreviation: "CA", agency_type: :oa)
 
         create(:onet, code: "13-1071.01")
         industry = create(:industry, prefix: "13")

--- a/spec/system/admin/occupation_standards/edit_spec.rb
+++ b/spec/system/admin/occupation_standards/edit_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "admin/occupation_standards/edit" do
   it "allows admin user to edit occupation_standard", :admin do
-    create(:registration_agency, state: nil) # National registration agency
     data_import = create(:data_import)
     occupation_standard = data_import.occupation_standard
     admin = create(:admin)

--- a/spec/system/occupation_standards/by_state_spec.rb
+++ b/spec/system/occupation_standards/by_state_spec.rb
@@ -2,11 +2,8 @@ require "rails_helper"
 
 RSpec.describe ":state/occupation_standards" do
   it "shows occupations from registration matching state initials" do
-    new_york = create(:state, name: "New York", abbreviation: "NY")
-    nevada = create(:state, name: "Nevada", abbreviation: "NV")
-
-    new_york_registration_agency = create(:registration_agency, state: new_york)
-    nevada_registration_agency = create(:registration_agency, state: nevada)
+    new_york_registration_agency = create(:registration_agency, for_state_abbreviation: "NY")
+    nevada_registration_agency = create(:registration_agency, for_state_abbreviation: "NV")
 
     standard_from_new_york = create(:occupation_standard,
       :with_work_processes,
@@ -19,7 +16,7 @@ RSpec.describe ":state/occupation_standards" do
       title: "Pipe Fitter",
       registration_agency: nevada_registration_agency)
 
-    visit occupation_standards_by_state_path(state: new_york.abbreviation)
+    visit occupation_standards_by_state_path(state: new_york_registration_agency.state.abbreviation)
 
     expect(page).to have_link "Mechanic", href: occupation_standard_path(standard_from_new_york)
     expect(page).not_to have_link "Pipe Fitter"

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -564,7 +564,6 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards with state shortcode" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
-      # washington = create(:state, name: "Washington", abbreviation: "WA")
       washington_registration_agency = create(:registration_agency, for_state_abbreviation: "WA")
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: washington_registration_agency)
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -154,8 +154,7 @@ RSpec.describe "occupation_standards/index" do
     end
 
     it "filters standards with state shortcode" do
-      washington = create(:state, name: "Washington", abbreviation: "WA")
-      washington_registration_agency = create(:registration_agency, state: washington)
+      washington_registration_agency = create(:registration_agency, for_state_abbreviation: "WA")
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: washington_registration_agency)
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR", onet_code: "12.34")
@@ -565,8 +564,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards with state shortcode" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
-      washington = create(:state, name: "Washington", abbreviation: "WA")
-      washington_registration_agency = create(:registration_agency, state: washington)
+      # washington = create(:state, name: "Washington", abbreviation: "WA")
+      washington_registration_agency = create(:registration_agency, for_state_abbreviation: "WA")
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: washington_registration_agency)
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR", onet_code: "12.34")


### PR DESCRIPTION
We usually have to create an state in order to create a registration agency for that state. This PR introduces a transient called `for_state_abbreviation`, which allows to set an specific state abbreviation directly in the factory.