### PR TITLE
Add unfurled status to Import model

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -8,7 +8,8 @@ class Import < ApplicationRecord
     :needs_support,
     :needs_human_review,
     :archived,
-    :needs_backend_support
+    :needs_backend_support,
+    :unfurled
   ]
   enum courtesy_notification: [
     :not_required,

--- a/app/models/imports/docx_listing.rb
+++ b/app/models/imports/docx_listing.rb
@@ -9,7 +9,7 @@ module Imports
           file_names.each do |file_name|
             imports.create!(
               type: "Imports::Uncategorized",
-              status: :pending,
+              status: :unfurled,
               assignee_id: assignee_id,
               public_document: public_document,
               courtesy_notification: courtesy_notification,

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -6,7 +6,7 @@ module Imports
       update!(
         processed_at: Time.current,
         processing_errors: nil,
-        status: :completed
+        status: :pending
       )
     end
   end

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -27,7 +27,7 @@ module Imports
 
     def create_child!(**kwargs)
       create_import!(
-        status: :pending,
+        status: child_status,
         assignee_id: assignee_id,
         public_document: public_document,
         courtesy_notification: courtesy_notification,
@@ -61,6 +61,15 @@ module Imports
         "Imports::Pdf"
       else
         raise Imports::UnknownFileTypeError, file_blob.content_type
+      end
+    end
+
+    def child_status
+      case file_blob.content_type
+      in PDF_CONTENT_TYPE
+        :pending
+      else
+        :unfurled
       end
     end
   end

--- a/app/services/create_import_from_uri.rb
+++ b/app/services/create_import_from_uri.rb
@@ -29,7 +29,8 @@ class CreateImportFromUri
       import = standards_import.imports.create(
         type: "Imports::Uncategorized",
         public_document: true,
-        metadata: standards_import.metadata
+        metadata: standards_import.metadata,
+        status: :unfurled
       )
 
       filename = File.basename(URI.decode_uri_component(uri))

--- a/spec/factories/imports.rb
+++ b/spec/factories/imports.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     file {
       Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"), "application/pdf")
     }
+    status { :unfurled }
 
     trait :docx_listing do
       file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "docx_file_attachments.docx")) }
@@ -22,6 +23,7 @@ FactoryBot.define do
       file {
         Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"), "application/pdf")
       }
+      status { :pending }
     end
   end
 
@@ -29,18 +31,21 @@ FactoryBot.define do
     parent factory: :imports_uncategorized
     type { "Imports::DocxListing" }
     file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "docx_file_attachments.docx")) }
+    status { :unfurled }
   end
 
   factory :imports_docx, class: Imports::Docx do
     parent factory: :imports_uncategorized
     type { "Imports::Docx" }
     file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "document.docx")) }
+    status { :unfurled }
   end
 
   factory :imports_doc, class: Imports::Doc do
     parent factory: :imports_uncategorized
     type { "Imports::Doc" }
     file { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "document.doc")) }
+    status { :unfurled }
   end
 
   factory :imports_pdf, class: Imports::Pdf do
@@ -49,5 +54,6 @@ FactoryBot.define do
     file {
       Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"), "application/pdf")
     }
+    status { :pending }
   end
 end

--- a/spec/models/imports/doc_spec.rb
+++ b/spec/models/imports/doc_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Imports::Doc, type: :model do
 
       expect(doc.pdf).to be_present
       pdf = doc.pdf
-      expect(pdf.status).to eq("completed")
+      expect(pdf.status).to eq("pending")
       expect(pdf.public_document).to eq(true)
       expect(pdf.courtesy_notification).to eq("not_required")
 

--- a/spec/models/imports/docx_spec.rb
+++ b/spec/models/imports/docx_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Imports::Docx, type: :model do
 
       expect(docx.pdf).to be_present
       pdf = docx.pdf
-      expect(pdf.status).to eq("completed")
+      expect(pdf.status).to eq("pending")
       expect(pdf.public_document).to eq(true)
       expect(pdf.courtesy_notification).to eq("not_required")
 

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe Imports::Pdf, type: :model do
 
     expect(pdf.processed_at).to be_present
     expect(pdf.processing_errors).to be_blank
-    expect(pdf.status).to eq("completed")
+    expect(pdf.status).to eq("pending")
   end
 end

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Imports::Uncategorized, type: :model do
       import.reload
 
       expect(import.import).to be_a(Imports::DocxListing)
+      expect(import.import).to be_unfurled
     end
 
     it "detects Docx files" do
@@ -22,6 +23,7 @@ RSpec.describe Imports::Uncategorized, type: :model do
       import.reload
 
       expect(import.import).to be_a(Imports::Docx)
+      expect(import.import).to be_unfurled
     end
 
     it "detects Doc files" do
@@ -32,6 +34,7 @@ RSpec.describe Imports::Uncategorized, type: :model do
       import.reload
 
       expect(import.import).to be_a(Imports::Doc)
+      expect(import.import).to be_unfurled
     end
 
     it "detects PDF files" do
@@ -42,6 +45,7 @@ RSpec.describe Imports::Uncategorized, type: :model do
       import.reload
 
       expect(import.import).to be_a(Imports::Pdf)
+      expect(import.import).to be_pending
     end
 
     it "processes the child" do

--- a/spec/services/create_import_from_uri_spec.rb
+++ b/spec/services/create_import_from_uri_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe CreateImportFromUri do
         expect(import.file.attached?).to be_truthy
         expect(import.file.blob.filename.to_s).to eq "Bulletin 2023-52 New NGS AFSA.docx"
         expect(import.parent).to eq standards_import
+        expect(import.status).to eq "unfurled"
       end
     end
   end


### PR DESCRIPTION
This adds an `unfurled` status to be used on newly created `Imports::Uncategorized` records and all children except `Imports::Pdf` records. `Imports::Pdf` will go back to being marked as `pending` upon creation, and will not be marked as `completed` until the corresponding `DataImport` records are processed.
