### PR TITLE
Add Imports to Administrate dashboard

### DIFF
--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -29,7 +29,12 @@ module Admin
     #   end
     # end
     def scoped_resource
-      resource_class.includes(file_attachment: :blob)
+      scope = resource_class.includes(file_attachment: :blob)
+      if current_user.admin?
+        scope
+      else
+        scope.where(type: "Imports::Pdf")
+      end
     end
 
     # Override `resource_params` if you want to transform the submitted

--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -21,13 +21,6 @@ module Admin
     # Override this if you have certain roles that require a subset
     # this will be used to set the records shown on the `index` action.
     #
-    # def scoped_resource
-    #   if current_user.super_admin?
-    #     resource_class
-    #   else
-    #     resource_class.with_less_stuff
-    #   end
-    # end
     def scoped_resource
       scope = resource_class.includes(file_attachment: :blob)
       if current_user.admin?

--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -1,0 +1,49 @@
+module Admin
+  class ImportsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+    def scoped_resource
+      resource_class.includes(file_attachment: :blob)
+    end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes(action_name)).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -1,0 +1,91 @@
+require "administrate/base_dashboard"
+
+class ImportDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::String,
+    assignee: Field::BelongsTo,
+    type: Field::String,
+    courtesy_notification: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    metadata: Field::String.with_options(searchable: false),
+    file: Field::ActiveStorage,
+    parent: Field::Polymorphic,
+    processed_at: Field::DateTime,
+    processing_errors: Field::Text,
+    public_document: Field::Boolean,
+    status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    type: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    created_at
+    type
+    file
+    assignee
+    public_document
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    file
+    assignee
+    courtesy_notification
+    metadata
+    parent
+    processed_at
+    processing_errors
+    public_document
+    status
+    type
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    assignee_id
+    courtesy_notification
+    metadata
+    parent
+    processed_at
+    processing_errors
+    public_document
+    status
+    type
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how imports are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(import)
+  #   "Import ##{import.id}"
+  # end
+end

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -40,16 +40,16 @@ class ImportDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
+    type
     file
     assignee
-    courtesy_notification
+    status
     metadata
-    parent
+    public_document
     processed_at
     processing_errors
-    public_document
-    status
-    type
+    courtesy_notification
+    parent
     created_at
     updated_at
   ].freeze

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -19,7 +19,6 @@ class ImportDashboard < Administrate::BaseDashboard
     processing_errors: Field::Text,
     public_document: Field::Boolean,
     status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
-    type: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,5 +1,6 @@
 class Import < ApplicationRecord
   belongs_to :parent, polymorphic: true
+  belongs_to :assignee, class_name: "User", optional: true
 
   enum :status, [
     :pending,

--- a/app/policies/import_policy.rb
+++ b/app/policies/import_policy.rb
@@ -1,0 +1,2 @@
+class ImportPolicy < AdminPolicy
+end

--- a/app/policies/import_policy.rb
+++ b/app/policies/import_policy.rb
@@ -1,2 +1,44 @@
-class ImportPolicy < AdminPolicy
+class ImportPolicy < ApplicationPolicy
+  def index?
+    admin_or_converter?
+  end
+
+  def show?
+    admin_or_converter?
+  end
+
+  def new?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def edit?
+    false
+  end
+
+  def update?
+    edit?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
 end

--- a/app/policies/import_policy.rb
+++ b/app/policies/import_policy.rb
@@ -1,6 +1,6 @@
 class ImportPolicy < ApplicationPolicy
   def index?
-    admin_or_converter?
+    Flipper.enabled?(:show_imports_in_administrate) && admin_or_converter?
   end
 
   def show?

--- a/app/policies/imports/doc_policy.rb
+++ b/app/policies/imports/doc_policy.rb
@@ -1,0 +1,2 @@
+class Imports::DocPolicy < AdminPolicy
+end

--- a/app/policies/imports/docx_listing_policy.rb
+++ b/app/policies/imports/docx_listing_policy.rb
@@ -1,0 +1,2 @@
+class Imports::DocxListingPolicy < AdminPolicy
+end

--- a/app/policies/imports/docx_policy.rb
+++ b/app/policies/imports/docx_policy.rb
@@ -1,0 +1,2 @@
+class Imports::DocxPolicy < AdminPolicy
+end

--- a/app/policies/imports/pdf_policy.rb
+++ b/app/policies/imports/pdf_policy.rb
@@ -1,2 +1,2 @@
-class Imports::PdfPolicy < AdminPolicy
+class Imports::PdfPolicy < ImportPolicy
 end

--- a/app/policies/imports/pdf_policy.rb
+++ b/app/policies/imports/pdf_policy.rb
@@ -1,0 +1,2 @@
+class Imports::PdfPolicy < AdminPolicy
+end

--- a/app/policies/imports/uncategorized_policy.rb
+++ b/app/policies/imports/uncategorized_policy.rb
@@ -1,0 +1,2 @@
+class Imports::UncategorizedPolicy < AdminPolicy
+end

--- a/app/views/admin/imports/_collection.html.erb
+++ b/app/views/admin/imports/_collection.html.erb
@@ -29,12 +29,12 @@ to display a collection of resources in an HTML table.
         scope="col"
         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
         <%= link_to(sanitized_order_params(page, collection_field_name).merge(
-          collection_presenter.order_params_for(attr_name, key: collection_field_name)
-        )) do %>
+              collection_presenter.order_params_for(attr_name, key: collection_field_name)
+            )) do %>
         <%= t(
-          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
-          default: resource_class.human_attribute_name(attr_name).titleize,
-        ) %>
+              "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+              default: resource_class.human_attribute_name(attr_name).titleize
+            ) %>
             <% if collection_presenter.ordered_by?(attr_name) %>
               <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
                 <svg aria-hidden="true">
@@ -46,12 +46,12 @@ to display a collection of resources in an HTML table.
         </th>
       <% end %>
       <%= render(
-        "collection_header_actions",
-        collection_presenter: collection_presenter,
-        page: page,
-        resources: resources,
-        table_title: "page-title"
-      ) %>
+            "collection_header_actions",
+            collection_presenter: collection_presenter,
+            page: page,
+            resources: resources,
+            table_title: "page-title"
+          ) %>
     </tr>
   </thead>
 
@@ -60,15 +60,13 @@ to display a collection of resources in an HTML table.
       <tr class="js-table-row"
           <% if accessible_action?(resource, :show) %>
             <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>
-          <% end %>
-          >
+          <% end %>>
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
             <% if authorized_action?(resource, :show) -%>
               <a href="<%= admin_import_path(resource) -%>"
                  tabindex="-1"
-                 class="action-show"
-                 >
+                 class="action-show">
                 <%= render_field attribute %>
               </a>
             <% else %>
@@ -78,14 +76,14 @@ to display a collection of resources in an HTML table.
         <% end %>
 
         <%= render(
-          "collection_item_actions",
-          collection_presenter: collection_presenter,
-          collection_field_name: collection_field_name,
-          page: page,
-          namespace: namespace,
-          resource: resource,
-          table_title: "page-title"
-        ) %>
+              "collection_item_actions",
+              collection_presenter: collection_presenter,
+              collection_field_name: collection_field_name,
+              page: page,
+              namespace: namespace,
+              resource: resource,
+              table_title: "page-title"
+            ) %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/imports/_collection.html.erb
+++ b/app/views/admin/imports/_collection.html.erb
@@ -1,0 +1,92 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label
+        cell-label--<%= attr_type.html_class %>
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
+        cell-label--<%= "#{collection_presenter.resource_name}_#{attr_name}" %>"
+        scope="col"
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
+        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
+          collection_presenter.order_params_for(attr_name, key: collection_field_name)
+        )) do %>
+        <%= t(
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          default: resource_class.human_attribute_name(attr_name).titleize,
+        ) %>
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <svg aria-hidden="true">
+                  <use xlink:href="#icon-up-caret" />
+                </svg>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <%= render(
+        "collection_header_actions",
+        collection_presenter: collection_presenter,
+        page: page,
+        resources: resources,
+        table_title: "page-title"
+      ) %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row"
+          <% if accessible_action?(resource, :show) %>
+            <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% end %>
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <% if authorized_action?(resource, :show) -%>
+              <a href="<%= admin_import_path(resource) -%>"
+                 tabindex="-1"
+                 class="action-show"
+                 >
+                <%= render_field attribute %>
+              </a>
+            <% else %>
+              <%= render_field attribute %>
+            <% end -%>
+          </td>
+        <% end %>
+
+        <%= render(
+          "collection_item_actions",
+          collection_presenter: collection_presenter,
+          collection_field_name: collection_field_name,
+          page: page,
+          namespace: namespace,
+          resource: resource,
+          table_title: "page-title"
+        ) %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -1,0 +1,74 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if accessible_action?(page.resource, :edit) %>
+
+    <%= link_to(
+      t("administrate.actions.destroy"),
+      [namespace, page.resource],
+      class: "button button--danger",
+      method: :delete,
+      data: { confirm: t("administrate.actions.confirm") }
+    ) if accessible_action?(page.resource, :destroy) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |title, attributes| %>
+      <fieldset class="<%= "field-unit--nested" if title.present? %>">
+        <% if title.present? %>
+          <legend><%= t "helpers.label.#{page.resource_name}.#{title}", default: title %></legend>
+        <% end %>
+
+        <% attributes.each do |attribute| %>
+          <dt class="attribute-label" id="<%= attribute.name %>">
+          <%= t(
+            "helpers.label.#{resource_name}.#{attribute.name}",
+            default: page.resource.class.human_attribute_name(attribute.name),
+          ) %>
+          </dt>
+
+          <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+              >
+              <% if attribute.name == "parent" %>
+                <% if attribute.data.is_a?(StandardsImport) %>
+                  <%= link_to "StandardsImport", admin_standards_import_path(attribute.data.id) %>
+                <% else %>
+                  <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
+                <% end %>
+              <% else %>
+                <%= render_field attribute, page: page %></dd>
+              <% end %>
+        <% end %>
+      </fieldset>
+    <% end %>
+  </dl>
+</section>

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -24,19 +24,23 @@ as well as a link to its edit page.
   </h1>
 
   <div>
-    <%= link_to(
-      t("administrate.actions.edit_resource", name: page.page_title),
-      [:edit, namespace, page.resource],
-      class: "button",
-    ) if accessible_action?(page.resource, :edit) %>
+    <% if accessible_action?(page.resource, :edit) %>
+      <%= link_to(
+            t("administrate.actions.edit_resource", name: page.page_title),
+            [:edit, namespace, page.resource],
+            class: "button"
+          ) %>
+    <% end %>
 
-    <%= link_to(
-      t("administrate.actions.destroy"),
-      [namespace, page.resource],
-      class: "button button--danger",
-      method: :delete,
-      data: { confirm: t("administrate.actions.confirm") }
-    ) if accessible_action?(page.resource, :destroy) %>
+    <% if accessible_action?(page.resource, :destroy) %>
+      <%= link_to(
+            t("administrate.actions.destroy"),
+            [namespace, page.resource],
+            class: "button button--danger",
+            method: :delete,
+            data: {confirm: t("administrate.actions.confirm")}
+          ) %>
+    <% end %>
   </div>
 </header>
 
@@ -50,23 +54,22 @@ as well as a link to its edit page.
 
         <% attributes.each do |attribute| %>
           <dt class="attribute-label" id="<%= attribute.name %>">
-          <%= t(
-            "helpers.label.#{resource_name}.#{attribute.name}",
-            default: page.resource.class.human_attribute_name(attribute.name),
-          ) %>
+            <%= t(
+                  "helpers.label.#{resource_name}.#{attribute.name}",
+                  default: page.resource.class.human_attribute_name(attribute.name)
+                ) %>
           </dt>
 
-          <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
-              >
-              <% if attribute.name == "parent" %>
-                <% if attribute.data.is_a?(StandardsImport) %>
-                  <%= link_to "StandardsImport", admin_standards_import_path(attribute.data.id) %>
-                <% else %>
-                  <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
-                <% end %>
+          <dd class="attribute-data attribute-data--<%= attribute.html_class %>">
+            <% if attribute.name == "parent" %>
+              <% if attribute.data.is_a?(StandardsImport) %>
+                <%= link_to "StandardsImport", admin_standards_import_path(attribute.data.id) %>
               <% else %>
-                <%= render_field attribute, page: page %></dd>
+                <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
               <% end %>
+            <% else %>
+              <%= render_field attribute, page: page %></dd>
+            <% end %>
         <% end %>
       </fieldset>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
         delete :redacted_source_file, on: :member, action: :destroy_redacted_source_file
       end
       resources :standards_imports
+      resources :imports
       resources :occupation_standards, only: [:index, :show, :edit, :update]
       resources :occupations, only: [:index, :show, :edit, :update]
       resources :organizations, only: [:index, :show, :edit, :update]

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "admin/imports/index" do
+  context "when admin" do
+    it "views Imports of all types", :admin do
+      admin = create(:admin)
+      create(:imports_uncategorized)
+      create(:imports_docx_listing)
+      create(:imports_pdf)
+
+      login_as admin
+      visit admin_imports_path
+
+      expect(page).to have_text "Imports::Uncategorized"
+      expect(page).to have_text "Imports::DocxListing"
+      expect(page).to have_text "Imports::Pdf"
+    end
+  end
+
+  context "when converter" do
+    it "views Imports of Pdf type only", :admin do
+      admin = create(:admin, :converter)
+      create(:imports_uncategorized)
+      create(:imports_docx_listing)
+      create(:imports_pdf)
+
+      login_as admin
+      visit admin_imports_path
+
+      expect(page).to_not have_text "Imports::Uncategorized"
+      expect(page).to_not have_text "Imports::DocxListing"
+      expect(page).to have_text "Imports::Pdf"
+    end
+  end
+end

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "admin/imports/index" do
   context "when admin" do
     it "views Imports of all types", :admin do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
       admin = create(:admin)
       create(:imports_uncategorized)
       create(:imports_docx_listing)
@@ -14,11 +16,15 @@ RSpec.describe "admin/imports/index" do
       expect(page).to have_text "Imports::Uncategorized"
       expect(page).to have_text "Imports::DocxListing"
       expect(page).to have_text "Imports::Pdf"
+
+      stub_feature_flag(:show_imports_in_administrate, false)
     end
   end
 
   context "when converter" do
     it "views Imports of Pdf type only", :admin do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
       admin = create(:admin, :converter)
       create(:imports_uncategorized)
       create(:imports_docx_listing)
@@ -30,6 +36,8 @@ RSpec.describe "admin/imports/index" do
       expect(page).to_not have_text "Imports::Uncategorized"
       expect(page).to_not have_text "Imports::DocxListing"
       expect(page).to have_text "Imports::Pdf"
+
+      stub_feature_flag(:show_imports_in_administrate, false)
     end
   end
 end

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe "admin/imports/index" do
       expect(page).to have_text "Imports::DocxListing"
       expect(page).to have_text "Imports::Pdf"
 
+      click_on "Imports::Uncategorized", match: :first
+      expect(page).to have_text "StandardsImport" # parent
+
       stub_feature_flag(:show_imports_in_administrate, false)
     end
   end
@@ -36,6 +39,9 @@ RSpec.describe "admin/imports/index" do
       expect(page).to_not have_text "Imports::Uncategorized"
       expect(page).to_not have_text "Imports::DocxListing"
       expect(page).to have_text "Imports::Pdf"
+
+      click_on "Imports::Pdf", match: :first
+      expect(page).to have_text "Imports::Uncategorized" # parent
 
       stub_feature_flag(:show_imports_in_administrate, false)
     end


### PR DESCRIPTION
This adds the index and show pages for Imports. It is currently behind a `:show_imports_in_administrate` feature flag so as not to confuse the converters. Admin users will see all Imports, but Converters will only see the final `Import::Pdf` type.

<img width="1550" alt="Screenshot 2024-05-07 at 3 54 29 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/51dcc92d-01f9-4107-8655-fec9a4159adb">

<img width="908" alt="Screenshot 2024-05-08 at 8 57 11 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/ab14bc07-edea-4790-ad6b-bb067acde7d0">



[Asana ticket](https://app.asana.com/0/0/1207225092876016/f)
