### PR TITLE
Create competencies only when occupation is not time-based

### DIFF
--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -66,7 +66,8 @@ class ImportDataFromRAPIDSJob < ApplicationJob
   def process_work_processes(work_processes_response, occupation_standard)
     work_processes_response.filter_map do |work_process_response|
       work_process = RAPIDS::WorkProcess.initialize_from_response(
-        work_process_response
+        work_process_response,
+        ojt_type: occupation_standard&.ojt_type&.to_sym
       )
       work_process.occupation_standard = occupation_standard
       work_process if work_process.valid?

--- a/app/models/rapids/work_process.rb
+++ b/app/models/rapids/work_process.rb
@@ -1,8 +1,9 @@
 module RAPIDS
   class WorkProcess
     class << self
-      def initialize_from_response(work_process_data)
+      def initialize_from_response(work_process_data, ojt_type: nil)
         tasks = work_process_data["tasks"]
+        tasks_titles = tasks.first.split(/\s?;\s?/)
 
         work_process = ::WorkProcess.new(
           title: work_process_data["title"],
@@ -10,9 +11,13 @@ module RAPIDS
           maximum_hours: work_process_data["maxHours"]
         )
 
-        if competencies_available?(tasks)
-          competencies = process_competencies(tasks)
-          work_process.competencies = competencies
+        if competencies_available?(tasks_titles)
+          if ojt_type == :time
+            work_process.description = tasks_titles.join("; ")
+          else
+            competencies = process_competencies(tasks_titles)
+            work_process.competencies = competencies
+          end
         end
 
         work_process
@@ -20,12 +25,11 @@ module RAPIDS
 
       private
 
-      def competencies_available?(tasks)
-        tasks&.first&.present?
+      def competencies_available?(tasks_titles)
+        tasks_titles.any?
       end
 
-      def process_competencies(tasks)
-        tasks_titles = tasks.first.split(/\s?;\s?/)
+      def process_competencies(tasks_titles)
         tasks_titles.map.with_index do |task_title, index|
           Competency.initialize_from_response({
             "title" => task_title,

--- a/spec/factories/rapids_api/occupation_standards.rb
+++ b/spec/factories/rapids_api/occupation_standards.rb
@@ -24,17 +24,20 @@ FactoryBot.define do
           when "Hybrid"
             create_list(
               :rapids_api_detailed_work_activity_for_hybrid,
-              context.with_detailed_work_activities
+              context.with_detailed_work_activities,
+              with_tasks: 1
             )
           when "Time-Based"
             create_list(
               :rapids_api_detailed_work_activity_for_time_based,
-              context.with_detailed_work_activities
+              context.with_detailed_work_activities,
+              with_tasks: 1
             )
           when "Competency-Based"
             create_list(
               :rapids_api_detailed_work_activity_for_competency_based,
-              context.with_detailed_work_activities
+              context.with_detailed_work_activities,
+              with_tasks: 1
             )
           end
       end

--- a/spec/jobs/import_data_from_rapids_job_spec.rb
+++ b/spec/jobs/import_data_from_rapids_job_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         expect {
           described_class.perform_now
         }.to change(OccupationStandard, :count).by(1).and \
-          change(WorkProcess, :count).by(3)
+          change(WorkProcess, :count).by(3).and \
+            change(Competency, :count).by(3)
 
         occupation_standard = OccupationStandard.last
 
@@ -57,7 +58,8 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         expect {
           described_class.perform_now
         }.to change(OccupationStandard, :count).by(1).and \
-          change(WorkProcess, :count).by(2)
+          change(WorkProcess, :count).by(2).and \
+            change(Competency, :count).by(0)
 
         occupation_standard = OccupationStandard.last
 
@@ -89,7 +91,8 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         expect {
           described_class.perform_now
         }.to change(OccupationStandard, :count).by(1).and \
-          change(WorkProcess, :count).by(4)
+          change(WorkProcess, :count).by(4).and \
+            change(Competency, :count).by(4)
 
         occupation_standard = OccupationStandard.last
 

--- a/spec/models/rapids/work_process_spec.rb
+++ b/spec/models/rapids/work_process_spec.rb
@@ -51,5 +51,52 @@ RSpec.describe RAPIDS::WorkProcess, type: :model do
       expect(second_competency.title).to eq "Competency #2"
       expect(third_competency.title).to eq "Competency #3"
     end
+
+    context "when receiving ojt_type" do
+      it "creates competencies when ojt_type is hybrid" do
+        work_process_response = create(
+          :rapids_api_detailed_work_activity,
+          tasks: ["Competency #1 ; Competency #2;Competency #3"]
+        )
+
+        work_process = described_class.initialize_from_response(
+          work_process_response,
+          ojt_type: :hybrid
+        )
+
+        expect(work_process.description).to be_nil
+        expect(work_process.competencies.size).to eq 3
+      end
+
+      it "creates competencies when ojt_type is competency" do
+        work_process_response = create(
+          :rapids_api_detailed_work_activity,
+          tasks: ["Competency #1 ; Competency #2;Competency #3"]
+        )
+
+        work_process = described_class.initialize_from_response(
+          work_process_response,
+          ojt_type: :competency
+        )
+
+        expect(work_process.description).to be_nil
+        expect(work_process.competencies.size).to eq 3
+      end
+
+      it "populates description when ojt_type is time" do
+        work_process_response = create(
+          :rapids_api_detailed_work_activity,
+          tasks: ["Competency #1 ; Competency #2;Competency #3"]
+        )
+
+        work_process = described_class.initialize_from_response(
+          work_process_response,
+          ojt_type: :time
+        )
+
+        expect(work_process.description).to eq "Competency #1; Competency #2; Competency #3"
+        expect(work_process.competencies.size).to eq 0
+      end
+    end
   end
 end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1206992680139956/f)

When importing a time-based occupation standard, we don't want to create competencies if available but use the list of competencies as the description of the WorkProcess