### PR TITLE
Handle retry when token expires

### DIFF
--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -28,7 +28,7 @@ class ImportDataFromRAPIDSJob < ApplicationJob
       if tries < MAXIMUM_TRIES
         @service.get_token!
         tries += 1
-        Rails.logger.error "OAuth2::Error. Retrying #{tries} / #{MAXIMUM_TRIES}"
+        Rails.logger.warn "[RAPIDSAPI] OAuth2::Error. Retrying #{tries} / #{MAXIMUM_TRIES}"
         retry
       end
     end

--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -4,22 +4,33 @@ class ImportDataFromRAPIDSJob < ApplicationJob
   include Sanitizable
 
   PER_PAGE_SIZE = 50
+  MAXIMUM_TRIES = 5
 
   def perform
     @service = RAPIDS::API.call
     start_index = 1
+    tries = 0
 
-    loop do
-      response = @service.work_processes(
-        batchSize: PER_PAGE_SIZE,
-        startIndex: start_index
-      )
-      parsed_response = response.parsed
-      process_api_response(parsed_response)
-      total_records = parsed_response["totalCount"]
-      start_index += PER_PAGE_SIZE
+    begin
+      loop do
+        response = @service.work_processes(
+          batchSize: PER_PAGE_SIZE,
+          startIndex: start_index
+        )
+        parsed_response = response.parsed
+        process_api_response(parsed_response)
+        total_records = parsed_response["totalCount"]
+        start_index += PER_PAGE_SIZE
 
-      break if start_index > total_records
+        break if start_index > total_records
+      end
+    rescue OAuth2::Error
+      if tries < MAXIMUM_TRIES
+        @service.get_token!
+        tries += 1
+        Rails.logger.error "OAuth2::Error. Retrying #{tries} / #{MAXIMUM_TRIES}"
+        retry
+      end
     end
   end
 

--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -30,6 +30,8 @@ class ImportDataFromRAPIDSJob < ApplicationJob
         tries += 1
         Rails.logger.warn "[RAPIDSAPI] OAuth2::Error. Retrying #{tries} / #{MAXIMUM_TRIES}"
         retry
+      else
+        Rails.logger.warn "[RAPIDSAPI] Maximum tries reached"
       end
     end
   end

--- a/app/services/rapids/api.rb
+++ b/app/services/rapids/api.rb
@@ -31,6 +31,10 @@ module RAPIDS
       nil
     end
 
+    def get_token!
+      @access = @client.client_credentials.get_token
+    end
+
     private
 
     # Params supported by API:
@@ -45,10 +49,6 @@ module RAPIDS
 
     def post(path)
       @access.post("#{BASE_URL}#{BASE_PATH}#{path}")
-    end
-
-    def get_token!
-      @access = @client.client_credentials.get_token
     end
   end
 end

--- a/spec/jobs/import_data_from_rapids_job_spec.rb
+++ b/spec/jobs/import_data_from_rapids_job_spec.rb
@@ -129,6 +129,48 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
       end
     end
 
+    context "retries" do
+      it "performs a second attempt to fetch API when token expires" do
+        stub_get_token!
+        create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
+        stub_const("ImportDataFromRAPIDSJob::PER_PAGE_SIZE", 1)
+
+        (first_occupation, second_occupation) = create_list(:rapids_api_occupation_standard, 2, :hybrid)
+
+        first_rapids_response = create(:rapids_response, totalCount: 2, wps: [first_occupation])
+        second_rapids_response = create(:rapids_response, totalCount: 2, wps: [second_occupation])
+
+        expect_any_instance_of(RAPIDS::API).to receive(:get).once.with("/sponsor/wps", {
+          batchSize: 1,
+          startIndex: 1
+        }).and_raise(
+          OAuth2::Error, "invalid oauth token"
+        )
+
+        expect_any_instance_of(RAPIDS::API).to receive(:get).with("/sponsor/wps", {
+          batchSize: 1,
+          startIndex: 1
+        }).and_return(
+          OpenStruct.new(
+            parsed: first_rapids_response
+          )
+        )
+
+        expect_any_instance_of(RAPIDS::API).to receive(:get).with("/sponsor/wps", {
+          batchSize: 1,
+          startIndex: 2
+        }).and_return(
+          OpenStruct.new(
+            parsed: second_rapids_response
+          )
+        )
+
+        expect {
+          described_class.perform_now
+        }.to change(OccupationStandard, :count).to eq 2
+      end
+    end
+
     context "pagination" do
       it "performs more than one call with correct arguments when records exceed batch size" do
         stub_get_token!

--- a/spec/jobs/import_data_from_rapids_job_spec.rb
+++ b/spec/jobs/import_data_from_rapids_job_spec.rb
@@ -152,6 +152,8 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         first_rapids_response = create(:rapids_response, totalCount: 2, wps: [first_occupation])
         second_rapids_response = create(:rapids_response, totalCount: 2, wps: [second_occupation])
 
+        stub_documents_response("1234", nil)
+
         expect_any_instance_of(RAPIDS::API).to receive(:get).once.with("/sponsor/wps", {
           batchSize: 1,
           startIndex: 1

--- a/spec/jobs/import_data_from_rapids_job_spec.rb
+++ b/spec/jobs/import_data_from_rapids_job_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe ImportDataFromRAPIDSJob, type: :job do
         create(:registration_agency, for_state_abbreviation: "MI", agency_type: :oa)
         stub_const("ImportDataFromRAPIDSJob::PER_PAGE_SIZE", 1)
 
-        (first_occupation, second_occupation) = create_list(:rapids_api_occupation_standard, 2, :hybrid)
+        (first_occupation, second_occupation) = create_pair(:rapids_api_occupation_standard, :hybrid)
 
         first_rapids_response = create(:rapids_response, totalCount: 2, wps: [first_occupation])
         second_rapids_response = create(:rapids_response, totalCount: 2, wps: [second_occupation])


### PR DESCRIPTION
It may happen that the OAuth token expires during the importing process. This PR handles that case and refreshes the token prior to retry
