### PR TITLE
Do not show SourceFiles in Administrate when Imports feature flag on

### DIFF
--- a/app/controllers/admin/source_files_controller.rb
+++ b/app/controllers/admin/source_files_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class SourceFilesController < Admin::ApplicationController
-    skip_after_action :verify_authorized, only:  :index
+    skip_after_action :verify_authorized, only: :index
 
     def index
       if Flipper.enabled?(:show_imports_in_administrate)

--- a/app/controllers/admin/source_files_controller.rb
+++ b/app/controllers/admin/source_files_controller.rb
@@ -1,5 +1,15 @@
 module Admin
   class SourceFilesController < Admin::ApplicationController
+    skip_after_action :verify_authorized, only:  :index
+
+    def index
+      if Flipper.enabled?(:show_imports_in_administrate)
+        redirect_to admin_imports_url
+      else
+        super
+      end
+    end
+
     def scoped_resource
       if params[:filter_by] == "needs_redaction"
         SourceFile.preload(active_storage_attachment: [:record]).ready_for_redaction

--- a/app/policies/source_file_policy.rb
+++ b/app/policies/source_file_policy.rb
@@ -1,6 +1,6 @@
 class SourceFilePolicy < ApplicationPolicy
   def index?
-    admin_or_converter?
+    !Flipper.enabled?(:show_imports_in_administrate) && admin_or_converter?
   end
 
   def show?


### PR DESCRIPTION
This hides the SourceFiles link in Administrate when the Imports feature flag is on by taking advantage of the Pundit policy. However, since `admin/source_files#index` is the root path, we still need to allow access to it, so we skip the authorization for just the SourceFile#index route.

Converter view when flag is on:

<img width="896" alt="Screenshot 2024-05-16 at 9 58 59 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/1afa0dec-5343-4852-852d-2470f0d9f4d0">

