### PR TITLE
Add sort order to competencies from Work Process

### DIFF
--- a/app/models/rapids/competency.rb
+++ b/app/models/rapids/competency.rb
@@ -2,7 +2,8 @@ module RAPIDS
   class Competency
     def self.initialize_from_response(competency_data)
       ::Competency.new(
-        title: competency_data["title"]
+        title: competency_data["title"],
+        sort_order: competency_data["sort_order"]
       )
     end
   end

--- a/app/models/rapids/work_process.rb
+++ b/app/models/rapids/work_process.rb
@@ -26,9 +26,10 @@ module RAPIDS
 
       def process_competencies(tasks)
         tasks_titles = tasks.first.split(/\s?;\s?/)
-        tasks_titles.map do |task_title|
+        tasks_titles.map.with_index do |task_title, index|
           Competency.initialize_from_response({
-            "title" => task_title
+            "title" => task_title,
+            "sort_order" => index
           })
         end
       end

--- a/spec/models/rapids/competency_spec.rb
+++ b/spec/models/rapids/competency_spec.rb
@@ -9,5 +9,19 @@ RSpec.describe RAPIDS::Competency, type: :model do
 
       expect(competency.title).to eq "Competency #1"
     end
+
+    it "sets the sort_order if provided" do
+      competency_response = create(:rapids_api_competency)
+
+      competency = described_class.initialize_from_response(
+        competency_response.merge(
+          {
+            "sort_order" => 2
+          }
+        )
+      )
+
+      expect(competency.sort_order).to eq 2
+    end
   end
 end

--- a/spec/models/rapids/work_process_spec.rb
+++ b/spec/models/rapids/work_process_spec.rb
@@ -29,8 +29,11 @@ RSpec.describe RAPIDS::WorkProcess, type: :model do
 
       expect(work_process.competencies.size).to eq 3
       expect(first_competency.title).to eq "Competency #1"
+      expect(first_competency.sort_order).to eq 0
       expect(second_competency.title).to eq "Competency #2"
+      expect(second_competency.sort_order).to eq 1
       expect(third_competency.title).to eq "Competency #3"
+      expect(third_competency.sort_order).to eq 2
     end
 
     it "returns correct number of competencies regardless of extra or missing spacing" do


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206992680139955)


While running the importer with production data, work processes were not created even though they were valid. After further inspection, work process was not saved due to their competencies being invalid: a competency requires a unique sort order for a given work process.

This PR add the sort order when creating a competency from the work process