### PR TITLE
Modify admin_mailer to send report for redacted imports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ end
 group :development do
   gem "erb_lint", require: false
   gem "erblint-github"
+  gem "letter_opener"
   gem "standard", "~> 1.36"
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.0.0)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crack (1.0.0)
@@ -275,6 +276,11 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -590,6 +596,7 @@ DEPENDENCIES
   importmap-rails
   jsonapi-resources
   jwt
+  letter_opener
   non-digest-assets!
   oauth2 (~> 2.0, >= 2.0.9)
   pagy

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,3 @@
 web: bin/rails server -p 3000
 css: bin/rails tailwindcss:watch
 elasticsearch: bin/elasticsearch
-mailcatcher: mailcatcher --foreground

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -29,12 +29,16 @@ class AdminMailer < ApplicationMailer
   end
 
   def daily_redacted_files_report
-    @recently_redacted_source_files = SourceFile.includes(active_storage_attachment: :blob).recently_redacted
+    @recently_redacted_records = if Flipper.enabled?(:show_imports_in_administrate)
+      Imports::Pdf.includes(file_attachment: :blob).recently_redacted
+    else
+      SourceFile.includes(active_storage_attachment: :blob).recently_redacted
+    end
 
-    if @recently_redacted_source_files.any?
+    if @recently_redacted_records.any?
       date = Time.zone.yesterday.to_date
       mail to: "info@workhands.us",
-        subject: "Daily redacted source files report #{date}"
+        subject: "Daily redacted files report #{date}"
     end
   end
 end

--- a/app/views/admin_mailer/daily_redacted_files_report.html.erb
+++ b/app/views/admin_mailer/daily_redacted_files_report.html.erb
@@ -1,7 +1,12 @@
 <div>
-  <% @recently_redacted_source_files.each do |source_file| %>
+  <% @recently_redacted_records.each do |record| %>
     <div>
-      <%= link_to source_file.active_storage_attachment.filename, admin_source_file_url(source_file) %>
-       <br> <br>
+      <% if Flipper.enabled?(:show_imports_in_administrate) %>
+        <%= link_to record.filename, admin_import_url(record) %>
+      <% else %>
+        <%= link_to record.active_storage_attachment.filename, admin_source_file_url(record) %>
+      <% end %>
+      <br> <br>
+    </div>
   <% end %>
 </div>

--- a/app/views/admin_mailer/daily_redacted_files_report.text.erb
+++ b/app/views/admin_mailer/daily_redacted_files_report.text.erb
@@ -1,5 +1,9 @@
-<% @recently_redacted_source_files.each do |source_file| %>
-  <%= source_file.active_storage_attachment.filename%>
-  <%= link_to "Admin", admin_source_file_url(source_file) %>
+<% @recently_redacted_records.each do |record| %>
+  <% if Flipper.enabled?(:show_imports_in_administrate) %>
+    <%= record.filename %>
+    <%= admin_import_url(record) %>
+  <% else %>
+    <%= record.active_storage_attachment.filename %>
+    <%= link_to "Admin", admin_source_file_url(record) %>
+  <% end %>
 <% end %>
-

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,8 +41,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {address: "127.0.0.1", port: 1025}
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = {host: "admin.example.localhost", port: 3000}
 
   # Print deprecation notices to the Rails logger.

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe AdminMailer, type: :mailer do
 
         mail = described_class.daily_redacted_files_report
 
-        expect(mail.subject).to eq("Daily redacted source files report 2023-06-14")
+        expect(mail.subject).to eq("Daily redacted files report 2023-06-14")
         expect(mail.to).to eq(["info@workhands.us"])
         expect(mail.from).to eq(["no-reply@apprenticeshipstandards.org"])
 
@@ -104,6 +104,37 @@ RSpec.describe AdminMailer, type: :mailer do
       expect {
         described_class.daily_redacted_files_report.deliver_now
       }.not_to change(ActionMailer::Base.deliveries, :count)
+    end
+
+    it "with import feature flag: renders the header and body correctly" do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
+      travel_to(Time.zone.local(2023, 6, 15)) do
+        import = create(:imports_pdf, redacted_at: Time.zone.local(2023, 6, 14))
+
+        mail = described_class.daily_redacted_files_report
+
+        expect(mail.subject).to eq("Daily redacted files report 2023-06-14")
+        expect(mail.to).to eq(["info@workhands.us"])
+        expect(mail.from).to eq(["no-reply@apprenticeshipstandards.org"])
+
+        mail.body.parts.each do |part|
+          expect(part.body.encoded).to match import.filename
+          expect(part.body.encoded).to match admin_import_url(import)
+        end
+      end
+
+      stub_feature_flag(:show_imports_in_administrate, false)
+    end
+
+    it "with import feature flag: does not send mail if no imports" do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
+      expect {
+        described_class.daily_redacted_files_report.deliver_now
+      }.not_to change(ActionMailer::Base.deliveries, :count)
+
+      stub_feature_flag(:show_imports_in_administrate, false)
     end
   end
 end


### PR DESCRIPTION
Also replace mailcatcher with letter_opener since getting [internal server error](https://github.com/sj26/mailcatcher/issues/558) locally :(

<img width="653" alt="Screenshot 2024-05-15 at 4 15 38 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/a9cc7aae-90f1-4d09-bac5-b8595d2d8a27">

<img width="781" alt="Screenshot 2024-05-15 at 4 15 43 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/65c2feb4-37a5-4ea7-9b77-6629ead711aa">


[Asana ticket](https://app.asana.com/0/1203289004376659/1207319519426700/f)
