### PR TITLE
Establish redacted_pdf for Imports::Pdf model

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -7,8 +7,6 @@ class Import < ApplicationRecord
   # of Administrate.
   has_many :data_imports, -> { none }, inverse_of: "import"
 
-  has_one_attached :redacted_pdf
-
   enum :status, [
     :pending,
     :completed,

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -7,6 +7,8 @@ class Import < ApplicationRecord
   # of Administrate.
   has_many :data_imports, -> { none }, inverse_of: "import"
 
+  has_one_attached :redacted_pdf
+
   enum :status, [
     :pending,
     :completed,

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -3,6 +3,28 @@ module Imports
     has_one_attached :file
     has_many :data_imports, inverse_of: "import"
 
+    def self.recently_redacted(start_time: Time.zone.yesterday.beginning_of_day, end_time: Time.zone.yesterday.end_of_day)
+      where(
+        redacted_at: (
+          start_time..end_time
+        )
+      )
+    end
+
+    def self.not_redacted
+      includes(:redacted_pdf_attachment)
+        .where(redacted_pdf_attachment: {id: nil})
+    end
+
+    def self.ready_for_redaction
+      where(public_document: false).completed.not_redacted
+    end
+
+    def self.already_redacted
+      includes(:redacted_pdf_attachment)
+        .where.not(redacted_pdf_attachment: {id: nil})
+    end
+
     def process(**_)
       update!(
         processed_at: Time.current,
@@ -13,6 +35,14 @@ module Imports
 
     def filename
       file.blob.filename.to_s
+    end
+
+    def redacted_pdf_url
+      redacted_pdf&.blob&.url
+    end
+
+    def file_for_redaction
+      redacted_pdf.attached? ? redacted_pdf : file
     end
   end
 end

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -1,6 +1,7 @@
 module Imports
   class Pdf < Import
     has_one_attached :file
+    has_one_attached :redacted_pdf
     has_many :data_imports, inverse_of: "import"
 
     def self.recently_redacted(start_time: Time.zone.yesterday.beginning_of_day, end_time: Time.zone.yesterday.end_of_day)

--- a/db/migrate/20240514222448_add_redacted_at_to_imports.rb
+++ b/db/migrate/20240514222448_add_redacted_at_to_imports.rb
@@ -1,0 +1,5 @@
+class AddRedactedAtToImports < ActiveRecord::Migration[7.1]
+  def change
+    add_column :imports, :redacted_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_08_181029) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_14_222448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_08_181029) do
     t.datetime "updated_at", null: false
     t.datetime "processed_at", precision: nil
     t.text "processing_errors"
+    t.datetime "redacted_at", precision: nil
     t.index ["assignee_id"], name: "index_imports_on_assignee_id"
     t.index ["parent_type", "parent_id"], name: "index_imports_on_parent"
     t.index ["processed_at"], name: "index_imports_on_processed_at"

--- a/spec/factories/imports.rb
+++ b/spec/factories/imports.rb
@@ -55,5 +55,19 @@ FactoryBot.define do
       Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"), "application/pdf")
     }
     status { :pending }
+
+    trait :without_redacted_pdf do
+      redacted_pdf { nil }
+    end
+
+    trait :with_redacted_pdf do
+      redacted_pdf {
+        Rack::Test::UploadedFile.new(
+          Rails.root.join(
+            "spec", "fixtures", "files", "pixel1x1_redacted.pdf"
+          )
+        )
+      }
+    end
   end
 end

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -13,4 +13,99 @@ RSpec.describe Imports::Pdf, type: :model do
     expect(pdf.processing_errors).to be_blank
     expect(pdf.status).to eq("pending")
   end
+
+  describe ".recently_redacted" do
+    it "returns records created the day before by default" do
+      travel_to(Time.zone.local(2023, 6, 15)) do
+        recent_records = [
+          create(:imports_pdf, redacted_at: Time.zone.local(2023, 6, 14)),
+          create(:imports_pdf, redacted_at: Time.zone.local(2023, 6, 14, 23, 59, 59))
+        ]
+        create(:imports_pdf, redacted_at: Time.zone.local(2023, 6, 13, 23, 59, 59))
+
+        expect(described_class.recently_redacted).to match_array recent_records
+      end
+    end
+
+    it "returns records within the passed start and end time" do
+      recent_records = [
+        create(:imports_pdf, redacted_at: Time.zone.local(2022, 6, 14)),
+        create(:imports_pdf, redacted_at: Time.zone.local(2022, 6, 14, 22, 59, 59))
+      ]
+      create(:imports_pdf, redacted_at: Time.zone.local(2022, 6, 14, 23, 59, 59))
+
+      start_time = Time.zone.local(2022, 6, 14)
+      end_time = Time.zone.local(2022, 6, 14, 23)
+      expect(described_class.recently_redacted(start_time: start_time, end_time: end_time)).to match_array recent_records
+    end
+  end
+
+  describe ".not_redacted" do
+    it "returns only Imports::Pdf without redacted pdf" do
+      create(:imports_pdf, :with_redacted_pdf)
+      import_without_redacted_pdf = create(:imports_pdf, :without_redacted_pdf)
+
+      expect(described_class.not_redacted).to eq [import_without_redacted_pdf]
+    end
+  end
+
+  describe ".ready_for_redaction" do
+    it "returns only private imports without attachment and completed" do
+      import_with_all_conditions = create(:imports_pdf,
+        :without_redacted_pdf,
+        :completed)
+
+      _import_not_complete = create(:imports_pdf,
+        :without_redacted_pdf,
+        :pending)
+
+      _import_with_redacted_pdf = create(:imports_pdf,
+        :with_redacted_pdf,
+        :completed)
+
+      _import_public = create(:imports_pdf,
+        :without_redacted_pdf,
+        :completed,
+        public_document: true)
+
+      expect(described_class.ready_for_redaction).to eq [import_with_all_conditions]
+    end
+  end
+
+  describe ".already_redacted" do
+    it "returns only source files that are already redacted" do
+      import_with_redacted_pdf = create(:imports_pdf, :with_redacted_pdf)
+      create(:imports_pdf, :without_redacted_pdf)
+
+      expect(described_class.already_redacted).to eq [import_with_redacted_pdf]
+    end
+  end
+
+  describe "#redacted_pdf_url" do
+    it "returns nil if file not present" do
+      import = build(:imports_pdf, redacted_pdf: nil)
+
+      expect(import.redacted_pdf_url).to be nil
+    end
+
+    it "returns file url if file present", :url_generation do
+      import = build(:imports_pdf, redacted_pdf: fixture_file_upload("pixel1x1.jpg", "image/jpeg"))
+
+      expect(import.redacted_pdf_url).to be_present
+    end
+  end
+
+  describe "#file_for_redaction" do
+    it "returns redacted_pdf if present" do
+      import = build(:imports_pdf, redacted_pdf: fixture_file_upload("pixel1x1.jpg", "image/jpeg"))
+
+      expect(import.file_for_redaction).to eq import.redacted_pdf
+    end
+
+    it "returns file if redacted_pdf is not present" do
+      import = create(:imports_pdf, redacted_pdf: nil)
+
+      expect(import.file_for_redaction).to eq import.file
+    end
+  end
 end


### PR DESCRIPTION
This adds a `redacted_pdf` file attachment
to the `Imports::Pdf` model. Existing methods
from the `SourceFile` model are copied over
to the `Imports::Pdf` model and modified. This
is the first of multiple PRs to transfer the
redaction feature from `SourceFile` records
to `Imports::Pdf` records.

[Asana ticket](https://app.asana.com/0/1203289004376659/1207319519426700/f)
