### PR TITLE
Use tailwindcss classes

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -20,7 +20,7 @@
       <div class="h-full w-full px-2">
         <h4 class="font-bold text-xl mt-4 mb-2">How to Use the Registered Apprenticeship Standards Library</h4>
         <p class="mb-1">The Library can help you:</p>
-        <ul class="list-disc list-inside" style="list-style-type: disc;">
+        <ul class="list-disc list-inside">
           <li class="mb-1.5"><strong><em>Search by industry, occupation, state, and more</em></strong> to find the apprenticeship program training standards most helpful for you.</li>
           <li class="mb-1.5"><strong><em>Find multiple examples of program standards for one occupation</em></strong> to provide options and ideas for your own apprenticeship.</li>
           <li class="mb-1.5"><strong><em>Access approved work process schedules and related instruction outlines</em></strong> you can use as a starting point.</li>
@@ -36,10 +36,10 @@
     </div>
 
     <h4 class="font-bold text-xl mt-6 mb-2">Additional Resources</h4>
-    <ul class="list-disc list-inside" style="list-style-type: disc;">
-      <li class="mb-2">Read the <%= link_to "fact sheet", asset_path("documents/Urban-FACTSHEET-RASL.pdf", skip_pipeline: true), class: "underline underline-offset-4", style: "text-underline-offset: 4px" %> to learn more about the Registered Apprenticeship Standards Library.</li>
-      <li class="mb-2">Access <%= link_to "definitions of key terms", definitions_page_path, class: "underline", style: "text-underline-offset: 4px" %> used throughout the Library.</li>
-      <li class="mb-2"><%= link_to "Contribute", new_standards_import_path, class: "underline", style: "text-underline-offset: 4px" %> your approved apprenticeship program training standards to the Library.</li>
+    <ul class="list-disc list-inside">
+      <li class="mb-2">Read the <%= link_to "fact sheet", asset_path("documents/Urban-FACTSHEET-RASL.pdf", skip_pipeline: true), class: "underline underline-offset-4" %> to learn more about the Registered Apprenticeship Standards Library.</li>
+      <li class="mb-2">Access <%= link_to "definitions of key terms", definitions_page_path, class: "underline underline-offset-4" %> used throughout the Library.</li>
+      <li class="mb-2"><%= link_to "Contribute", new_standards_import_path, class: "underline underline-offset-4" %> your approved apprenticeship program training standards to the Library.</li>
     </ul>
 
     <p class="mt-6">


### PR DESCRIPTION
The `list-disc` and `underline-offset` tailwind
classes were not working for some inexplicable
reason, but seem to have recovered now.

Ref #615 

<img width="1335" alt="Screenshot 2024-04-30 at 12 51 02 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/ce7809f6-97fb-455a-a49b-5c72935c9ad8">


[Asana ticket](https://app.asana.com/0/1203289004376659/1206556719578099/f)
