### PR TITLE
Add rake task to transfer source_file status and redaction info to Pdf import

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,7 +1,6 @@
 class Import < ApplicationRecord
   belongs_to :parent, polymorphic: true
   belongs_to :assignee, class_name: "User", optional: true
-  belongs_to :source_file, optional: true
 
   # DataImport records can only be linked to type Imports::Pdf,
   # but this association is needed for all types due to limitations

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -26,7 +26,11 @@ module Imports
     def transfer_source_file_data!
       pdf = pdf_leaf
       if source_file && pdf
-        pdf.update!(status: source_file.status)
+        pdf.update!(
+          status: source_file.status,
+          redacted_at: source_file.redacted_at,
+          redacted_pdf: source_file.redacted_source_file&.blob
+        )
       end
     end
 

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -23,6 +23,13 @@ module Imports
       import&.pdf_leaf
     end
 
+    def transfer_source_file_data!
+      pdf = pdf_leaf
+      if source_file && pdf
+        pdf.update!(status: source_file.status)
+      end
+    end
+
     private
 
     DOCX_CONTENT_TYPE = Mime::Type.lookup_by_extension("docx").to_s

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -5,6 +5,7 @@ module Imports
   class Uncategorized < Import
     has_one_attached :file
     has_one :import, as: :parent, dependent: :destroy, autosave: true
+    belongs_to :source_file, optional: true
 
     def process(**)
       create_child!(**)

--- a/app/models/source_file.rb
+++ b/app/models/source_file.rb
@@ -6,7 +6,7 @@ class SourceFile < ApplicationRecord
   has_many :data_imports, -> { includes(:occupation_standard, file_attachment: :blob) }
   has_many :associated_occupation_standards, -> { distinct }, through: :data_imports, source: :occupation_standard
   has_one_attached :redacted_source_file
-  has_one :import
+  has_one :import, class_name: "Imports::Uncategorized"
 
   enum :status, [:pending, :completed, :needs_support, :needs_human_review, :archived]
   enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true

--- a/lib/tasks/source_file.rake
+++ b/lib/tasks/source_file.rake
@@ -16,4 +16,10 @@ namespace :source_file do
       end
     end
   end
+
+  task transfer_data_to_import: :environment do
+    Imports::Uncategorized.joins(:source_file).each do |import|
+      import.transfer_source_file_data!
+    end
+  end
 end

--- a/spec/factories/source_files.rb
+++ b/spec/factories/source_files.rb
@@ -62,6 +62,7 @@ FactoryBot.define do
           )
         )
       }
+      redacted_at { Time.current }
     end
 
     trait :bulletin do

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -141,6 +141,18 @@ RSpec.describe Imports::Uncategorized, type: :model do
       expect(pdf.status).to eq "completed"
     end
 
+    it "transfers the redacted file to the pdf leaf" do
+      source_file = create(:source_file, :with_redacted_source_file)
+      uncat = create(:imports_uncategorized, source_file: source_file)
+      pdf = create(:imports_pdf, parent: uncat, status: :pending)
+
+      uncat.transfer_source_file_data!
+
+      pdf.reload
+      expect(pdf.redacted_pdf.attached?).to be_truthy
+      expect(pdf.redacted_at).to be_present
+    end
+
     it "returns nil if no pdf_leaf" do
       source_file = create(:source_file)
       uncat = create(:imports_uncategorized, source_file: source_file)

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -128,4 +128,30 @@ RSpec.describe Imports::Uncategorized, type: :model do
       expect(uncat.import_root).to eq standards_import
     end
   end
+
+  describe "#transfer_source_file_data!" do
+    it "transfers the status to the pdf leaf" do
+      source_file = create(:source_file, status: :completed)
+      uncat = create(:imports_uncategorized, source_file: source_file)
+      pdf = create(:imports_pdf, parent: uncat, status: :pending)
+
+      uncat.transfer_source_file_data!
+
+      pdf.reload
+      expect(pdf.status).to eq "completed"
+    end
+
+    it "returns nil if no pdf_leaf" do
+      source_file = create(:source_file)
+      uncat = create(:imports_uncategorized, source_file: source_file)
+
+      expect(uncat.transfer_source_file_data!).to be_nil
+    end
+
+    it "returns nil if no source_file" do
+      uncat = create(:imports_uncategorized, source_file: nil)
+
+      expect(uncat.transfer_source_file_data!).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This adds a rake task that is used to transfer status and redaction info from a source file to its corresponding PDF file. We move the source_file -> import association back to the `Imports::Uncategorized` model since we are not associating any other type of import with a source file.

[Asana ticket](https://app.asana.com/0/1203289004376659/1207249791981940/f)
