### PR TITLE
Allow redacting of private Imports::Pdf files

### DIFF
--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -14,11 +14,10 @@ module Admin
     # this will be used to set the records shown on the `index` action.
     #
     def scoped_resource
-      scope = resource_class&.preload(file_attachment: :blob)
       if current_user.admin?
-        scope
+        resource_class&.preload(file_attachment: :blob)
       else
-        scope.where(type: "Imports::Pdf")
+        Imports::Pdf.preload(file_attachment: :blob)
       end
     end
 

--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -14,10 +14,10 @@ module Admin
     # this will be used to set the records shown on the `index` action.
     #
     def scoped_resource
-      if current_user.admin?
-        resource_class&.preload(file_attachment: :blob)
-      else
+      if current_user.converter? || params[:pdf_only] == "true"
         Imports::Pdf.preload(file_attachment: :blob)
+      else
+        resource_class&.preload(file_attachment: :blob)
       end
     end
 

--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -14,11 +14,12 @@ module Admin
     # this will be used to set the records shown on the `index` action.
     #
     def scoped_resource
-      if current_user.converter? || params[:pdf_only] == "true"
-        Imports::Pdf.preload(file_attachment: :blob)
+      scope = if current_user.converter? || params[:pdf_only] == "true"
+        Imports::Pdf
       else
-        resource_class&.preload(file_attachment: :blob)
+        resource_class
       end
+      scope.preload(file_attachment: :blob)
     end
 
     private

--- a/app/controllers/admin/redact_files_controller.rb
+++ b/app/controllers/admin/redact_files_controller.rb
@@ -1,8 +1,13 @@
 module Admin
   class RedactFilesController < Admin::ApplicationController
     def new
-      @source_file = SourceFile.find(params[:source_file_id])
+      @record = if Flipper.enabled?(:show_imports_in_administrate)
+        Imports::Pdf.find(params[:import_id])
+      else
+        SourceFile.find(params[:source_file_id])
+      end
       authorize :redact_file, :new?
+
       # Use a custom layout
       render layout: "admin/pdf_editor"
     end
@@ -10,21 +15,31 @@ module Admin
     def create
       respond_to do |format|
         format.json do
-          @source_file = SourceFile.find(params[:source_file_id])
+          @record = if Flipper.enabled?(:show_imports_in_administrate)
+            Import.find(params[:import_id])
+          else
+            SourceFile.find(params[:source_file_id])
+          end
           authorize :redact_file, :new?
+
           if params[:redacted_file]
-            @source_file.redacted_source_file.attach(params[:redacted_file])
-            @source_file.associated_occupation_standards.each do |occupation_standard|
+            if Flipper.enabled?(:show_imports_in_administrate)
+              @record.redacted_pdf.attach(params[:redacted_file])
+            else
+              @record.redacted_source_file.attach(params[:redacted_file])
+            end
+            @record.associated_occupation_standards.each do |occupation_standard|
               occupation_standard.redacted_document.attach(params[:redacted_file])
             end
-            @source_file.update(redacted_at: Time.current)
+            @record.update(redacted_at: Time.current)
+
             render json: {
               message: "Redacted document saved for all occupation standards associated to this source file",
               status: :ok
             }.to_json
           else
             render json: {
-              error: "Redacted document saved for all occupation standards assoaciated to this source file",
+              error: "Redacted document saved for all occupation standards associated to this source file",
               status: :unprocessable_entity
             }.to_json
           end

--- a/app/controllers/admin/redact_files_controller.rb
+++ b/app/controllers/admin/redact_files_controller.rb
@@ -39,7 +39,7 @@ module Admin
             }.to_json
           else
             render json: {
-              error: "Redacted document saved for all occupation standards associated to this source file",
+              error: "No redacted document was saved",
               status: :unprocessable_entity
             }.to_json
           end

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -98,7 +98,9 @@ class ImportDashboard < Administrate::BaseDashboard
         .joins("JOIN active_storage_attachments ON (active_storage_attachments.record_id = imports.id)")
         .joins("JOIN active_storage_blobs ON (active_storage_attachments.blob_id = active_storage_blobs.id)")
         .where("active_storage_blobs.filename ILIKE ?", "%#{arg}%")
-    }
+    },
+    not_redacted: ->(resources) { resources.not_redacted },
+    redacted: ->(resources) { resources.already_redacted }
   }.freeze
 
   # Overwrite this method to customize how imports are displayed

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -3,6 +3,7 @@ module Imports
     has_one_attached :file
     has_one_attached :redacted_pdf
     has_many :data_imports, inverse_of: "import"
+    has_many :associated_occupation_standards, -> { distinct }, through: :data_imports, source: :occupation_standard
 
     def self.recently_redacted(start_time: Time.zone.yesterday.beginning_of_day, end_time: Time.zone.yesterday.end_of_day)
       where(

--- a/app/views/admin/imports/_filters.html.erb
+++ b/app/views/admin/imports/_filters.html.erb
@@ -7,11 +7,11 @@
 <div id="dropdown" class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700">
     <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton">
       <li>
-        <%= link_to "Needs Redaction", url_for(search: "not_redacted:"),
+        <%= link_to "Needs Redaction", url_for(search: "not_redacted:", pdf_only: true),
               class: "block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white" %>
       </li>
       <li>
-        <%= link_to "Redacted", url_for(search: "redacted:"),
+        <%= link_to "Redacted", url_for(search: "redacted:", pdf_only: true),
               class: "block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white" %>
       </li>
       <li>

--- a/app/views/admin/imports/_filters.html.erb
+++ b/app/views/admin/imports/_filters.html.erb
@@ -1,0 +1,24 @@
+<button id="dropdownDefaultButton" data-dropdown-toggle="dropdown" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800" type="button">Filter by: <svg class="w-2.5 h-2.5 ms-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4" />
+</svg>
+</button>
+
+<!-- Dropdown menu -->
+<div id="dropdown" class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700">
+    <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton">
+      <li>
+        <%= link_to "Needs Redaction", url_for(search: "not_redacted:"),
+              class: "block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white" %>
+      </li>
+      <li>
+        <%= link_to "Redacted", url_for(search: "redacted:"),
+              class: "block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white" %>
+      </li>
+      <li>
+        <div class="py-1" role="none">
+          <%= link_to "Show All", admin_imports_path,
+                class: "block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white" %>
+        </div>
+      </li>
+    </ul>
+</div>

--- a/app/views/admin/imports/_index_header.html.erb
+++ b/app/views/admin/imports/_index_header.html.erb
@@ -7,9 +7,7 @@
     <%= content_for(:title) %>
   </h1>
 
-  <% if current_user.converter? %>
-    <%= render partial: "filters" %>
-  <% end %>
+  <%= render partial: "filters" %>
 
   <% if show_search_bar %>
     <%= render(

--- a/app/views/admin/imports/_index_header.html.erb
+++ b/app/views/admin/imports/_index_header.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <% if current_user.converter? %>
+    <%= render partial: "filters" %>
+  <% end %>
+
+  <% if show_search_bar %>
+    <%= render(
+          "search",
+          search_term: search_term,
+          resource_name: display_resource_name(page.resource_name)
+        ) %>
+  <% end %>
+</header>

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -1,46 +1,58 @@
-<%#
-# Show
-
-This view is the template for the show page.
-It renders the attributes of a resource,
-as well as a link to its edit page.
-
-## Local variables:
-
-- `page`:
-  An instance of [Administrate::Page::Show][1].
-  Contains methods for accessing the resource to be displayed on the page,
-  as well as helpers for describing how each attribute of the resource
-  should be displayed.
-
-[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
-%>
-
 <% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
 
-<header class="main-content__header">
-  <h1 class="main-content__page-title">
+<header class="main-content__header" role="banner">
+  <h1 id="title_id" class="main-content__page-title">
     <%= content_for(:title) %>
   </h1>
 
   <div>
-    <% if accessible_action?(page.resource, :edit) %>
+    <% if page.resource.is_a?(Imports::Pdf) %>
+      <%= if current_user.converter?
+            button_to(
+              "Needs support",
+              admin_import_path(page.resource),
+              params: {
+                import: {status: "needs_support"},
+                redirect_back_to: admin_import_path(page.resource)
+              },
+              method: :patch,
+              class: "button",
+              form_class: "form-button"
+            )
+          end %>
+
       <%= link_to(
-            t("administrate.actions.edit_resource", name: page.page_title),
-            [:edit, namespace, page.resource],
+            "New data import",
+            new_admin_import_data_import_path(page.resource),
             class: "button"
           ) %>
+
+      <%= if accessible_action?(:redact_file, :new)
+            link_to(
+              "Redact document",
+              new_admin_import_redact_file_path(page.resource),
+              class: "button"
+            )
+          end %>
     <% end %>
 
-    <% if accessible_action?(page.resource, :destroy) %>
-      <%= link_to(
+    <%= if authorized_action?(page.resource, :edit)
+          link_to(
+            t("administrate.actions.edit_resource", name: page.page_title),
+            edit_admin_import_path(page.resource),
+            class: "button"
+          )
+        end %>
+
+    <%= if authorized_action?(page.resource, :destroy)
+          link_to(
             t("administrate.actions.destroy"),
-            [namespace, page.resource],
+            admin_import_path(page.resource),
             class: "button button--danger",
             method: :delete,
             data: {confirm: t("administrate.actions.confirm")}
-          ) %>
-    <% end %>
+          )
+        end %>
   </div>
 </header>
 

--- a/app/views/admin/redact_files/new.html.erb
+++ b/app/views/admin/redact_files/new.html.erb
@@ -2,11 +2,11 @@
   data-controller="pdf-editor"
   data-pdf-editor-license-key-value="<%= ENV["FOXIT_SDK_LICENSE_KEY"] %>"
   data-pdf-editor-license-serial-number-value="<%= ENV["FOXIT_SDK_SERIAL_NUMBER"] %>"
-  data-pdf-editor-file-url-value="<%= rails_storage_proxy_path(@source_file.file_for_redaction) %>"
-  data-pdf-editor-file-size-value="<%= @source_file.file_for_redaction.byte_size %>"
-  data-pdf-editor-file-name-value="<%= @source_file.file_for_redaction.blob.filename %>"
-  data-pdf-editor-save-file-url-value="<%= admin_source_file_redact_file_path(@source_file, format: :json) %>"
-  data-pdf-editor-go-back-url-value="<%= admin_source_file_path(@source_file) %>">
+  data-pdf-editor-file-url-value="<%= rails_storage_proxy_path(@record.file_for_redaction) %>"
+  data-pdf-editor-file-size-value="<%= @record.file_for_redaction.byte_size %>"
+  data-pdf-editor-file-name-value="<%= @record.file_for_redaction.blob.filename %>"
+  data-pdf-editor-save-file-url-value="<%= admin_source_file_redact_file_path(@record, format: :json) %>"
+  data-pdf-editor-go-back-url-value="<%= Flipper.enabled?(:show_imports_in_administrate) ? admin_import_path(@record) : admin_source_file_path(@record) %>">
   <%= form_tag(url_for(action: :create), method: :post, multipart: true, data: {turbo: false, pdf_editor_target: "form"}) do %>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       end
       resources :standards_imports
       resources :imports do
+        resource :redact_file, only: [:new, :create]
         resources :data_imports, except: [:index]
       end
       resources :occupation_standards, only: [:index, :show, :edit, :update]

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -108,4 +108,14 @@ RSpec.describe Imports::Pdf, type: :model do
       expect(import.file_for_redaction).to eq import.file
     end
   end
+
+  describe "#associated_occupation_standards" do
+    it "returns unique occupation standards" do
+      import = create(:imports_pdf)
+      occupation_standard = create(:occupation_standard)
+      create_pair(:data_import, import: import, occupation_standard: occupation_standard)
+
+      expect(import.associated_occupation_standards).to eq [occupation_standard]
+    end
+  end
 end

--- a/spec/requests/admin/imports_spec.rb
+++ b/spec/requests/admin/imports_spec.rb
@@ -133,6 +133,42 @@ RSpec.describe "Admin::Imports", type: :request do
 
           stub_feature_flag(:show_imports_in_administrate, false)
         end
+
+        it "allows filtering by needs redaction" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin, :converter)
+          redacted = create(:imports_pdf, :with_redacted_pdf)
+          not_redacted = create(:imports_pdf)
+
+          sign_in admin
+
+          get admin_imports_path(search: "not_redacted:")
+
+          expect(response).to be_successful
+          expect(response.body).to include(not_redacted.id)
+          expect(response.body).not_to include(redacted.id)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+
+        it "allows filtering by redacted" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin, :converter)
+          redacted = create(:imports_pdf, :with_redacted_pdf)
+          not_redacted = create(:imports_pdf)
+
+          sign_in admin
+
+          get admin_imports_path(search: "redacted:")
+
+          expect(response).to be_successful
+          expect(response.body).to include(redacted.id)
+          expect(response.body).not_to include(not_redacted.id)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
       end
 
       context "when guest" do

--- a/spec/requests/admin/imports_spec.rb
+++ b/spec/requests/admin/imports_spec.rb
@@ -117,6 +117,42 @@ RSpec.describe "Admin::Imports", type: :request do
 
           stub_feature_flag(:show_imports_in_administrate, false)
         end
+
+        it "allows filtering by needs redaction" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          redacted = create(:imports_pdf, :with_redacted_pdf)
+          not_redacted = create(:imports_pdf)
+
+          sign_in admin
+
+          get admin_imports_path(search: "not_redacted:", pdf_only: true)
+
+          expect(response).to be_successful
+          expect(response.body).to include(not_redacted.id)
+          expect(response.body).not_to include(redacted.id)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+
+        it "allows filtering by redacted" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          redacted = create(:imports_pdf, :with_redacted_pdf)
+          not_redacted = create(:imports_pdf)
+
+          sign_in admin
+
+          get admin_imports_path(search: "redacted:", pdf_only: true)
+
+          expect(response).to be_successful
+          expect(response.body).to include(redacted.id)
+          expect(response.body).not_to include(not_redacted.id)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
       end
 
       context "when converter" do

--- a/spec/requests/admin/imports_spec.rb
+++ b/spec/requests/admin/imports_spec.rb
@@ -179,18 +179,36 @@ RSpec.describe "Admin::Imports", type: :request do
     end
 
     context "when converter" do
-      it "returns http success" do
-        stub_feature_flag(:show_imports_in_administrate, true)
+      context "when Imports::Pdf type" do
+        it "returns http success" do
+          stub_feature_flag(:show_imports_in_administrate, true)
 
-        admin = create(:user, :converter)
-        import = create(:imports_pdf)
+          admin = create(:user, :converter)
+          import = create(:imports_pdf)
 
-        sign_in admin
-        get admin_import_path(import)
+          sign_in admin
+          get admin_import_path(import)
 
-        expect(response).to be_successful
+          expect(response).to be_successful
 
-        stub_feature_flag(:show_imports_in_administrate, false)
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+
+      context "when not Imports::Pdf type" do
+        it "returns 404" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:user, :converter)
+          import = create(:imports_uncategorized)
+
+          sign_in admin
+          get admin_import_path(import)
+
+          expect(response).to be_not_found
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
       end
     end
   end

--- a/spec/requests/admin/redact_file_spec.rb
+++ b/spec/requests/admin/redact_file_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
 
           expect(response).to be_successful
         end
+
+        it "with import feature flag: returns http success" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          import = create(:imports_pdf)
+
+          sign_in admin
+          get new_admin_import_redact_file_path(import)
+
+          expect(response).to be_successful
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
       end
 
       context "when converter" do
@@ -25,6 +39,20 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
 
           expect(response).to be_successful
         end
+
+        it "with import feature flag: returns http success" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:user, :converter)
+          import = create(:imports_pdf)
+
+          sign_in admin
+          get new_admin_import_redact_file_path(import)
+
+          expect(response).to be_successful
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
       end
 
       context "when guest" do
@@ -35,6 +63,18 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
 
           expect(response).to redirect_to new_user_session_path
         end
+
+        it "with import feature flag: redirects to root path" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          import = create(:imports_pdf)
+
+          get new_admin_import_redact_file_path(import)
+
+          expect(response).to redirect_to new_user_session_path
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
       end
     end
 
@@ -43,6 +83,14 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
         source_file = create(:source_file)
 
         get new_admin_source_file_redact_file_path(source_file)
+
+        expect(response).to be_not_found
+      end
+
+      it "with import feature flag: has 404 response" do
+        import = create(:imports_pdf)
+
+        get new_admin_import_redact_file_path(import)
 
         expect(response).to be_not_found
       end
@@ -63,6 +111,21 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
             expect(response).to be_successful
             expect(source_file.reload.redacted_at).to be nil
           end
+
+          it "with import feature flag: returns http success" do
+            stub_feature_flag(:show_imports_in_administrate, true)
+
+            admin = create(:admin)
+            import = create(:imports_pdf)
+
+            sign_in admin
+            post admin_import_redact_file_path(import), as: :json
+
+            expect(response).to be_successful
+            expect(import.reload.redacted_at).to be nil
+
+            stub_feature_flag(:show_imports_in_administrate, false)
+          end
         end
 
         context "with redacted file" do
@@ -81,6 +144,28 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
               expect(response).to be_successful
               expect(source_file.reload.redacted_at).to eq Time.current
               expect(source_file.redacted_source_file).to be_attached
+            end
+          end
+
+          it "with import feature flag: returns http success" do
+            stub_feature_flag(:show_imports_in_administrate, true)
+
+            travel_to Time.current do
+              admin = create(:admin)
+              import = create(:imports_pdf)
+              redacted_file = fixture_file_upload("pixel1x1.jpg", "image/jpeg")
+
+              sign_in admin
+              post admin_import_redact_file_path(import), params: {
+                format: :json,
+                redacted_file: redacted_file
+              }
+
+              expect(response).to be_successful
+              expect(import.reload.redacted_at).to eq Time.current
+              expect(import.redacted_pdf).to be_attached
+
+              stub_feature_flag(:show_imports_in_administrate, false)
             end
           end
         end
@@ -105,6 +190,31 @@ RSpec.describe "Admin::SourceFiles::RedactFile", type: :request do
               expect(source_file.reload.redacted_at).to eq Time.current
               expect(source_file.redacted_source_file).to be_attached
             end
+          end
+
+          it "with import feature flag: only updates redacted_source_file" do
+            stub_feature_flag(:show_imports_in_administrate, true)
+
+            travel_to Time.current do
+              admin = create(:admin)
+              data_import = create(:data_import, occupation_standard: nil)
+              import = create(:imports_pdf, data_imports: [data_import])
+              redacted_file = fixture_file_upload("pixel1x1.jpg", "image/jpeg")
+
+              params = {
+                format: :json,
+                redacted_file: redacted_file
+              }
+
+              sign_in admin
+              post admin_import_redact_file_path(import), params: params
+
+              expect(response).to be_successful
+              expect(import.reload.redacted_at).to eq Time.current
+              expect(import.redacted_pdf).to be_attached
+            end
+
+            stub_feature_flag(:show_imports_in_administrate, false)
           end
         end
       end

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -68,6 +68,48 @@ RSpec.describe "admin/imports/index", :admin do
 
       stub_feature_flag(:show_imports_in_administrate, false)
     end
+
+    it "allows filtering by redaction status" do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
+      admin = create(:admin)
+      import_uncategorized = create(:imports_uncategorized)
+      import_redacted = create(:imports_pdf, :with_redacted_pdf, status: :pending)
+      import_not_redacted = create(:imports_pdf, status: :needs_support)
+
+      login_as admin
+      visit admin_imports_path
+
+      expect(page).to have_content("Imports::Uncategorized")
+      expect(page).to have_content("Imports::Pdf").twice
+
+      expect(page).to have_button "Filter by:"
+      click_on "Filter by"
+      click_on "Needs Redaction"
+
+      expect(page).to have_text "needs_support"
+      expect(page).to_not have_text "pending"
+      expect(page).to_not have_content("Imports::Uncategorized")
+      expect(page).to have_content("Imports::Pdf").once
+
+      click_on "Filter by"
+      click_on "Redacted"
+
+      expect(page).to_not have_text "needs_support"
+      expect(page).to have_text "pending"
+      expect(page).to_not have_content("Imports::Uncategorized")
+      expect(page).to have_content("Imports::Pdf").once
+
+      click_on "Filter by"
+      click_on "Show All"
+
+      expect(page).to have_text "needs_support"
+      expect(page).to have_text "pending"
+      expect(page).to have_content("Imports::Uncategorized")
+      expect(page).to have_content("Imports::Pdf").twice
+
+      stub_feature_flag(:show_imports_in_administrate, false)
+    end
   end
 
   context "when converter" do
@@ -92,7 +134,7 @@ RSpec.describe "admin/imports/index", :admin do
       stub_feature_flag(:show_imports_in_administrate, false)
     end
 
-    it "has Filter by" do
+    it "allows filtering by redaction status" do
       stub_feature_flag(:show_imports_in_administrate, true)
 
       admin = create(:admin, :converter)

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -92,6 +92,38 @@ RSpec.describe "admin/imports/index", :admin do
       stub_feature_flag(:show_imports_in_administrate, false)
     end
 
+    it "has Filter by" do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
+      admin = create(:admin, :converter)
+      import_redacted = create(:imports_pdf, :with_redacted_pdf, status: :pending)
+      import_not_redacted = create(:imports_pdf, status: :needs_support)
+
+      login_as admin
+      visit admin_imports_path
+
+      expect(page).to have_button "Filter by:"
+      click_on "Filter by"
+      click_on "Needs Redaction"
+
+      expect(page).to have_text "needs_support"
+      expect(page).to_not have_text "pending"
+
+      click_on "Filter by"
+      click_on "Redacted"
+
+      expect(page).to_not have_text "needs_support"
+      expect(page).to have_text "pending"
+
+      click_on "Filter by"
+      click_on "Show All"
+
+      expect(page).to have_text "needs_support"
+      expect(page).to have_text "pending"
+
+      stub_feature_flag(:show_imports_in_administrate, false)
+    end
+
     it "can claim an import" do
       stub_feature_flag(:show_imports_in_administrate, true)
 

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe "admin/imports/index", :admin do
       stub_feature_flag(:show_imports_in_administrate, true)
 
       admin = create(:admin)
-      import_uncategorized = create(:imports_uncategorized)
-      import_redacted = create(:imports_pdf, :with_redacted_pdf, status: :pending)
-      import_not_redacted = create(:imports_pdf, status: :needs_support)
+      create(:imports_uncategorized)
+      create(:imports_pdf, :with_redacted_pdf, status: :pending)
+      create(:imports_pdf, status: :needs_support)
 
       login_as admin
       visit admin_imports_path
@@ -138,8 +138,8 @@ RSpec.describe "admin/imports/index", :admin do
       stub_feature_flag(:show_imports_in_administrate, true)
 
       admin = create(:admin, :converter)
-      import_redacted = create(:imports_pdf, :with_redacted_pdf, status: :pending)
-      import_not_redacted = create(:imports_pdf, status: :needs_support)
+      create(:imports_pdf, :with_redacted_pdf, status: :pending)
+      create(:imports_pdf, status: :needs_support)
 
       login_as admin
       visit admin_imports_path

--- a/spec/system/admin/imports/show_spec.rb
+++ b/spec/system/admin/imports/show_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "admin/imports/show", :admin do
+  context "when Imports::Pdf" do
+    context "when admin" do
+      it "does not have button for needing support but has data import and redact buttons" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin)
+        import = create(:imports_pdf)
+
+        login_as admin
+        visit admin_import_path(import)
+
+        expect(page).to have_text "Imports::Pdf"
+        expect(page).to_not have_button "Needs support"
+        expect(page).to have_link "New data import", href: new_admin_import_data_import_path(import)
+        expect(page).to have_link "Redact document", href: new_admin_import_redact_file_path(import)
+        expect(page).to have_link "Edit", href: edit_admin_import_path(import)
+        expect(page).to_not have_link "Destroy"
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+
+    context "when converter" do
+      it "has button for needing support, data imports, and redact buttons" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin, :converter)
+        import = create(:imports_pdf)
+
+        login_as admin
+        visit admin_import_path(import)
+
+        expect(page).to have_text "Imports::Pdf"
+        expect(page).to have_button "Needs support"
+        expect(page).to have_link "New data import", href: new_admin_import_data_import_path(import)
+        expect(page).to have_link "Redact document", href: new_admin_import_redact_file_path(import)
+        expect(page).to_not have_link "Edit", href: edit_admin_import_path(import)
+        expect(page).to_not have_link "Destroy"
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
+end

--- a/spec/system/admin/imports/show_spec.rb
+++ b/spec/system/admin/imports/show_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe "admin/imports/show", :admin do
       end
     end
   end
+
+  context "when not Imports::Pdf type" do
+    context "when admin" do
+      it "does not have buttons for needing support, data import or redact" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin)
+        import = create(:imports_uncategorized)
+
+        login_as admin
+        visit admin_import_path(import)
+
+        expect(page).to have_text "Imports::Uncategorized"
+        expect(page).to_not have_button "Needs support"
+        expect(page).to_not have_link "New data import"
+        expect(page).to_not have_link "Redact document"
+        expect(page).to have_link "Edit", href: edit_admin_import_path(import)
+        expect(page).to_not have_link "Destroy"
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
 end

--- a/spec/system/admin/imports/show_spec.rb
+++ b/spec/system/admin/imports/show_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "admin/imports/show", :admin do
         stub_feature_flag(:show_imports_in_administrate, true)
 
         admin = create(:admin, :converter)
-        import = create(:imports_pdf)
+        import = create(:imports_pdf, status: :pending)
 
         login_as admin
         visit admin_import_path(import)
@@ -39,6 +39,11 @@ RSpec.describe "admin/imports/show", :admin do
         expect(page).to have_link "Redact document", href: new_admin_import_redact_file_path(import)
         expect(page).to_not have_link "Edit", href: edit_admin_import_path(import)
         expect(page).to_not have_link "Destroy"
+
+        click_on "Needs support"
+
+        expect(page).to have_text "needs_support"
+        expect(import.reload).to be_needs_support
 
         stub_feature_flag(:show_imports_in_administrate, false)
       end


### PR DESCRIPTION
This adds the ability to redact `Imports::Pdf` documents. This also adds in the filters for displaying redacted vs non-redacted files.

**Admin Index view**
<img width="1443" alt="Screenshot 2024-05-15 at 11 55 16 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/472b08ad-51cc-4225-945e-7075eb1e4377">

**Admin show view**
<img width="1274" alt="Screenshot 2024-05-15 at 11 55 48 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/5151226f-e98c-43c9-814d-ef605f982a39">

**Converter show view**
<img width="1606" alt="Screenshot 2024-05-15 at 11 56 01 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/93dd24f8-6f08-4c24-bc80-4b34359441de">


[Asana ticket](https://app.asana.com/0/1203289004376659/1207319519426700/f)
