### PR TITLE
Link occupation standards to imports when feature flag on

### DIFF
--- a/app/dashboards/occupation_standard_dashboard.rb
+++ b/app/dashboards/occupation_standard_dashboard.rb
@@ -21,7 +21,6 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
     related_job_titles: Field::String.with_options(searchable: false),
     rsi_hours_max: Field::Number,
     rsi_hours_min: Field::Number,
-    source_file: Field::String.with_options(searchable: false),
     status: EnumField,
     term_months: Field::Number,
     title: Field::String,

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -32,11 +32,7 @@ class Import < ApplicationRecord
   def redacted_pdf_url
   end
 
-  def root
-    if parent.is_a?(StandardsImport)
-      parent
-    else
-      parent.root
-    end
+  def import_root
+    parent.import_root
   end
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -31,4 +31,12 @@ class Import < ApplicationRecord
 
   def redacted_pdf_url
   end
+
+  def root
+    if parent.is_a?(StandardsImport)
+      parent
+    else
+      parent.root
+    end
+  end
 end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -250,7 +250,11 @@ class OccupationStandard < ApplicationRecord
   end
 
   def source_file
-    data_import&.source_file
+    if Flipper.enabled?(:show_imports_in_administrate)
+      data_import&.import
+    else
+      data_import&.source_file
+    end
   end
 
   def public_document?

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -232,7 +232,7 @@ class OccupationStandard < ApplicationRecord
 
   def standards_import
     if Flipper.enabled?(:show_imports_in_administrate)
-      source_file&.root
+      source_file&.import_root
     else
       source_file&.standards_import
     end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -20,7 +20,6 @@ class OccupationStandard < ApplicationRecord
   delegate :title, to: :organization, prefix: true, allow_nil: true
   delegate :title, to: :occupation, prefix: true, allow_nil: true
   delegate :name, to: :industry, prefix: true, allow_nil: true
-  delegate :standards_import, to: :source_file, allow_nil: true
   delegate :state, to: :registration_agency, allow_nil: true
 
   enum ojt_type: [:time, :competency, :hybrid], _suffix: :based
@@ -229,6 +228,14 @@ class OccupationStandard < ApplicationRecord
 
   def sponsor_name
     organization&.title
+  end
+
+  def standards_import
+    if Flipper.enabled?(:show_imports_in_administrate)
+      source_file&.root
+    else
+      source_file&.standards_import
+    end
   end
 
   def data_import

--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -20,6 +20,10 @@ class StandardsImport < ApplicationRecord
     end
   end
 
+  def import_root
+    self
+  end
+
   def source_files
     files
       .includes(source_file: {active_storage_attachment: :blob})

--- a/spec/factories/occupation_standards.rb
+++ b/spec/factories/occupation_standards.rb
@@ -18,7 +18,12 @@ FactoryBot.define do
 
     trait :with_data_import do
       after :create do |occupation_standard|
-        create(:data_import, occupation_standard: occupation_standard)
+        if Flipper.enabled?(:show_imports_in_administrate)
+          import = build(:imports_pdf)
+          create(:data_import, import: import, source_file: nil, occupation_standard: occupation_standard)
+        else
+          create(:data_import, occupation_standard: occupation_standard)
+        end
       end
     end
 

--- a/spec/models/imports/doc_spec.rb
+++ b/spec/models/imports/doc_spec.rb
@@ -50,4 +50,15 @@ RSpec.describe Imports::Doc, type: :model do
       expect(pdf_import).to have_received(:process).with(arg: 1)
     end
   end
+
+  describe "#root" do
+    it "retrieves the standards_import at the root" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx_listing = create(:imports_docx_listing, parent: uncat)
+      doc = create(:imports_doc, parent: docx_listing)
+
+      expect(doc.root).to eq standards_import
+    end
+  end
 end

--- a/spec/models/imports/doc_spec.rb
+++ b/spec/models/imports/doc_spec.rb
@@ -51,14 +51,14 @@ RSpec.describe Imports::Doc, type: :model do
     end
   end
 
-  describe "#root" do
+  describe "#import_root" do
     it "retrieves the standards_import at the root" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       docx_listing = create(:imports_docx_listing, parent: uncat)
       doc = create(:imports_doc, parent: docx_listing)
 
-      expect(doc.root).to eq standards_import
+      expect(doc.import_root).to eq standards_import
     end
   end
 end

--- a/spec/models/imports/docx_listing_spec.rb
+++ b/spec/models/imports/docx_listing_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe Imports::DocxListing, type: :model do
     end
   end
 
-  describe "#root" do
+  describe "#import_root" do
     it "retrieves the standards_import at the root" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       docx_listing = create(:imports_docx_listing, parent: uncat)
 
-      expect(docx_listing.root).to eq standards_import
+      expect(docx_listing.import_root).to eq standards_import
     end
   end
 end

--- a/spec/models/imports/docx_listing_spec.rb
+++ b/spec/models/imports/docx_listing_spec.rb
@@ -69,4 +69,14 @@ RSpec.describe Imports::DocxListing, type: :model do
       expect(docx_listing.status).to eq("needs_backend_support")
     end
   end
+
+  describe "#root" do
+    it "retrieves the standards_import at the root" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx_listing = create(:imports_docx_listing, parent: uncat)
+
+      expect(docx_listing.root).to eq standards_import
+    end
+  end
 end

--- a/spec/models/imports/docx_spec.rb
+++ b/spec/models/imports/docx_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe Imports::Docx, type: :model do
     end
   end
 
-  describe "#root" do
+  describe "#import_root" do
     it "retrieves the standards_import at the root" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       docx_listing = create(:imports_docx_listing, parent: uncat)
       docx = create(:imports_docx, parent: docx_listing)
 
-      expect(docx.root).to eq standards_import
+      expect(docx.import_root).to eq standards_import
     end
   end
 end

--- a/spec/models/imports/docx_spec.rb
+++ b/spec/models/imports/docx_spec.rb
@@ -49,4 +49,15 @@ RSpec.describe Imports::Docx, type: :model do
       expect(pdf_import).to have_received(:process).with(arg: 1)
     end
   end
+
+  describe "#root" do
+    it "retrieves the standards_import at the root" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx_listing = create(:imports_docx_listing, parent: uncat)
+      docx = create(:imports_docx, parent: docx_listing)
+
+      expect(docx.root).to eq standards_import
+    end
+  end
 end

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -119,14 +119,14 @@ RSpec.describe Imports::Pdf, type: :model do
     end
   end
 
-  describe "#root" do
+  describe "#import_root" do
     it "retrieves the standards_import at the root" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       docx_listing = create(:imports_docx_listing, parent: uncat)
       pdf = create(:imports_pdf, parent: docx_listing)
 
-      expect(pdf.root).to eq standards_import
+      expect(pdf.import_root).to eq standards_import
     end
   end
 end

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -118,4 +118,15 @@ RSpec.describe Imports::Pdf, type: :model do
       expect(import.associated_occupation_standards).to eq [occupation_standard]
     end
   end
+
+  describe "#root" do
+    it "retrieves the standards_import at the root" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx_listing = create(:imports_docx_listing, parent: uncat)
+      pdf = create(:imports_pdf, parent: docx_listing)
+
+      expect(pdf.root).to eq standards_import
+    end
+  end
 end

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -100,12 +100,12 @@ RSpec.describe Imports::Uncategorized, type: :model do
     end
   end
 
-  describe "#root" do
+  describe "#import_root" do
     it "retrieves the standards_import at the root" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
 
-      expect(uncat.root).to eq standards_import
+      expect(uncat.import_root).to eq standards_import
     end
   end
 end

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -99,4 +99,13 @@ RSpec.describe Imports::Uncategorized, type: :model do
       expect(import.status).to eq("needs_backend_support")
     end
   end
+
+  describe "#root" do
+    it "retrieves the standards_import at the root" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+
+      expect(uncat.root).to eq standards_import
+    end
+  end
 end

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -267,6 +267,18 @@ RSpec.describe OccupationStandard, type: :model do
 
       expect(occupation_standard.source_file).to be_nil
     end
+
+    it "with import feature flag: returns the linked import record" do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
+      import = create(:imports_pdf)
+      data_import = create(:data_import, import: import, source_file: nil)
+      occupation_standard = build(:occupation_standard, data_imports: [data_import])
+
+      expect(occupation_standard.source_file).to eq import
+
+      stub_feature_flag(:show_imports_in_administrate, false)
+    end
   end
 
   describe "#compentencies_count" do

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -616,25 +616,64 @@ RSpec.describe OccupationStandard, type: :model do
   end
 
   describe "#public_document?" do
-    it "returns true if OccupationStandard#public_document flag is true" do
-      occupation_standard = create(:occupation_standard, :with_data_import)
-      allow_any_instance_of(SourceFile).to receive(:public_document).and_return(true)
+    context "with import feature flag off" do
+      it "returns true if source_file public document flag is true" do
+        occupation_standard = create(:occupation_standard, :with_data_import)
+        allow_any_instance_of(SourceFile).to receive(:public_document).and_return(true)
 
-      expect(occupation_standard.public_document?).to be true
+        expect(occupation_standard.public_document?).to be true
+      end
+
+      it "returns true if associated standard import is public document regardless of source_file public_document flag" do
+        occupation_standard = create(:occupation_standard, :with_data_import)
+        allow_any_instance_of(SourceFile).to receive(:public_document).and_return(false)
+        allow_any_instance_of(StandardsImport).to receive(:public_document).and_return(true)
+
+        expect(occupation_standard.public_document?).to be true
+      end
+
+      it "returns false if no source_file or standard_import is associated to the occupation standard" do
+        occupation_standard = build(:occupation_standard)
+
+        expect(occupation_standard.public_document?).to be false
+      end
     end
 
-    it "returns true if associated standard import is public document regardless of public_document flag" do
-      occupation_standard = create(:occupation_standard, :with_data_import)
-      allow_any_instance_of(SourceFile).to receive(:public_document).and_return(false)
-      allow_any_instance_of(StandardsImport).to receive(:public_document).and_return(true)
+    context "with import feature flag on" do
+      it "returns true if import public_document flag is true" do
+        stub_feature_flag(:show_imports_in_administrate, true)
 
-      expect(occupation_standard.public_document?).to be true
-    end
+        import = create(:imports_pdf, public_document: true)
+        data_import = create(:data_import, import: import, source_file: nil)
+        occupation_standard = create(:occupation_standard, data_imports: [data_import])
 
-    it "returns false if no source_file or standard_import is associated to the occupation standard" do
-      occupation_standard = build(:occupation_standard)
+        expect(occupation_standard.public_document?).to be true
 
-      expect(occupation_standard.public_document?).to be false
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+
+      it "returns true if associated standard import is public document regardless of import public_document flag" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        standards_import = create(:standards_import, public_document: true)
+        import = create(:imports_pdf, public_document: false, parent: standards_import)
+        data_import = create(:data_import, import: import, source_file: nil)
+        occupation_standard = create(:occupation_standard, data_imports: [data_import])
+
+        expect(occupation_standard.public_document?).to be true
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+
+      it "returns false if no import or standard_import is associated to the occupation standard" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        occupation_standard = build(:occupation_standard)
+
+        expect(occupation_standard.public_document?).to be false
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
     end
   end
 

--- a/spec/models/occupation_standard_spec.rb
+++ b/spec/models/occupation_standard_spec.rb
@@ -317,7 +317,6 @@ RSpec.describe OccupationStandard, type: :model do
       it "returns nil if no data_imports" do
         stub_feature_flag(:show_imports_in_administrate, true)
 
-        standards_import = create(:standards_import)
         occupation_standard = create(:occupation_standard, data_imports: [])
 
         expect(occupation_standard.standards_import).to be_nil

--- a/spec/requests/occupation_standards_spec.rb
+++ b/spec/requests/occupation_standards_spec.rb
@@ -14,8 +14,22 @@ RSpec.describe "OccupationStandard", type: :request do
       end
 
       context "with ES search", :elasticsearch do
+        it "with import flag on: makes one Elasticsearch query if no search params" do
+          stub_feature_flag(:use_elasticsearch_for_search, true)
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          create(:occupation_standard, :with_work_processes, :with_data_import)
+
+          expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
+          get occupation_standards_path
+
+          expect(response).to be_successful
+        end
+
         it "makes one Elasticsearch query if no search params" do
           stub_feature_flag(:use_elasticsearch_for_search, true)
+          stub_feature_flag(:show_imports_in_administrate, false)
+
           create(:occupation_standard, :with_work_processes, :with_data_import)
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
@@ -26,6 +40,8 @@ RSpec.describe "OccupationStandard", type: :request do
 
         it "makes one Elasticsearch query if only filter params" do
           stub_feature_flag(:use_elasticsearch_for_search, true)
+          stub_feature_flag(:show_imports_in_administrate, false)
+
           ra = create(:registration_agency)
           create(:occupation_standard, :with_work_processes, :with_data_import, registration_agency: ra)
 
@@ -37,6 +53,8 @@ RSpec.describe "OccupationStandard", type: :request do
 
         it "makes one Elasticsearch query if search params does not start with letter" do
           stub_feature_flag(:use_elasticsearch_for_search, true)
+          stub_feature_flag(:show_imports_in_administrate, false)
+
           create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "15-1234.00")
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
@@ -47,6 +65,8 @@ RSpec.describe "OccupationStandard", type: :request do
 
         it "makes two Elasticsearch queries if search params start with letter" do
           stub_feature_flag(:use_elasticsearch_for_search, true)
+          stub_feature_flag(:show_imports_in_administrate, false)
+
           create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).twice.and_call_original
@@ -57,6 +77,8 @@ RSpec.describe "OccupationStandard", type: :request do
 
         it "makes one Elasticsearch query if search params start with letter but onet_prefix is included in the search params" do
           stub_feature_flag(:use_elasticsearch_for_search, true)
+          stub_feature_flag(:show_imports_in_administrate, false)
+
           create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
 
           expect(OccupationStandardElasticsearchQuery).to receive(:new).once.and_call_original
@@ -67,6 +89,8 @@ RSpec.describe "OccupationStandard", type: :request do
 
         it "does not include onet_prefix in 2nd query if first hit has no onet code" do
           stub_feature_flag(:use_elasticsearch_for_search, true)
+          stub_feature_flag(:show_imports_in_administrate, false)
+
           create(:occupation_standard, :with_work_processes, :with_data_import, onet_code: nil, title: "Mechanic")
 
           search_params = ActionController::Parameters.new({q: "Mechanic"}).permit!

--- a/spec/system/occupation_standards/index_spec.rb
+++ b/spec/system/occupation_standards/index_spec.rb
@@ -323,6 +323,33 @@ RSpec.describe "occupation_standards/index" do
   context "when using elasticsearch for search", :elasticsearch do
     it "displays pagination correctly when no collapsed items" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
+      default_items = Pagy::DEFAULT[:items]
+      Pagy::DEFAULT[:items] = 2
+      create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR Specialist")
+      create_list(:occupation_standard, 2, :with_work_processes, :with_data_import)
+
+      OccupationStandard.import
+      OccupationStandard.__elasticsearch__.refresh_index!
+
+      visit occupation_standards_path
+
+      expect(page).to_not have_text "HR Specialist"
+
+      within(".pagy.nav") do
+        expect(page).to have_link "2", href: occupation_standards_path(page: 2)
+        click_on "2"
+      end
+      expect(page).to have_text "HR Specialist"
+
+      Pagy::DEFAULT[:items] = default_items
+    end
+
+    it "when import feature flag on: displays pagination correctly when no collapsed items" do
+      stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, true)
+
       default_items = Pagy::DEFAULT[:items]
       Pagy::DEFAULT[:items] = 2
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR Specialist")
@@ -346,6 +373,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "displays pagination correctly when there are collapsed items" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       default_items = Pagy::DEFAULT[:items]
       Pagy::DEFAULT[:items] = 2
 
@@ -382,6 +411,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards based on search term" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       dental = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Dental Assistant", onet_code: "12-3456.01")
       medical = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Medical Assistant", onet_code: "12-9876.00")
       create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Other Assistant With Different ONET Code Prefix", onet_code: "13-9876.00")
@@ -407,6 +438,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "can handle a search that returns no results" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
 
       OccupationStandard.import
@@ -425,6 +458,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards based on rapids_code search term" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", rapids_code: "1234")
       pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", rapids_code: "1234CB")
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR", rapids_code: "9876")
@@ -448,6 +483,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards based on onet_code search term" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       pipe_fitter = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "HR", onet_code: "12.34")
@@ -471,6 +508,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards based on onet_code search term and state filter", :js do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       wa = create(:state, name: "Washington")
       ra = create(:registration_agency, state: wa)
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
@@ -499,6 +538,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards based on onet_code search term and national_standard_type filter", :js do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       mechanic = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :guideline_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -532,6 +573,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards based on onet_code search term and ojt_type filter", :js do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       medical_assistant = create(:occupation_standard, :with_work_processes, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -564,6 +607,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards with state shortcode" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       washington_registration_agency = create(:registration_agency, for_state_abbreviation: "WA")
       mechanic = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: washington_registration_agency)
       create(:occupation_standard, :with_work_processes, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -588,6 +633,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards with national_standard_type shortcode" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       mechanic = create(:occupation_standard, :with_work_processes, :program_standard, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       create(:occupation_standard, :with_work_processes, :occupational_framework, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :guideline_standard, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -614,6 +661,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "filters standards with ojt_type shortcode" do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456")
       create(:occupation_standard, :with_work_processes, :time, :with_data_import, title: "Medical Assistant", onet_code: "12.34567")
       create(:occupation_standard, :with_work_processes, :competency, :with_data_import, title: "Pipe Fitter", onet_code: "12.34567")
@@ -638,6 +687,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "can clear form", :js do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       wa = create(:state, name: "Washington")
       ra = create(:registration_agency, state: wa)
       mechanic = create(:occupation_standard, :with_work_processes, :hybrid, :with_data_import, title: "Mechanic", onet_code: "12.3456", registration_agency: ra)
@@ -711,6 +762,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "shows suggestions based on occupation title", :js do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       mechanic = create(:occupation, title: "Mechanic")
       pipe_fitter = create(:occupation, title: "Pipe Fitter")
       pippen_apple_collector = create(:occupation, title: "Pippen Apple Collector")
@@ -747,6 +800,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "shows suggestions based on onet code", :js do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       mechanic_onet = create(:onet, code: "12-1234")
       mechanic = create(:occupation, title: "Mechanic", onet: mechanic_onet)
       pipe_fitter_onet = create(:onet, code: "51-6789")
@@ -767,6 +822,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "shows suggestions based on rapids code", :js do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       mechanic = create(:occupation, title: "Mechanic", rapids_code: "9108")
       pipe_fitter = create(:occupation, title: "Pipe Fitter", rapids_code: "1582")
 
@@ -826,6 +883,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "expands similar results accordion when accordion button is clicked", js: true do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       os = create(:occupation_standard, :with_work_processes, :with_data_import, title: "Mechanic")
       new_wp = create(:work_process, title: os.work_processes.first.title)
       create(:occupation_standard, :with_data_import, :program_standard, work_processes: [new_wp], title: "Mechanic")
@@ -842,6 +901,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "closes similar results accordion when accordion button is clicked", js: true do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       os = create(:occupation_standard, :with_work_processes, :with_data_import, :program_standard, title: "Mechanic")
       new_wp = create(:work_process, title: os.work_processes.first.title)
       mechanic = create(:occupation_standard, :with_data_import, work_processes: [new_wp], title: "Mechanic")
@@ -859,6 +920,8 @@ RSpec.describe "occupation_standards/index" do
 
     it "displays toolip on hover", js: true do
       stub_feature_flag(:use_elasticsearch_for_search, true)
+      stub_feature_flag(:show_imports_in_administrate, false)
+
       occupation = create(:occupation, time_based_hours: 2000)
       occupation_standard = create(:occupation_standard, :with_data_import, occupation: occupation)
       create(:work_process, maximum_hours: 1000, occupation_standard: occupation_standard)

--- a/spec/system/pages/home_spec.rb
+++ b/spec/system/pages/home_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe "pages/home" do
 
   context "with Elasticsearch enabled", :elasticsearch do
     before(:each) do |example|
+      stub_feature_flag(:show_imports_in_administrate, false)
       stub_feature_flag(:use_elasticsearch_for_search, true)
     end
 
@@ -277,29 +278,60 @@ RSpec.describe "pages/home" do
   end
 
   describe "Recently Added" do
-    before(:each) do |example|
-      stub_feature_flag(:similar_programs_elasticsearch, false)
-      stub_feature_flag(:use_elasticsearch_for_search, false)
+    context "with imports flag off" do
+      before(:each) do |example|
+        stub_feature_flag(:similar_programs_elasticsearch, false)
+        stub_feature_flag(:use_elasticsearch_for_search, false)
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+
+      it "displays a link to a search of occupation standards sorted by creation date" do
+        create(:occupation_standard, :with_work_processes, :with_data_import, national_standard_type: :guideline_standard, title: "Mechanic")
+
+        visit home_page_path
+
+        click_link("See All", href: "/occupation_standards?sort=created_at")
+
+        expect(page).to have_text "Mechanic"
+      end
+
+      it "displays a link to latest occupation standard" do
+        create(:occupation_standard, :with_work_processes, :with_data_import, national_standard_type: :guideline_standard, title: "Mechanic")
+
+        visit home_page_path
+
+        click_on("Mechanic")
+
+        expect(page).to have_text "Mechanic"
+      end
     end
 
-    it "displays a link to a search of occupation standards sorted by creation date" do
-      create(:occupation_standard, :with_work_processes, :with_data_import, national_standard_type: :guideline_standard, title: "Mechanic")
+    context "with imports flag on" do
+      before(:each) do |example|
+        stub_feature_flag(:similar_programs_elasticsearch, false)
+        stub_feature_flag(:use_elasticsearch_for_search, false)
+        stub_feature_flag(:show_imports_in_administrate, true)
+      end
 
-      visit home_page_path
+      it "displays a link to a search of occupation standards sorted by creation date" do
+        create(:occupation_standard, :with_work_processes, :with_data_import, national_standard_type: :guideline_standard, title: "Mechanic")
 
-      click_link("See All", href: "/occupation_standards?sort=created_at")
+        visit home_page_path
 
-      expect(page).to have_text "Mechanic"
-    end
+        click_link("See All", href: "/occupation_standards?sort=created_at")
 
-    it "displays a link to latest occupation standard" do
-      create(:occupation_standard, :with_work_processes, :with_data_import, national_standard_type: :guideline_standard, title: "Mechanic")
+        expect(page).to have_text "Mechanic"
+      end
 
-      visit home_page_path
+      it "displays a link to latest occupation standard" do
+        create(:occupation_standard, :with_work_processes, :with_data_import, national_standard_type: :guideline_standard, title: "Mechanic")
 
-      click_on("Mechanic")
+        visit home_page_path
 
-      expect(page).to have_text "Mechanic"
+        click_on("Mechanic")
+
+        expect(page).to have_text "Mechanic"
+      end
     end
   end
 end


### PR DESCRIPTION
When the imports feature flag is on, then an `occupation_standard.source_file` will link to an Import record. While in the short term, this terminology may be confusing, in the long term after we have gotten rid of the SourceFile model, then an `occupation_standard.source_file` will be more apt of a name than `occupation_standard.import`.

This PR is best viewed when hiding whitespace:

<img width="399" alt="Screenshot 2024-05-16 at 1 32 21 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/c98f1a55-7851-4572-993c-3a59e33f39b4">


[Asana ticket](https://app.asana.com/0/1203289004376659/1207337122136912/f)
