### PR TITLE
Allow Pdf Import records to get assigned

### DIFF
--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -1,13 +1,5 @@
 module Admin
   class ImportsController < Admin::ApplicationController
-    # Overwrite any of the RESTful controller actions to implement custom behavior
-    # For example, you may want to send an email after a foo is updated.
-    #
-    # def update
-    #   super
-    #   send_foo_updated_email(requested_resource)
-    # end
-
     # Override this method to specify custom lookup behavior.
     # This will be used to set the resource for the `show`, `edit`, and `update`
     # actions.
@@ -22,7 +14,7 @@ module Admin
     # this will be used to set the records shown on the `index` action.
     #
     def scoped_resource
-      scope = resource_class.includes(file_attachment: :blob)
+      scope = resource_class&.preload(file_attachment: :blob)
       if current_user.admin?
         scope
       else
@@ -36,8 +28,8 @@ module Admin
       super.permit(policy(requested_resource).permitted_attributes)
     end
 
-    def after_resource_updated_path(import)
-      admin_import_path(import)
+    def after_resource_updated_path(resource)
+      params[:redirect_back_to].presence || admin_imports_path
     end
   end
 end

--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -30,18 +30,14 @@ module Admin
       end
     end
 
-    # Override `resource_params` if you want to transform the submitted
-    # data before it's persisted. For example, the following would turn all
-    # empty values into nil values. It uses other APIs such as `resource_class`
-    # and `dashboard`:
-    #
-    # def resource_params
-    #   params.require(resource_class.model_name.param_key).
-    #     permit(dashboard.permitted_attributes(action_name)).
-    #     transform_values { |value| value == "" ? nil : value }
-    # end
+    private
 
-    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
-    # for more information
+    def resource_params
+      super.permit(policy(requested_resource).permitted_attributes)
+    end
+
+    def after_resource_updated_path(import)
+      admin_import_path(import)
+    end
   end
 end

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -9,7 +9,7 @@ class ImportDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::String,
-    assignee: Field::BelongsTo,
+    assignee: AssigneeField,
     type: Field::String,
     courtesy_notification: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     metadata: Field::String.with_options(searchable: false),
@@ -61,7 +61,7 @@ class ImportDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    assignee_id
+    assignee
     courtesy_notification
     metadata
     parent

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -84,10 +84,21 @@ class ImportDashboard < Administrate::BaseDashboard
   #   }.freeze
   COLLECTION_FILTERS = {
     status: ->(resources, arg) { resources.where(status: arg) },
-    assignee: ->(resources, arg) { resources.joins(:assignee).where("users.name ILIKE ?", "%#{arg}%") },
-    organization: ->(resources, arg) { resources.joins("JOIN standards_imports ON (standards_imports.id = imports.parent_id AND imports.parent_type = 'StandardsImport')").where("standards_imports.organization ILIKE ?", "%#{arg}%") },
+    assignee: ->(resources, arg) {
+      resources.joins(:assignee).where("users.name ILIKE ?", "%#{arg}%")
+    },
+    organization: ->(resources, arg) {
+      resources
+        .joins("JOIN standards_imports ON (standards_imports.id = imports.parent_id AND imports.parent_type = 'StandardsImport')")
+        .where("standards_imports.organization ILIKE ?", "%#{arg}%")
+    },
     public_document: ->(resources, arg) { resources.where(public_document: arg) },
-    file: ->(resources, arg) { resources.joins("JOIN active_storage_attachments ON (active_storage_attachments.record_id = imports.id)").joins("JOIN active_storage_blobs ON (active_storage_attachments.blob_id = active_storage_blobs.id)").where("active_storage_blobs.filename ILIKE ?", "%#{arg}%") }
+    file: ->(resources, arg) {
+      resources
+        .joins("JOIN active_storage_attachments ON (active_storage_attachments.record_id = imports.id)")
+        .joins("JOIN active_storage_blobs ON (active_storage_attachments.blob_id = active_storage_blobs.id)")
+        .where("active_storage_blobs.filename ILIKE ?", "%#{arg}%")
+    }
   }.freeze
 
   # Overwrite this method to customize how imports are displayed

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -82,7 +82,13 @@ class ImportDashboard < Administrate::BaseDashboard
   #   COLLECTION_FILTERS = {
   #     open: ->(resources) { resources.where(open: true) }
   #   }.freeze
-  COLLECTION_FILTERS = {}.freeze
+  COLLECTION_FILTERS = {
+    status: ->(resources, arg) { resources.where(status: arg) },
+    assignee: ->(resources, arg) { resources.joins(:assignee).where("users.name ILIKE ?", "%#{arg}%") },
+    organization: ->(resources, arg) { resources.joins("JOIN standards_imports ON (standards_imports.id = imports.parent_id AND imports.parent_type = 'StandardsImport')").where("standards_imports.organization ILIKE ?", "%#{arg}%") },
+    public_document: ->(resources, arg) { resources.where(public_document: arg) },
+    file: ->(resources, arg) { resources.joins("JOIN active_storage_attachments ON (active_storage_attachments.record_id = imports.id)").joins("JOIN active_storage_blobs ON (active_storage_attachments.blob_id = active_storage_blobs.id)").where("active_storage_blobs.filename ILIKE ?", "%#{arg}%") }
+  }.freeze
 
   # Overwrite this method to customize how imports are displayed
   # across all pages of the admin dashboard.

--- a/app/policies/import_policy.rb
+++ b/app/policies/import_policy.rb
@@ -16,7 +16,7 @@ class ImportPolicy < ApplicationPolicy
   end
 
   def edit?
-    false
+    user.admin?
   end
 
   def update?
@@ -27,18 +27,11 @@ class ImportPolicy < ApplicationPolicy
     false
   end
 
-  class Scope
-    def initialize(user, scope)
-      @user = user
-      @scope = scope
+  def permitted_attributes
+    if user.converter?
+      [:status, :assignee_id, :ready_for_redaction]
+    else
+      [:status, :assignee_id, :metadata, :public_document, :courtesy_notification, :ready_for_redaction]
     end
-
-    def resolve
-      scope.all
-    end
-
-    private
-
-    attr_reader :user, :scope
   end
 end

--- a/app/policies/import_policy.rb
+++ b/app/policies/import_policy.rb
@@ -19,8 +19,10 @@ class ImportPolicy < ApplicationPolicy
     user.admin?
   end
 
+  # Allowing converters to update so they can claim an import. But we do not
+  # currently want them to access the edit page.
   def update?
-    edit?
+    admin_or_converter?
   end
 
   def destroy?

--- a/app/policies/imports/doc_policy.rb
+++ b/app/policies/imports/doc_policy.rb
@@ -1,2 +1,9 @@
-class Imports::DocPolicy < AdminPolicy
+class Imports::DocPolicy < ImportPolicy
+  def show?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
 end

--- a/app/policies/imports/docx_listing_policy.rb
+++ b/app/policies/imports/docx_listing_policy.rb
@@ -1,2 +1,9 @@
-class Imports::DocxListingPolicy < AdminPolicy
+class Imports::DocxListingPolicy < ImportPolicy
+  def show?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
 end

--- a/app/policies/imports/docx_policy.rb
+++ b/app/policies/imports/docx_policy.rb
@@ -1,4 +1,4 @@
-class Imports::DocxPolicy < AdminPolicy
+class Imports::DocxPolicy < ImportPolicy
   def show?
     user.admin?
   end

--- a/app/policies/imports/docx_policy.rb
+++ b/app/policies/imports/docx_policy.rb
@@ -1,2 +1,9 @@
 class Imports::DocxPolicy < AdminPolicy
+  def show?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
 end

--- a/app/policies/imports/uncategorized_policy.rb
+++ b/app/policies/imports/uncategorized_policy.rb
@@ -1,2 +1,9 @@
-class Imports::UncategorizedPolicy < AdminPolicy
+class Imports::UncategorizedPolicy < ImportPolicy
+  def show?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
 end

--- a/app/views/admin/imports/_form.html.erb
+++ b/app/views/admin/imports/_form.html.erb
@@ -14,15 +14,15 @@ and renders all form fields for a resource's editable attributes.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<%= form_with(model: page.resource, url: admin_import_path(page.resource), html: { class: "form" }) do |f| %>
+<%= form_with(model: page.resource, url: admin_import_path(page.resource), html: {class: "form"}) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
       <h2>
         <%= t(
-          "administrate.form.errors",
-          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
-          resource_name: display_resource_name(page.resource_name, singular: true)
-        ) %>
+              "administrate.form.errors",
+              pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+              resource_name: display_resource_name(page.resource_name, singular: true)
+            ) %>
       </h2>
 
       <ul>

--- a/app/views/admin/imports/_form.html.erb
+++ b/app/views/admin/imports/_form.html.erb
@@ -1,0 +1,60 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_with(model: page.resource, url: admin_import_path(page.resource), html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name, singular: true)
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes(controller.action_name).each do |title, attributes| -%>
+    <fieldset class="<%= "field-unit--nested" if title.present? %>">
+      <% if title.present? %>
+        <legend><%= t "helpers.label.#{f.object_name}.#{title}", default: title %></legend>
+      <% end %>
+
+      <% attributes.each do |attribute| %>
+        <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+          <%= render_field attribute, f: f %>
+
+          <% hint_key = "administrate.field_hints.#{page.resource_name}.#{attribute.name}" %>
+          <% if I18n.exists?(hint_key) -%>
+            <div class="field-unit__hint">
+              <%= I18n.t(hint_key) %>
+            </div>
+          <% end -%>
+        </div>
+      <% end %>
+    </fieldset>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/fields/assignee_field/_index.html.erb
+++ b/app/views/fields/assignee_field/_index.html.erb
@@ -8,13 +8,27 @@
     <%= field.display_associated_resource %>
   <% end %>
 <% else %>
-  <%= button_to "Claim",
-        admin_source_file_path(field.resource),
-        params: {
-          source_file: {assignee_id: current_user.id},
-          redirect_back_to: url_for(_page: params[:_page])
-        },
-        method: :patch,
-        class: "button",
-        form_class: "form-button" %>
+  <% if Flipper.enabled?(:show_imports_in_administrate) %>
+    <% if field.resource.is_a?(Imports::Pdf) %>
+      <%= button_to "Claim",
+            admin_import_path(field.resource),
+            params: {
+              import: {assignee_id: current_user.id},
+              redirect_back_to: url_for(_page: params[:_page])
+            },
+            method: :patch,
+            class: "button",
+            form_class: "form-button" %>
+    <% end %>
+  <% else %>
+    <%= button_to "Claim",
+          admin_source_file_path(field.resource),
+          params: {
+            source_file: {assignee_id: current_user.id},
+            redirect_back_to: url_for(_page: params[:_page])
+          },
+          method: :patch,
+          class: "button",
+          form_class: "form-button" %>
+  <% end %>
 <% end %>

--- a/spec/requests/admin/imports_spec.rb
+++ b/spec/requests/admin/imports_spec.rb
@@ -1,0 +1,333 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Imports", type: :request do
+  describe "GET /index" do
+    context "on admin subdomain", :admin do
+      context "when admin user" do
+        it "returns http success" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          create_pair(:imports_uncategorized)
+
+          sign_in admin
+          get admin_imports_path
+
+          expect(response).to be_successful
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+
+        it "allows filtering by status" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          unfurled = create(:imports_uncategorized, status: "unfurled")
+          archived = create(:imports_uncategorized, status: "archived")
+
+          sign_in admin
+
+          get admin_imports_path(search: "status:archived")
+
+          expect(response).to be_successful
+          expect(response.body).to include(archived.id)
+          expect(response.body).not_to include(unfurled.id)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+
+        it "allows filtering by assignee name" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          benny = create(:user, :converter, name: "Benny")
+          piper = create(:user, :converter, name: "Piper")
+          import1 = create(:imports_uncategorized, assignee: benny)
+          import2 = create(:imports_uncategorized, assignee: piper)
+
+          sign_in admin
+
+          get admin_imports_path(search: "assignee:ben")
+
+          expect(response).to be_successful
+          expect(response.body).to include(import1.id)
+          expect(response.body).not_to include(import2.id)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+
+        it "allows filtering by standards import organization field" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          import = create(:imports_uncategorized)
+          standards_import = import.parent
+          standards_import.update!(organization: "Urban Institute")
+          other_import = create(:imports_uncategorized)
+
+          sign_in admin
+
+          get admin_imports_path(search: "organization:urban")
+
+          expect(response).to be_successful
+          expect(response.body).to include(import.id)
+          expect(response.body).not_to include(other_import.id)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+
+        it "allows filtering by public document" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          import_public = create(:imports_uncategorized, public_document: true)
+          import_private = create(:imports_uncategorized, public_document: false)
+
+          sign_in admin
+
+          get admin_imports_path(search: "public_document:true")
+
+          expect(response).to be_successful
+          expect(response.body).to include(import_public.id)
+          expect(response.body).not_to include(import_private.id)
+
+          get admin_imports_path(search: "public_document:false")
+
+          expect(response).to be_successful
+          expect(response.body).to_not include(import_public.id)
+          expect(response.body).to include(import_private.id)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+
+        it "allows filtering by filename" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          import_pdf = create(:imports_pdf)
+          import_doc = create(:imports_doc)
+
+          sign_in admin
+
+          get admin_imports_path(search: "file:pixel")
+
+          expect(response).to be_successful
+          expect(response.body).to include(import_pdf.id)
+          expect(response.body).not_to include(import_doc.id)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+
+      context "when converter" do
+        it "returns http success" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:user, :converter)
+          create_pair(:imports_uncategorized)
+
+          sign_in admin
+          get admin_imports_path
+
+          expect(response).to be_successful
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+
+      context "when guest" do
+        it "redirects to root path" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          get admin_imports_path
+
+          expect(response).to redirect_to new_user_session_path
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+    end
+
+    context "on non-admin subdomain" do
+      it "has 404 response" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        get admin_imports_path
+
+        expect(response).to be_not_found
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
+
+  describe "GET /show", :admin do
+    context "when admin" do
+      it "returns http success" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin)
+        import = create(:imports_uncategorized)
+
+        sign_in admin
+        get admin_import_path(import)
+
+        expect(response).to be_successful
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+
+    context "when converter" do
+      it "returns http success" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:user, :converter)
+        import = create(:imports_pdf)
+
+        sign_in admin
+        get admin_import_path(import)
+
+        expect(response).to be_successful
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
+
+  describe "GET /edit/:id" do
+    context "on admin subdomain", :admin do
+      context "when admin user" do
+        it "returns http success" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          import = create(:imports_uncategorized)
+
+          sign_in admin
+          get edit_admin_import_path(import)
+
+          expect(response).to be_successful
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+
+      context "when converter" do
+        it "redirects" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:user, :converter)
+          import = create(:imports_pdf)
+
+          sign_in admin
+          get edit_admin_import_path(import)
+
+          expect(response).to redirect_to root_path
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+
+      context "when guest" do
+        it "redirects to root path" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          import = create(:imports_uncategorized)
+          get edit_admin_import_path(import)
+
+          expect(response).to redirect_to new_user_session_path
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+    end
+
+    context "on non-admin subdomain" do
+      it "has 404 response" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        import = create(:imports_uncategorized)
+
+        get edit_admin_import_path(import)
+
+        expect(response).to be_not_found
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
+
+  describe "PUT /update/:id" do
+    context "on admin subdomain", :admin do
+      context "when admin user" do
+        it "updates record and redirects to index" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          import = create(:imports_uncategorized, status: :unfurled)
+
+          sign_in admin
+          patch admin_import_path(import), params: {
+            import: {
+              status: "archived"
+            }
+          }
+
+          expect(import.reload).to be_archived
+          expect(response).to redirect_to admin_imports_path
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+
+      context "when converter" do
+        it "can update assignee and status only" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          assignee = create(:user, :converter)
+          admin = create(:user, :converter)
+          import = create(:imports_pdf)
+
+          sign_in admin
+          patch admin_import_path(import), params: {
+            import: {
+              status: "needs_support",
+              assignee_id: assignee.id,
+              metadata: {foo: "bob"}.to_json
+            }
+          }
+
+          import.reload
+          expect(import).to be_needs_support
+          expect(import.assignee).to eq assignee
+          expect(import.metadata).to be_empty
+          expect(response).to redirect_to admin_imports_path
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+
+        it "will redirect back to redirect_to param" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          assignee = create(:user, :converter)
+          admin = create(:user, :converter)
+          import = create(:imports_pdf)
+
+          sign_in admin
+          patch admin_import_path(import), params: {
+            import: {
+              status: "completed",
+              assignee_id: assignee.id
+            },
+            redirect_back_to: admin_imports_path(_page: 3)
+          }
+
+          expect(response).to redirect_to admin_imports_path(_page: 3)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe "admin/imports/index" do
+RSpec.describe "admin/imports/index", :admin do
   context "when admin" do
-    it "views Imports of all types", :admin do
+    it "views Imports of all types" do
       stub_feature_flag(:show_imports_in_administrate, true)
 
       admin = create(:admin)
@@ -27,7 +27,7 @@ RSpec.describe "admin/imports/index" do
       stub_feature_flag(:show_imports_in_administrate, false)
     end
 
-    it "shows Convert link on Imports::Pdf", :admin do
+    it "shows Convert link on Imports::Pdf" do
       stub_feature_flag(:show_imports_in_administrate, true)
 
       admin = create(:admin)
@@ -46,10 +46,32 @@ RSpec.describe "admin/imports/index" do
 
       stub_feature_flag(:show_imports_in_administrate, false)
     end
+
+    it "can claim an import" do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
+      converter = create(:user, :converter, name: "Mickey Mouse")
+      create(:imports_pdf)
+      create(:imports_pdf, assignee: converter)
+      admin = create(:admin, name: "Amy Applebaum")
+
+      login_as admin
+      visit admin_imports_path
+
+      expect(page).to have_text "Mickey Mouse"
+      expect(page).to have_button("Claim").once
+
+      click_button "Claim"
+
+      expect(page).to have_text "Amy Applebaum"
+      expect(page).to_not have_button "Claim"
+
+      stub_feature_flag(:show_imports_in_administrate, false)
+    end
   end
 
   context "when converter" do
-    it "views Imports of Pdf type only", :admin do
+    it "views Imports of Pdf type only" do
       stub_feature_flag(:show_imports_in_administrate, true)
 
       admin = create(:admin, :converter)
@@ -66,6 +88,25 @@ RSpec.describe "admin/imports/index" do
 
       click_on "Imports::Pdf", match: :first
       expect(page).to have_text "Imports::Uncategorized" # parent
+
+      stub_feature_flag(:show_imports_in_administrate, false)
+    end
+
+    it "can claim an import" do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
+      create(:imports_pdf)
+      admin = create(:user, :converter, name: "Amy Applebaum")
+
+      login_as admin
+      visit admin_imports_path
+
+      expect(page).to have_button("Claim").once
+
+      click_button "Claim"
+
+      expect(page).to have_text "Amy Applebaum"
+      expect(page).to_not have_button "Claim"
 
       stub_feature_flag(:show_imports_in_administrate, false)
     end


### PR DESCRIPTION
This adds the ability for an admin or converter to claim an Import record. It also adds filtering functionality for imports across: assignee, public_document, filename, and standards_import organization.

<img width="1439" alt="Screenshot 2024-05-14 at 2 36 52 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/1a6026c6-4f12-4ec9-9bf9-3590989d8d75">


[Asana ticket](https://app.asana.com/0/1203289004376659/1207249791981944/f)
