### PR TITLE
Add rake tasks to convert existing files to Import records

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -37,6 +37,13 @@ class DataImport < ApplicationRecord
       .first
   end
 
+  def set_import_field!
+    source_file_import = source_file&.import
+    if source_file_import
+      update!(import_id: source_file_import.pdf_leaf&.id)
+    end
+  end
+
   private
 
   def file_presence

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -40,7 +40,7 @@ class DataImport < ApplicationRecord
   def set_import_field!
     source_file_import = source_file&.import
     if source_file_import
-      update!(import_id: source_file_import.pdf_leaf&.id)
+      update!(import: source_file_import.pdf_leaf)
     end
   end
 

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,6 +1,7 @@
 class Import < ApplicationRecord
   belongs_to :parent, polymorphic: true
   belongs_to :assignee, class_name: "User", optional: true
+  belongs_to :source_file, optional: true
 
   # DataImport records can only be linked to type Imports::Pdf,
   # but this association is needed for all types due to limitations

--- a/app/models/imports/doc.rb
+++ b/app/models/imports/doc.rb
@@ -27,5 +27,9 @@ module Imports
       )
       raise
     end
+
+    def pdf_leaf
+      pdf
+    end
   end
 end

--- a/app/models/imports/docx.rb
+++ b/app/models/imports/docx.rb
@@ -27,5 +27,9 @@ module Imports
       )
       raise
     end
+
+    def pdf_leaf
+      pdf
+    end
   end
 end

--- a/app/models/imports/docx_listing.rb
+++ b/app/models/imports/docx_listing.rb
@@ -35,5 +35,9 @@ module Imports
       )
       raise
     end
+
+    def pdf_leaf
+      raise NoMethodError.new("#{self.class.name} records do not have a PDF leaf")
+    end
   end
 end

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -42,5 +42,9 @@ module Imports
     def file_for_redaction
       redacted_pdf.attached? ? redacted_pdf : file
     end
+
+    def pdf_leaf
+      self
+    end
   end
 end

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -5,7 +5,6 @@ module Imports
   class Uncategorized < Import
     has_one_attached :file
     has_one :import, as: :parent, dependent: :destroy, autosave: true
-    belongs_to :source_file, optional: true
 
     def process(**)
       create_child!(**)

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -5,6 +5,7 @@ module Imports
   class Uncategorized < Import
     has_one_attached :file
     has_one :import, as: :parent, dependent: :destroy, autosave: true
+    belongs_to :source_file, optional: true
 
     def process(**)
       create_child!(**)

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -19,6 +19,10 @@ module Imports
       raise
     end
 
+    def pdf_leaf
+      import&.pdf_leaf
+    end
+
     private
 
     DOCX_CONTENT_TYPE = Mime::Type.lookup_by_extension("docx").to_s

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -6,7 +6,7 @@ class SourceFile < ApplicationRecord
   has_many :data_imports, -> { includes(:occupation_standard, file_attachment: :blob) }
   has_many :associated_occupation_standards, -> { distinct }, through: :data_imports, source: :occupation_standard
   has_one_attached :redacted_source_file
-  has_one :import, class_name: "Imports::Uncategorized"
+  has_one :import
 
   enum :status, [:pending, :completed, :needs_support, :needs_human_review, :archived]
   enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -65,6 +65,21 @@ class SourceFile < ApplicationRecord
     where(public_document: false).completed.not_redacted.pdf_attachment
   end
 
+  def create_import!
+    if !archived? && import.nil?
+      import = standards_import.imports.create(
+        type: "Imports::Uncategorized",
+        public_document: public_document,
+        metadata: metadata,
+        status: :unfurled,
+        source_file: self
+      )
+
+      import.file.attach(active_storage_attachment.blob)
+      import
+    end
+  end
+
   def filename
     active_storage_attachment.blob.filename
   end

--- a/db/migrate/20240520214503_add_source_file_id_to_imports.rb
+++ b/db/migrate/20240520214503_add_source_file_id_to_imports.rb
@@ -1,0 +1,5 @@
+class AddSourceFileIdToImports < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :imports, :source_file, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_14_222448) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_20_214503) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -137,9 +137,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_222448) do
     t.datetime "processed_at", precision: nil
     t.text "processing_errors"
     t.datetime "redacted_at", precision: nil
+    t.uuid "source_file_id"
     t.index ["assignee_id"], name: "index_imports_on_assignee_id"
     t.index ["parent_type", "parent_id"], name: "index_imports_on_parent"
     t.index ["processed_at"], name: "index_imports_on_processed_at"
+    t.index ["source_file_id"], name: "index_imports_on_source_file_id"
   end
 
   create_table "industries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -367,6 +369,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_222448) do
   add_foreign_key "data_imports", "occupation_standards"
   add_foreign_key "data_imports", "source_files"
   add_foreign_key "data_imports", "users"
+  add_foreign_key "imports", "source_files"
   add_foreign_key "imports", "users", column: "assignee_id"
   add_foreign_key "occupation_standards", "industries"
   add_foreign_key "occupation_standards", "occupations"

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -2,4 +2,11 @@ namespace :data_import do
   task daily_report: :environment do
     AdminMailer.daily_uploads_report.deliver_now
   end
+
+  desc "One-off task to link existing data_imports to new import field"
+  task link_to_import: :environment do
+    DataImport.where(import_id: nil).find_each do |data_import|
+      data_import.set_import_field!
+    end
+  end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -8,8 +8,11 @@ namespace :import do
     ].each do |model|
       puts "Processing unfurled #{model} records"
       model.unfurled.find_each.with_index do |import, index|
-        import.process
-        rest(index)
+        begin
+          import.process
+          rest(index)
+        rescue
+        end
       end
 
       sleep 60
@@ -17,9 +20,9 @@ namespace :import do
   end
 
   def rest(index)
-    if (index+1) % 200 == 0
+    if (index+1) % 100 == 0
       puts "Record count: #{index+1}"
-      sleep 10
+      sleep 15
     end
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,25 @@
+namespace :import do
+  task process_unfurled: :environment do
+    [
+      Imports::Doc,
+      Imports::Docx,
+      Imports::DocxListing,
+      Imports::Uncategorized
+    ].each do |model|
+      puts "Processing unfurled #{model} records"
+      model.unfurled.find_each.with_index do |import, index|
+        import.process
+        rest(index)
+      end
+
+      sleep 60
+    end
+  end
+
+  def rest(index)
+    if (index+1) % 200 == 0
+      puts "Record count: #{index+1}"
+      sleep 10
+    end
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -8,11 +8,9 @@ namespace :import do
     ].each do |model|
       puts "Processing unfurled #{model} records"
       model.unfurled.find_each.with_index do |import, index|
-        begin
-          import.process
-          rest(index)
-        rescue
-        end
+        import.process
+        rest(index)
+      rescue
       end
 
       sleep 60
@@ -20,8 +18,8 @@ namespace :import do
   end
 
   def rest(index)
-    if (index+1) % 100 == 0
-      puts "Record count: #{index+1}"
+    if (index + 1) % 100 == 0
+      puts "Record count: #{index + 1}"
       sleep 15
     end
   end

--- a/lib/tasks/source_file.rake
+++ b/lib/tasks/source_file.rake
@@ -1,0 +1,12 @@
+namespace :source_file do
+  task create_imports: :environment do
+    SourceFile.missing_import.find_each.with_index do |source_file, index|
+      source_file.create_import!
+
+      if (index+1) % 200 == 0
+        puts "Record count: #{index+1}"
+        sleep 10
+      end
+    end
+  end
+end

--- a/lib/tasks/source_file.rake
+++ b/lib/tasks/source_file.rake
@@ -1,11 +1,16 @@
 namespace :source_file do
   task create_imports: :environment do
-    SourceFile.missing_import.find_each.with_index do |source_file, index|
-      source_file.create_import!
+    SourceFile.missing_import.find_each do |source_file|
+      count = 0
+      import = source_file.create_import!
 
-      if (index+1) % 200 == 0
-        puts "Record count: #{index+1}"
-        sleep 10
+      if import
+        count += 1
+
+        if count % 200 == 0
+          puts "Record count: #{index+1}"
+          sleep 10
+        end
       end
     end
   end

--- a/lib/tasks/source_file.rake
+++ b/lib/tasks/source_file.rake
@@ -1,7 +1,7 @@
 namespace :source_file do
   task create_imports: :environment do
+    count = 0
     SourceFile.missing_import.find_each do |source_file|
-      count = 0
       import = source_file.create_import!
 
       if import

--- a/lib/tasks/source_file.rake
+++ b/lib/tasks/source_file.rake
@@ -8,7 +8,7 @@ namespace :source_file do
         count += 1
 
         if count % 200 == 0
-          puts "Record count: #{index+1}"
+          puts "Record count: #{index + 1}"
           sleep 10
         end
       end

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -72,4 +72,40 @@ RSpec.describe DataImport, type: :model do
       expect(data_import_corrected.related_occupation_standard("HUMAN RESOURCE SPECIALIST")).to eq different_os_for_same_source_file
     end
   end
+
+  describe "#set_import_field!" do
+    context "when no source_file" do
+      it "does not change the import_id field" do
+        pdf = create(:imports_pdf)
+        data_import = create(:data_import, import: pdf, source_file: nil)
+
+        data_import.set_import_field!
+
+        expect(data_import.reload.import_id).to eq pdf.id
+      end
+    end
+
+    context "when no pdf leaf for linked source_file import" do
+      it "does not set the import_id field" do
+        source_file = create(:source_file)
+        uncat = create(:imports_uncategorized, parent: source_file.standards_import, source_file: source_file)
+        data_import = create(:data_import, source_file: source_file, import: nil)
+
+        data_import.set_import_field!
+
+        expect(data_import.reload.import_id).to be_nil
+      end
+    end
+
+    it "sets the import to be the pdf leaf of the related source_file import" do
+      source_file = create(:source_file)
+      uncat = create(:imports_uncategorized, parent: source_file.standards_import, source_file: source_file)
+      pdf = create(:imports_pdf, parent: uncat)
+      data_import = create(:data_import, source_file: source_file, import: nil)
+
+      data_import.set_import_field!
+
+      expect(data_import.reload.import_id).to eq pdf.id
+    end
+  end
 end

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe DataImport, type: :model do
     context "when no pdf leaf for linked source_file import" do
       it "does not set the import_id field" do
         source_file = create(:source_file)
-        uncat = create(:imports_uncategorized, parent: source_file.standards_import, source_file: source_file)
+        create(:imports_uncategorized, parent: source_file.standards_import, source_file: source_file)
         data_import = create(:data_import, source_file: source_file, import: nil)
 
         data_import.set_import_field!

--- a/spec/models/imports/doc_spec.rb
+++ b/spec/models/imports/doc_spec.rb
@@ -61,4 +61,23 @@ RSpec.describe Imports::Doc, type: :model do
       expect(doc.import_root).to eq standards_import
     end
   end
+
+  describe "#pdf_leaf" do
+    context "when pdf exists" do
+      it "returns the Imports::Pdf record" do
+        doc = create(:imports_doc)
+        pdf = create(:imports_pdf, parent: doc)
+
+        expect(doc.pdf_leaf).to eq pdf
+      end
+    end
+
+    context "when pdf does not exist" do
+      it "returns nil" do
+        doc = create(:imports_doc)
+
+        expect(doc.pdf_leaf).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/imports/docx_listing_spec.rb
+++ b/spec/models/imports/docx_listing_spec.rb
@@ -79,4 +79,14 @@ RSpec.describe Imports::DocxListing, type: :model do
       expect(docx_listing.import_root).to eq standards_import
     end
   end
+
+  describe "#pdf_leaf" do
+    it "raises a not implemented error" do
+      docx_listing = create(:imports_docx_listing)
+
+      expect{
+        docx_listing.pdf_leaf
+      }.to raise_error(NoMethodError, "Imports::DocxListing records do not have a PDF leaf")
+    end
+  end
 end

--- a/spec/models/imports/docx_listing_spec.rb
+++ b/spec/models/imports/docx_listing_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Imports::DocxListing, type: :model do
     it "raises a not implemented error" do
       docx_listing = create(:imports_docx_listing)
 
-      expect{
+      expect {
         docx_listing.pdf_leaf
       }.to raise_error(NoMethodError, "Imports::DocxListing records do not have a PDF leaf")
     end

--- a/spec/models/imports/docx_spec.rb
+++ b/spec/models/imports/docx_spec.rb
@@ -60,4 +60,23 @@ RSpec.describe Imports::Docx, type: :model do
       expect(docx.import_root).to eq standards_import
     end
   end
+
+  describe "#pdf_leaf" do
+    context "when pdf exists" do
+      it "returns the Imports::Pdf record" do
+        docx = create(:imports_docx)
+        pdf = create(:imports_pdf, parent: docx)
+
+        expect(docx.pdf_leaf).to eq pdf
+      end
+    end
+
+    context "when pdf does not exist" do
+      it "returns nil" do
+        docx = create(:imports_docx)
+
+        expect(docx.pdf_leaf).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -129,4 +129,12 @@ RSpec.describe Imports::Pdf, type: :model do
       expect(pdf.import_root).to eq standards_import
     end
   end
+
+  describe "#pdf_leaf" do
+    it "returns self" do
+      pdf = create(:imports_pdf)
+
+      expect(pdf.pdf_leaf).to eq pdf
+    end
+  end
 end

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -100,6 +100,26 @@ RSpec.describe Imports::Uncategorized, type: :model do
     end
   end
 
+  describe "#pdf_leaf" do
+    context "when pdf leaf exists" do
+      it "returns the Imports::Pdf record" do
+        uncat = create(:imports_uncategorized)
+        doc = create(:imports_doc, parent: uncat)
+        pdf = create(:imports_pdf, parent: doc)
+
+        expect(uncat.pdf_leaf).to eq pdf
+      end
+    end
+
+    context "when pdf leaf does not exist" do
+      it "returns nil" do
+        uncat = create(:imports_uncategorized)
+
+        expect(uncat.pdf_leaf).to be_nil
+      end
+    end
+  end
+
   describe "#import_root" do
     it "retrieves the standards_import at the root" do
       standards_import = create(:standards_import)

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SourceFile, type: :model do
     expect(source_file.reload.metadata).to eq({"date" => "03/29/2023"})
   end
 
-  describe ".mising_import" do
+  describe ".missing_import" do
     it "returns all non-archived source files which do not have an import" do
       sf1a = create(:source_file, :pending)
       sf1b = create(:source_file, :pending)

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe SourceFile, type: :model do
         create(:imports_uncategorized, source_file: source_file)
 
         resp = nil
-        expect{
+        expect {
           resp = source_file.create_import!
         }.to_not change(Import, :count)
         expect(resp).to be_nil
@@ -391,7 +391,7 @@ RSpec.describe SourceFile, type: :model do
         source_file = create(:source_file, :archived)
 
         resp = nil
-        expect{
+        expect {
           resp = source_file.create_import!
         }.to_not change(Import, :count)
         expect(resp).to be_nil
@@ -402,7 +402,7 @@ RSpec.describe SourceFile, type: :model do
         source_file = create(:source_file, :pending, public_document: true, metadata: metadata)
 
         import = nil
-        expect{
+        expect {
           import = source_file.create_import!
         }.to change(Imports::Uncategorized, :count).by(1)
           .and change(ActiveStorage::Attachment, :count).by(1)

--- a/spec/models/source_file_spec.rb
+++ b/spec/models/source_file_spec.rb
@@ -23,6 +23,30 @@ RSpec.describe SourceFile, type: :model do
     expect(source_file.reload.metadata).to eq({"date" => "03/29/2023"})
   end
 
+  describe ".mising_import" do
+    it "returns all non-archived source files which do not have an import" do
+      sf1a = create(:source_file, :pending)
+      sf1b = create(:source_file, :pending)
+      create(:imports_uncategorized, source_file: sf1b)
+
+      sf2a = create(:source_file, :completed)
+      sf2b = create(:source_file, :completed)
+      create(:imports_uncategorized, source_file: sf2b)
+
+      sf3a = create(:source_file, :needs_support)
+      sf3b = create(:source_file, :needs_support)
+      create(:imports_uncategorized, source_file: sf3b)
+
+      sf4a = create(:source_file, :needs_human_review)
+      sf4b = create(:source_file, :needs_human_review)
+      create(:imports_uncategorized, source_file: sf4b)
+
+      create(:source_file, :archived)
+
+      expect(described_class.missing_import).to contain_exactly(sf1a, sf2a, sf3a, sf4a)
+    end
+  end
+
   describe "#converted_source_file" do
     it "returns the converted source file (pdf)" do
       word = create(:source_file, :docx)


### PR DESCRIPTION
This adds a temporary new `source_file` reference field on the `Import` model so we keep track of which source files have corresponding import records. Once we cut over to the new system, this field can be removed.

Three new rake tasks are created. The first to be run will be `source_file:create_imports`. This takes all unarchived SourceFile records that do not have a corresponding import record and creates a new `Imports::Uncategorized` record that links to a SourceFiles attachment. The task leaves the status of the newly created import records as `unfurled` and does not process the imports at this stage.

Once the new `Imports::Uncategorized` records have been created, we run the `import:process_unfurled` rake task. In order to make sure we avoid any duplicate processing caused by race conditions, this task will start with all unfurled `Doc` and `Docx` imports and process them first, which will result in new `Imports::Pdf` records. After this, `DocxListing` records are unfurled, and as part of the `process` method, any new `Doc` and `Docx` records will also be processed. Finally, we process any unfurled `Imports::Uncategorized` records down the tree.

After all the imports have been unfurled, we run `data_import:link_to_import` which will take the linked source_file and find the pdf leaf from the source_file's linked import. It will then set the `import_id` field of the `data_import` record. Once we flip the Imports flag, then the occupation_standards will be automatically linked to the new import records through the `data_import` record.

[Asana ticket](https://app.asana.com/0/1203289004376659/1207249791981940/f)
