### PR TITLE
Direct Standards import new button to public page

### DIFF
--- a/app/views/admin/standards_imports/_index_header.html.erb
+++ b/app/views/admin/standards_imports/_index_header.html.erb
@@ -9,20 +9,22 @@
 
   <% if show_search_bar %>
     <%= render(
-      "search",
-      search_term: search_term,
-      resource_name: display_resource_name(page.resource_name)
-    ) %>
+          "search",
+          search_term: search_term,
+          resource_name: display_resource_name(page.resource_name)
+        ) %>
   <% end %>
 
   <div>
-    <%= link_to(
-      t(
-        "administrate.actions.new_resource",
-        name: display_resource_name(page.resource_name, singular: true).downcase
-      ),
-      [:new, page.resource_path.to_sym],
-      class: "button",
-    ) if accessible_action?(new_resource, :new) %>
+    <% if accessible_action?(new_resource, :new) %>
+      <%= link_to(
+            t(
+              "administrate.actions.new_resource",
+              name: display_resource_name(page.resource_name, singular: true).downcase
+            ),
+            [:new, page.resource_path.to_sym],
+            class: "button"
+          ) %>
+    <% end %>
   </div>
 </header>

--- a/app/views/admin/standards_imports/_index_header.html.erb
+++ b/app/views/admin/standards_imports/_index_header.html.erb
@@ -1,0 +1,28 @@
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <% if show_search_bar %>
+    <%= render(
+      "search",
+      search_term: search_term,
+      resource_name: display_resource_name(page.resource_name)
+    ) %>
+  <% end %>
+
+  <div>
+    <%= link_to(
+      t(
+        "administrate.actions.new_resource",
+        name: display_resource_name(page.resource_name, singular: true).downcase
+      ),
+      [:new, page.resource_path.to_sym],
+      class: "button",
+    ) if accessible_action?(new_resource, :new) %>
+  </div>
+</header>

--- a/spec/system/admin/standards_imports/index_spec.rb
+++ b/spec/system/admin/standards_imports/index_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "admin/standards_imports/index" do
+  it "has a New button that goes to the public page", :admin do
+    admin = create(:admin)
+
+    login_as admin
+    visit admin_standards_imports_path
+
+    expect(page).to have_link "New standards import", href: new_standards_import_path
+    click_on "New standards import"
+
+    expect(page).to have_content "Public document"
+  end
+end


### PR DESCRIPTION
On Admin, the Standards Import new button
should direct to the public upload page
as it handles the uploading of files. It
also displays a checkbox that will allow
marking a document as public.

[Asana ticket](https://app.asana.com/0/1203289004376659/1206584765083296/f)
