### PR TITLE
Download all documents from RAPIDS API

### DIFF
--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -34,14 +34,12 @@ class ImportDataFromRAPIDSJob < ApplicationJob
         occupation_standard
       )
 
-      if work_process_document_available?(occupation_standard_response)
-        document = fetch_document_response(occupation_standard.external_id)
-        if document
-          attachment = convert_response_to_attachment(document)
-          occupation_standard.redacted_document.attach(
-            io: attachment, filename: "#{occupation_standard.external_id}.docx"
-          )
-        end
+      document = fetch_document_response(occupation_standard.external_id)
+      if document
+        attachment = convert_response_to_attachment(document)
+        occupation_standard.redacted_document.attach(
+          io: attachment, filename: "#{occupation_standard.external_id}.docx"
+        )
       end
       occupation_standard.save
     end
@@ -72,10 +70,6 @@ class ImportDataFromRAPIDSJob < ApplicationJob
       work_process.occupation_standard = occupation_standard
       work_process if work_process.valid?
     end
-  end
-
-  def work_process_document_available?(work_process_response)
-    work_process_response.fetch("isWPSUploaded", false)
   end
 
   def fetch_document_response(external_id)

--- a/spec/factories/rapids_api/occupation_standards.rb
+++ b/spec/factories/rapids_api/occupation_standards.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     jobDesc { "Operate telephone, radio, or other communication systems to receive and communicate requests for emergency assistance at 9-1-1." }
     jobZone { "Job Zone Two: Some Preparation Needed." }
     isWPSUploaded { false }
-    sequence(:wpsDocument) { |n| "https://entbpmpstg.dol.gov/suite/webapi/rapids/data-sharing/documents/wps/#{n}" }
+    wpsDocument { "https://entbpmpstg.dol.gov/suite/webapi/rapids/data-sharing/documents/wps/1234" }
     dwas { [] }
 
     transient do


### PR DESCRIPTION
This PR dismisses the `isWPSUploaded` value and grabs the document from RAPIDS API