### PR TITLE
View and delete redacted import files

### DIFF
--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -22,6 +22,13 @@ module Admin
       scope.preload(file_attachment: :blob)
     end
 
+    def destroy_redacted_pdf
+      redacted_pdf = requested_resource.redacted_pdf
+      redacted_pdf.purge
+
+      redirect_to admin_import_path(requested_resource)
+    end
+
     private
 
     def resource_params

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -18,6 +18,12 @@ class ImportDashboard < Administrate::BaseDashboard
     processed_at: Field::DateTime,
     processing_errors: Field::Text,
     public_document: Field::Boolean,
+    redacted_pdf: Field::ActiveStorage.with_options(
+      destroy_url: proc do |namespace, resource, attachment|
+        [:redacted_import_admin_import, {attachment_id: attachment.id}]
+      end
+    ),
+    redacted_pdf_url: Field::Url.with_options(searchable: false),
     status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     data_imports: HasManyDataImportsField,
     created_at: Field::DateTime,
@@ -48,6 +54,8 @@ class ImportDashboard < Administrate::BaseDashboard
     status
     metadata
     public_document
+    redacted_pdf
+    redacted_pdf_url
     processed_at
     processing_errors
     courtesy_notification

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -22,7 +22,14 @@ class Import < ApplicationRecord
     :completed
   ], _prefix: true
 
+
   def filename
     file.blob.filename.to_s
+  end
+
+  def redacted_pdf
+  end
+
+  def redacted_pdf_url
   end
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -22,7 +22,6 @@ class Import < ApplicationRecord
     :completed
   ], _prefix: true
 
-
   def filename
     file.blob.filename.to_s
   end

--- a/app/policies/imports/pdf_policy.rb
+++ b/app/policies/imports/pdf_policy.rb
@@ -1,2 +1,5 @@
 class Imports::PdfPolicy < ImportPolicy
+  def destroy_redacted_pdf?
+    user.admin?
+  end
 end

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -65,6 +65,7 @@
         <% end %>
 
         <% attributes.each do |attribute| %>
+          <% next if attribute.name.match?("redacted") && !page.resource.is_a?(Imports::Pdf) %>
           <dt class="attribute-label" id="<%= attribute.name %>">
             <%= t(
                   "helpers.label.#{resource_name}.#{attribute.name}",

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -10,7 +10,7 @@
   </div>
 <% end %>
 
-<% if field.destroy_url.present? && accessible_action?(field.resource, :"destroy_#{field.attribute}") %>
+<% if field.destroy_url.present? && authorized_action?(field.resource, :"destroy_#{field.attribute}") %>
   <% destroy_url = field.destroy_url.call(namespace, field.data.record, attachment) %>
   <div>
     <%= link_to I18n.t("administrate.fields.active_storage.remove", default: "Remove"),

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -10,6 +10,12 @@
   </div>
 <% end %>
 
+<%
+  # This authorized_action? was changed from accessible_action? since Imports
+  # STI is causing issues looking up the correct dashboard. The
+  # accessible_action first makes sure that a valid Dashboard exists before
+  # checking if the action is authorized.
+%>
 <% if field.destroy_url.present? && authorized_action?(field.resource, :"destroy_#{field.attribute}") %>
   <% destroy_url = field.destroy_url.call(namespace, field.data.record, attachment) %>
   <div>

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -10,12 +10,10 @@
   </div>
 <% end %>
 
-<%
-  # This authorized_action? was changed from accessible_action? since Imports
+<%# This authorized_action? was changed from accessible_action? since Imports
   # STI is causing issues looking up the correct dashboard. The
   # accessible_action first makes sure that a valid Dashboard exists before
-  # checking if the action is authorized.
-%>
+  # checking if the action is authorized. %>
 <% if field.destroy_url.present? && authorized_action?(field.resource, :"destroy_#{field.attribute}") %>
   <% destroy_url = field.destroy_url.call(namespace, field.data.record, attachment) %>
   <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
       resources :imports do
         resource :redact_file, only: [:new, :create]
         resources :data_imports, except: [:index]
+        delete :redacted_import, on: :member, action: :destroy_redacted_pdf
       end
       resources :occupation_standards, only: [:index, :show, :edit, :update]
       resources :occupations, only: [:index, :show, :edit, :update]

--- a/spec/system/admin/imports/show_spec.rb
+++ b/spec/system/admin/imports/show_spec.rb
@@ -21,6 +21,30 @@ RSpec.describe "admin/imports/show", :admin do
 
         stub_feature_flag(:show_imports_in_administrate, false)
       end
+
+      it "allows admin to remove a redacted file" do
+        admin = create(:admin)
+        import = create(:imports_pdf, :with_redacted_pdf)
+
+        login_as admin
+        visit admin_import_path(import)
+
+        expect(page).to have_text import.redacted_pdf.filename
+
+        expect(page).to have_link(
+          "Remove",
+          href: redacted_import_admin_import_path(
+            import,
+            attachment_id: import.redacted_pdf.id
+          )
+        )
+
+        click_link "Remove"
+
+        expect(page).to_not have_text import.redacted_pdf.filename
+        expect(page).to have_text "No attachment"
+        expect(page).to_not have_link "Remove"
+      end
     end
 
     context "when converter" do


### PR DESCRIPTION
This allows viewing a redacted file in Administrate, as well as deleting it.

**Display redacted fields on `Imports::Pdf` records**
<img width="1433" alt="Screenshot 2024-05-15 at 3 36 10 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/8f5d6d08-2b5a-4236-9ae4-4383fdda43f4">

**Do not display redacted fields on other Import types**
<img width="801" alt="Screenshot 2024-05-15 at 3 36 24 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/124bf7fd-a55d-4009-a30a-f067c857f099">

**Converters cannot remove redacted files**
<img width="1446" alt="Screenshot 2024-05-15 at 3 37 39 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/3c1466e9-6415-4d90-a13c-4d28afbf362f">


[Asana ticket](https://app.asana.com/0/1203289004376659/1207319519426700/f)
