### PR TITLE
Introduce import tree

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,0 +1,3 @@
+class Import < ApplicationRecord
+  belongs_to :parent, polymorphic: true
+end

--- a/app/models/imports/doc.rb
+++ b/app/models/imports/doc.rb
@@ -1,0 +1,6 @@
+module Imports
+  class Doc < Import
+    has_one :pdf, as: :parent, dependent: :destroy, autosave: true
+    has_one_attached :file
+  end
+end

--- a/app/models/imports/docx.rb
+++ b/app/models/imports/docx.rb
@@ -1,0 +1,6 @@
+module Imports
+  class Docx < Import
+    has_one :pdf, as: :parent, dependent: :destroy, autosave: true
+    has_one_attached :file
+  end
+end

--- a/app/models/imports/docx_listing.rb
+++ b/app/models/imports/docx_listing.rb
@@ -1,0 +1,6 @@
+module Imports
+  class DocxListing < Import
+    has_many :imports, as: :parent, dependent: :destroy, autosave: true
+    has_one_attached :file
+  end
+end

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -1,0 +1,5 @@
+module Imports
+  class Pdf < Import
+    has_one_attached :file
+  end
+end

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -1,0 +1,6 @@
+module Imports
+  class Uncategorized < Import
+    has_one_attached :file
+    has_one :import, as: :parent, dependent: :destroy, autosave: true
+  end
+end

--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -1,5 +1,6 @@
 class StandardsImport < ApplicationRecord
   has_many_attached :files
+  has_many :imports, as: :parent, dependent: :destroy
 
   enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true
 

--- a/db/migrate/20240404161634_add_uploads_to_standards_import.rb
+++ b/db/migrate/20240404161634_add_uploads_to_standards_import.rb
@@ -1,0 +1,14 @@
+class AddUploadsToStandardsImport < ActiveRecord::Migration[7.1]
+  def change
+    create_table :imports, id: :uuid do |t|
+      t.integer "status", default: 0, null: false
+      t.references "assignee", foreign_key: {to_table: :users}, type: :uuid
+      t.boolean "public_document", default: false, null: false
+      t.integer "courtesy_notification", default: 0
+      t.references "parent", polymorphic: true, null: false, type: :uuid
+      t.string "type", null: false
+      t.jsonb "metadata", default: {}
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_28_221229) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_04_161634) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -119,6 +119,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_28_221229) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
+  create_table "imports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "status", default: 0, null: false
+    t.uuid "assignee_id"
+    t.boolean "public_document", default: false, null: false
+    t.integer "courtesy_notification", default: 0
+    t.string "parent_type", null: false
+    t.uuid "parent_id", null: false
+    t.string "type", null: false
+    t.jsonb "metadata", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assignee_id"], name: "index_imports_on_assignee_id"
+    t.index ["parent_type", "parent_id"], name: "index_imports_on_parent"
   end
 
   create_table "industries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -344,6 +359,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_28_221229) do
   add_foreign_key "data_imports", "occupation_standards"
   add_foreign_key "data_imports", "source_files"
   add_foreign_key "data_imports", "users"
+  add_foreign_key "imports", "users", column: "assignee_id"
   add_foreign_key "occupation_standards", "industries"
   add_foreign_key "occupation_standards", "occupations"
   add_foreign_key "occupation_standards", "organizations"

--- a/spec/factories/imports.rb
+++ b/spec/factories/imports.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :imports_uncategorized, class: Imports::Uncategorized do
+    parent factory: :standards_import
+    type { "Imports::Uncategorized" }
+    file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"), "application/pdf") }
+  end
+
+  factory :imports_docx_listing, class: Imports::DocxListing do
+    parent factory: :imports_uncategorized
+    type { "Imports::DocxListing" }
+    file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "docx_file_attachments.docx")) }
+  end
+
+  factory :imports_docx, class: Imports::Docx do
+    parent factory: :imports_uncategorized
+    type { "Imports::Docx" }
+    file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "document.docx")) }
+  end
+
+  factory :imports_pdf, class: Imports::Pdf do
+    parent factory: :imports_uncategorized
+    type { "Imports::Pdf" }
+    file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"), "application/pdf") }
+  end
+end


### PR DESCRIPTION
Document imports come in via two ways:

- User uploads a document directly, typically a PDF or Docx
- We fetch data from an endpoint, typically PDF or Docx

The Docx that we fetch sometimes has attachments, which we then continue to process. It can look like this:

```
Docx (listing)
    |
   / \
Docx  Docx
  |    |
 PDF  PDF
```

A `StandardsImport` model can contain many of these trees, if we process multiple API endpoints or if the user uploads many documents.

An additional thing to note is that knowing whether something is a Docx listing, Docx, Doc, or PDF is itself a processing step. At first it's an uncategorized attachment.

Therefore, we can imagine this structure:

```
                  StandardsImport
                         |
     /-------------------+-------------------\
     |                   |                   |
Uncategorized      Uncategorized       Uncategorized
    |                    |                   |
Docx (listing)          PDF                 Doc
    |                                        |
   / \                                      PDF
Docx  Docx
  |    |
 PDF  PDF
```

And so we get our processing rules:

- An Uncategorized processes into a Docx, Docx listing, Doc, or PDF
- A Docx listing processes into many imports, which are Docx, Doc, or PDF
- A Docx and Doc process into a PDF

And our assumptions:

- A StandardsImport has many imports, all of which are Uncategorized
- A PDF terminates

---

This commit is the first step in implementing this. It add the tree, but does not yet connect it. We have documented connection tasks in Asana.

The tree is single table inheritance (STI). This allows the StandardsImport#imports to be of any type, and each import can have any parent.

STI brings some constraints:

- The factory_bot definitions must be separate for each child, and must define a `type` column.
- The `belongs_to :parent` must be in the parent (`Import`). To quote [the Rails docs]:
    > Using polymorphic associations in combination with single table
    > inheritance (STI) is a little tricky. In order for the
    > associations to work as expected, ensure that you store the base
    > model for the STI models in the type column of the polymorphic
    > association. To continue with the asset example above, suppose
    > there are guest posts and member posts that use the posts table
    > for STI. In this case, there must be a type column in the posts
    > table.

[the Rails docs]: https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#module-ActiveRecord::Associations::ClassMethods-label-Polymorphic+Associations

STI also means that the one table must cater to every child:

- `assignee`, `public_document`, `courtesy_notification`, `metadata` - needed for PDF
- `status`, `parent`, `type` - needed for all children

---

[Asana ticket](https://app.asana.com/0/1203289004376659/1207002310256042)

Co-authored-by: Fernando Perales <fer@thoughtbot.com>
Co-authored-by: Jeanine Soterwood <jeanine@thoughtbot.com>