### PR TITLE
Do not run process import method in transaction

### DIFF
--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -7,11 +7,9 @@ module Imports
     has_one :import, as: :parent, dependent: :destroy, autosave: true
 
     def process(**kwargs)
-      transaction do
-        create_child!(**kwargs)
-        process_child(**kwargs, listing: false)
-        complete_processing
-      end
+      create_child!(**kwargs)
+      process_child(**kwargs, listing: false)
+      complete_processing
     rescue => e
       update!(
         processed_at: nil,

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -6,9 +6,9 @@ module Imports
     has_one_attached :file
     has_one :import, as: :parent, dependent: :destroy, autosave: true
 
-    def process(**kwargs)
-      create_child!(**kwargs)
-      process_child(**kwargs, listing: false)
+    def process(**)
+      create_child!(**)
+      process_child(**, listing: false)
       complete_processing
     rescue => e
       update!(


### PR DESCRIPTION
When the process method is run in a transaction,
the ActiveStorage attachments are not available
when creating the child records. If a child
record fails to create, the parent will be picked
up by a (future) rake task and reprocessed.

