### PR TITLE
Update all scraper jobs to use new tree design

### DIFF
--- a/app/jobs/scraper/apprenticeship_bulletins_job.rb
+++ b/app/jobs/scraper/apprenticeship_bulletins_job.rb
@@ -14,7 +14,7 @@ class Scraper::ApprenticeshipBulletinsJob < ApplicationJob
         title: row["Title"],
         notes: "From Scraper::ApprenticeshipBulletinsJob",
         source: Scraper::ApprenticeshipBulletinsJob::BULLETIN_LIST_URL,
-        date: row["Date"],
+        metadata: {date: row["Date"]},
         listing: true
       )
     end

--- a/app/jobs/scraper/apprenticeship_bulletins_job.rb
+++ b/app/jobs/scraper/apprenticeship_bulletins_job.rb
@@ -9,10 +9,13 @@ class Scraper::ApprenticeshipBulletinsJob < ApplicationJob
     xlsx.parse(headers: true).each_with_index do |row, index|
       next if index < 1
 
-      ProcessApprenticeshipBulletin.call(
+      CreateImportFromUri.call(
         uri: row["File URI"],
         title: row["Title"],
-        date: row["Date"]
+        notes: "From Scraper::ApprenticeshipBulletinsJob",
+        source: Scraper::ApprenticeshipBulletinsJob::BULLETIN_LIST_URL,
+        date: row["Date"],
+        listing: true
       )
     end
   end

--- a/app/jobs/scraper/california_job.rb
+++ b/app/jobs/scraper/california_job.rb
@@ -18,26 +18,12 @@ class Scraper::CaliforniaJob < ApplicationJob
       query = url_base + path
       query.gsub!(/\s/, "%20")
 
-      standards_import = StandardsImport.where(
-        name: protocol + query,
-        organization: link_text
-      ).first_or_initialize(
+      CreateImportFromUri.call(
+        uri: protocol + query,
+        title: link_text,
         notes: "From Scraper::CaliforniaJob",
-        public_document: true,
-        source_url: fetch_url
+        source: fetch_url
       )
-
-      if standards_import.new_record?
-        standards_import.save!
-
-        # protocol needs to be hardcoded to avoid Rubocop error:
-        # Security/Open: The use of `URI.open` is a serious security risk
-        # https://github.com/rubocop/rubocop/issues/6216#issuecomment-1252449855
-        standards_import.files.attach(
-          io: URI.open("https://#{query}"),
-          filename: File.basename(path)
-        )
-      end
     end
   end
 end

--- a/app/jobs/scraper/hcap_job.rb
+++ b/app/jobs/scraper/hcap_job.rb
@@ -29,21 +29,13 @@ class Scraper::HcapJob < ApplicationJob
 
       pdf_uri = fields["PDF Download Resource"]
       if pdf_uri.present?
-        standards_import = StandardsImport.where(
-          name: pdf_uri,
-          organization: fields["Sponsor"]
-        ).first_or_initialize(
+        CreateImportFromUri.call(
+          uri: pdf_uri,
+          title: fields["Sponsor"],
           notes: "From Scraper::HcapJob",
-          public_document: true,
+          source: nil,
           metadata: fields
         )
-
-        if standards_import.new_record?
-          standards_import.save!
-          standards_import.files.attach(
-            io: URI.parse(pdf_uri).open, filename: File.basename(pdf_uri)
-          )
-        end
       end
     end
   end

--- a/app/jobs/scraper/new_york_job.rb
+++ b/app/jobs/scraper/new_york_job.rb
@@ -20,24 +20,15 @@ class Scraper::NewYorkJob < ApplicationJob
         file_name
       end
 
-      standards_import = StandardsImport.where(
-        name: file_name
-      ).first_or_initialize(
-        notes: "From Scraper::NewYorkJob",
-        public_document: true,
-        source_url: url
-      )
-
-      if standards_import.new_record?
-        begin
-          standards_import.files.attach(
-            io: URI.open("https://#{download_url_base}#{file_path}.pdf"),
-            filename: File.basename(file_name)
-          )
-          standards_import.save!
-        rescue OpenURI::HTTPError
-          next
-        end
+      begin
+        CreateImportFromUri.call(
+          uri: "https://#{download_url_base}#{file_path}.pdf",
+          title: file_name,
+          notes: "From Scraper::NewYorkJob",
+          source: url
+        )
+      rescue OpenURI::HTTPError
+        next
       end
     end
   end

--- a/app/jobs/scraper/oregon_job.rb
+++ b/app/jobs/scraper/oregon_job.rb
@@ -31,7 +31,6 @@ class Scraper::OregonJob < Scraper::WatirJob
         standards_table.css("tr").each do |row|
           file = row.css("td > a").first
           file_path = file["href"]
-          file_name = file.content
 
           CreateImportFromUri.call(
             uri: base + file_path,

--- a/app/jobs/scraper/oregon_job.rb
+++ b/app/jobs/scraper/oregon_job.rb
@@ -33,23 +33,12 @@ class Scraper::OregonJob < Scraper::WatirJob
           file_path = file["href"]
           file_name = file.content
 
-          standards_import = StandardsImport.where(
-            name: base + file_path,
-            organization: organization
-          ).first_or_initialize(
+          CreateImportFromUri.call(
+            uri: base + file_path,
+            title: organization,
             notes: "From Scraper::OregonJob",
-            public_document: true,
-            source_url: apprenticeship_url + "apprenticeship-opportunities.aspx"
+            source: apprenticeship_url + "apprenticeship-opportunities.aspx"
           )
-
-          if standards_import.new_record?
-            standards_import.save!
-
-            standards_import.files.attach(
-              io: URI.open("https://www.oregon.gov#{file_path}"),
-              filename: File.basename(file_name)
-            )
-          end
         end
       end
     end

--- a/app/jobs/scraper/washington_job.rb
+++ b/app/jobs/scraper/washington_job.rb
@@ -45,23 +45,12 @@ class Scraper::WashingtonJob < Scraper::WatirJob
       organization = browser.h3(class: "lni-u-heading--3").text
 
       begin
-        standards_import = StandardsImport.where(
-          name: file
-        ).first_or_initialize(
-          organization: organization,
+        CreateImportFromUri.call(
+          uri: "https://#{file_path}",
+          title: file,
           notes: "From Scraper::WashingtonJob",
-          public_document: true,
-          source_url: program_link
+          source: program_link
         )
-
-        if standards_import.new_record?
-          standards_import.save!
-
-          standards_import.files.attach(
-            io: URI.open("https://#{file_path}"),
-            filename: File.basename(file)
-          )
-        end
       rescue OpenURI::HTTPError
         next
       rescue Watir::Exception::UnknownObjectException => e

--- a/app/jobs/scraper/washington_job.rb
+++ b/app/jobs/scraper/washington_job.rb
@@ -47,7 +47,7 @@ class Scraper::WashingtonJob < Scraper::WatirJob
       begin
         CreateImportFromUri.call(
           uri: "https://#{file_path}",
-          title: file,
+          title: organization,
           notes: "From Scraper::WashingtonJob",
           source: program_link
         )

--- a/app/services/create_import_from_uri.rb
+++ b/app/services/create_import_from_uri.rb
@@ -1,15 +1,15 @@
 class CreateImportFromUri
-  def self.call(uri:, title:, notes:, source:, listing: false, date: nil)
-    new(uri:, title:, notes:, source:, listing:, date:).call
+  def self.call(uri:, title:, notes:, source:, listing: false, metadata: {})
+    new(uri:, title:, notes:, source:, listing:, metadata:).call
   end
 
-  def initialize(uri:, title:, notes:, source:, listing:, date:)
+  def initialize(uri:, title:, notes:, source:, listing:, metadata:)
     @uri = uri
     @title = title
     @notes = notes
     @source = source
     @listing = listing
-    @date = date
+    @metadata = metadata
   end
 
   def call
@@ -19,12 +19,9 @@ class CreateImportFromUri
     ).first_or_initialize(
       notes: notes,
       public_document: true,
-      source_url: source
-    ).tap do |import|
-      if date
-        import[:metadata][:date] = date
-      end
-    end
+      source_url: source,
+      metadata: metadata
+    )
 
     if standards_import.new_record?
       standards_import.save!
@@ -45,5 +42,5 @@ class CreateImportFromUri
 
   private
 
-  attr_reader :uri, :title, :notes, :source, :listing, :date
+  attr_reader :uri, :title, :notes, :source, :listing, :metadata
 end

--- a/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
+++ b/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
@@ -5,15 +5,21 @@ RSpec.describe Scraper::ApprenticeshipBulletinsJob, type: :job do
     it "calls ProcessApprenticeshipBulletin service for each row in csv file" do
       stub_responses
 
-      expect(ProcessApprenticeshipBulletin).to receive(:call).with(
+      expect(CreateImportFromUri).to receive(:call).with(
         uri: "https://www.apprenticeship.gov/sites/default/files/bulletins/Bulletin%202023-52%20New%20NGS%20AFSA.docx",
         title: "2023-52",
-        date: "01/11/2023"
+        notes: "From Scraper::ApprenticeshipBulletinsJob",
+        source: Scraper::ApprenticeshipBulletinsJob::BULLETIN_LIST_URL,
+        date: "01/11/2023",
+        listing: true
       )
-      expect(ProcessApprenticeshipBulletin).to receive(:call).with(
+      expect(CreateImportFromUri).to receive(:call).with(
         uri: "https://www.apprenticeship.gov/sites/default/files/bulletins/Bulletin_2016-22.pdf",
         title: "Wildland Fire Fighter Specialist",
-        date: "03/11/16"
+        notes: "From Scraper::ApprenticeshipBulletinsJob",
+        source: Scraper::ApprenticeshipBulletinsJob::BULLETIN_LIST_URL,
+        date: "03/11/16",
+        listing: true
       )
 
       described_class.new.perform

--- a/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
+++ b/spec/jobs/scraper/apprenticeship_bulletins_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Scraper::ApprenticeshipBulletinsJob, type: :job do
         title: "2023-52",
         notes: "From Scraper::ApprenticeshipBulletinsJob",
         source: Scraper::ApprenticeshipBulletinsJob::BULLETIN_LIST_URL,
-        date: "01/11/2023",
+        metadata: {date: "01/11/2023"},
         listing: true
       )
       expect(CreateImportFromUri).to receive(:call).with(
@@ -18,7 +18,7 @@ RSpec.describe Scraper::ApprenticeshipBulletinsJob, type: :job do
         title: "Wildland Fire Fighter Specialist",
         notes: "From Scraper::ApprenticeshipBulletinsJob",
         source: Scraper::ApprenticeshipBulletinsJob::BULLETIN_LIST_URL,
-        date: "03/11/16",
+        metadata: {date: "03/11/16"},
         listing: true
       )
 

--- a/spec/jobs/scraper/hcap_job_spec.rb
+++ b/spec/jobs/scraper/hcap_job_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Scraper::HcapJob, type: :job do
           expect(standards_import1.organization).to eq "National Center for Healthcare Apprenticeships"
           expect(standards_import1.notes).to eq "From Scraper::HcapJob"
           expect(standards_import1.public_document).to be true
+          expect(standards_import1.source_url).to be_nil
           metadata1 = standards_import1.metadata
           expect(metadata1["Location"]).to eq "California"
           expect(metadata1["Care Setting"]).to eq "Ambulatory"
@@ -38,6 +39,7 @@ RSpec.describe Scraper::HcapJob, type: :job do
           expect(standards_import2.organization).to eq "AHIMA Foundation"
           expect(standards_import2.notes).to eq "From Scraper::HcapJob"
           expect(standards_import2.public_document).to be true
+          expect(standards_import2.source_url).to be_nil
           metadata2 = standards_import2.metadata
           expect(metadata2["Location"]).to eq "No results"
           expect(metadata2["Care Setting"]).to eq "Acute, Ambulatory"

--- a/spec/jobs/scraper/new_york_job_spec.rb
+++ b/spec/jobs/scraper/new_york_job_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Scraper::NewYorkJob, type: :job do
 
     context "when some files have been downloaded previously" do
       it "downloads new pdf files to a standards import record" do
-        old_standards_import = create(:standards_import, :with_files, name: "https://dol.ny.gov/system/files/documents/2022/06/cnc-tool-and-cutter-grinder-time.pdf")
+        name = "https://dol.ny.gov/system/files/documents/2022/06/cnc-tool-and-cutter-grinder-time.pdf"
+        old_standards_import = create(:standards_import, :with_files, name: name, organization: name)
         stub_responses
         expect {
           described_class.new.perform

--- a/spec/services/create_import_from_uri_spec.rb
+++ b/spec/services/create_import_from_uri_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ProcessApprenticeshipBulletin do
+RSpec.describe CreateImportFromUri do
   describe "#call" do
     context "when file has not been downloaded previously" do
       it "downloads file to a standards import record and creates an Uncategorized Import child" do
@@ -12,7 +12,12 @@ RSpec.describe ProcessApprenticeshipBulletin do
 
         expect {
           described_class.call(
-            uri: file_uri, title: "Specialist", date: "01/11/2023"
+            uri: file_uri,
+            title: "Specialist",
+            notes: "Some notes",
+            source: "Some source URL",
+            listing: true,
+            date: "01/11/2023"
           )
         }.to change(StandardsImport, :count).by(1)
           .and change(Imports::Uncategorized, :count).by(1)
@@ -23,10 +28,9 @@ RSpec.describe ProcessApprenticeshipBulletin do
         expect(standards_import.files.count).to eq 1
         expect(standards_import.name).to eq file_uri
         expect(standards_import.organization).to eq "Specialist"
-        expect(standards_import.notes).to eq "From Scraper::ApprenticeshipBulletinsJob"
+        expect(standards_import.notes).to eq "Some notes"
         expect(standards_import.public_document).to be true
-        expect(standards_import.source_url).to eq Scraper::ApprenticeshipBulletinsJob::BULLETIN_LIST_URL
-        expect(standards_import).to be_bulletin # bulletin field to be removed but leaving for now to help with production verification
+        expect(standards_import.source_url).to eq "Some source URL"
         expect(standards_import.metadata).to eq({"date" => "01/11/2023"})
 
         import = Imports::Uncategorized.last
@@ -34,6 +38,27 @@ RSpec.describe ProcessApprenticeshipBulletin do
         expect(import.file.attached?).to be_truthy
         expect(import.file.blob.filename.to_s).to eq "Bulletin 2023-52 New NGS AFSA.docx"
         expect(import.parent).to eq standards_import
+      end
+
+      it "does not include meta field if no date" do
+        stub_responses
+
+        file_uri = "https://www.apprenticeship.gov/sites/default/files/bulletins/Bulletin%202023-52%20New%20NGS%20AFSA.docx"
+
+        expect_any_instance_of(Imports::Uncategorized).to receive(:process).with(listing: false)
+
+        described_class.call(
+          uri: file_uri,
+          title: "Specialist",
+          notes: "Some notes",
+          source: "Some source URL"
+        )
+
+        standards_import = StandardsImport.last
+        expect(standards_import.metadata).to eq({})
+
+        import = Imports::Uncategorized.last
+        expect(import.metadata).to eq({})
       end
     end
   end
@@ -51,7 +76,12 @@ RSpec.describe ProcessApprenticeshipBulletin do
 
       expect {
         described_class.call(
-          uri: file_uri, title: "Specialist", date: "01/11/2023"
+          uri: file_uri,
+          title: "Specialist",
+          notes: "Some notes",
+          source: "Some source URL",
+          listing: true,
+          date: "01/11/2023"
         )
       }.to change(StandardsImport, :count).by(0)
         .and change(Imports::Uncategorized, :count).by(0)

--- a/spec/services/create_import_from_uri_spec.rb
+++ b/spec/services/create_import_from_uri_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CreateImportFromUri do
             notes: "Some notes",
             source: "Some source URL",
             listing: true,
-            date: "01/11/2023"
+            metadata: {date: "01/11/2023"}
           )
         }.to change(StandardsImport, :count).by(1)
           .and change(Imports::Uncategorized, :count).by(1)
@@ -38,27 +38,6 @@ RSpec.describe CreateImportFromUri do
         expect(import.file.attached?).to be_truthy
         expect(import.file.blob.filename.to_s).to eq "Bulletin 2023-52 New NGS AFSA.docx"
         expect(import.parent).to eq standards_import
-      end
-
-      it "does not include meta field if no date" do
-        stub_responses
-
-        file_uri = "https://www.apprenticeship.gov/sites/default/files/bulletins/Bulletin%202023-52%20New%20NGS%20AFSA.docx"
-
-        expect_any_instance_of(Imports::Uncategorized).to receive(:process).with(listing: false)
-
-        described_class.call(
-          uri: file_uri,
-          title: "Specialist",
-          notes: "Some notes",
-          source: "Some source URL"
-        )
-
-        standards_import = StandardsImport.last
-        expect(standards_import.metadata).to eq({})
-
-        import = Imports::Uncategorized.last
-        expect(import.metadata).to eq({})
       end
     end
   end
@@ -81,7 +60,7 @@ RSpec.describe CreateImportFromUri do
           notes: "Some notes",
           source: "Some source URL",
           listing: true,
-          date: "01/11/2023"
+          metadata: {date: "01/11/2023"}
         )
       }.to change(StandardsImport, :count).by(0)
         .and change(Imports::Uncategorized, :count).by(0)


### PR DESCRIPTION
This generalizes the `ProcessApprenticeshipBulletin` service to accept more generic parameters. The modified service is then used in the remaining scraper jobs to replace the creation of the `StandardsImport` record with the creating of the `Imports::Uncategorized` record and corresponding `StandardsImport`.

[Asana ticket](https://app.asana.com/0/0/1207002310256050/f)
