### PR TITLE
Transfer assignee and courtesy_notification down the import tree

### DIFF
--- a/app/models/imports/doc.rb
+++ b/app/models/imports/doc.rb
@@ -10,7 +10,9 @@ module Imports
         create_pdf!(
           file: File.open(output_pdf_path),
           public_document: public_document,
-          metadata: metadata
+          metadata: metadata,
+          courtesy_notification: courtesy_notification,
+          assignee: assignee
         )
         pdf.process(**kwargs)
         update!(

--- a/app/models/imports/docx.rb
+++ b/app/models/imports/docx.rb
@@ -10,7 +10,9 @@ module Imports
         create_pdf!(
           file: File.open(output_pdf_path),
           public_document: public_document,
-          metadata: metadata
+          metadata: metadata,
+          courtesy_notification: courtesy_notification,
+          assignee: assignee
         )
         pdf.process(**kwargs)
         update!(

--- a/spec/models/imports/doc_spec.rb
+++ b/spec/models/imports/doc_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Imports::Doc, type: :model do
       allow(ConvertDocToPdf).to receive(:call).and_return(
         Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf")
       )
-      doc = create(:imports_doc, public_document: true)
+      assignee = create(:user, :converter)
+      doc = create(:imports_doc, public_document: true, courtesy_notification: :pending, assignee: assignee)
 
       doc.process
       doc.reload
@@ -17,7 +18,8 @@ RSpec.describe Imports::Doc, type: :model do
       pdf = doc.pdf
       expect(pdf.status).to eq("pending")
       expect(pdf.public_document).to eq(true)
-      expect(pdf.courtesy_notification).to eq("not_required")
+      expect(pdf.courtesy_notification).to eq("pending")
+      expect(pdf.assignee).to eq assignee
 
       expect(doc.processed_at).to be_present
       expect(doc.processing_errors).to be_blank

--- a/spec/models/imports/docx_spec.rb
+++ b/spec/models/imports/docx_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Imports::Docx, type: :model do
     it "attaches a PDF to the Docx" do
       pdf_path = Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf")
       allow(ConvertDocToPdf).to receive(:call).and_return(pdf_path)
-      docx = create(:imports_docx, public_document: true)
+      assignee = create(:user, :converter)
+      docx = create(:imports_docx, public_document: true, courtesy_notification: :pending, assignee: assignee)
 
       docx.process
       docx.reload
@@ -16,7 +17,8 @@ RSpec.describe Imports::Docx, type: :model do
       pdf = docx.pdf
       expect(pdf.status).to eq("pending")
       expect(pdf.public_document).to eq(true)
-      expect(pdf.courtesy_notification).to eq("not_required")
+      expect(pdf.courtesy_notification).to eq("pending")
+      expect(pdf.assignee).to eq assignee
 
       expect(docx.processed_at).to be_present
       expect(docx.processing_errors).to be_blank


### PR DESCRIPTION
If `assignee` or `courtesy_notification` are set on an `Import::Uncategorized` record then these should be passed down the tree to the `Imports::Pdf` record.
