### PR TITLE
Handle case when uncategorized child is docx_listing when finding pdf_leaf

### DIFF
--- a/app/models/imports/docx_listing.rb
+++ b/app/models/imports/docx_listing.rb
@@ -1,4 +1,7 @@
 module Imports
+  class NoPdfLeafError < NoMethodError
+  end
+
   class DocxListing < Import
     has_many :imports, as: :parent, dependent: :destroy, autosave: true
     has_one_attached :file
@@ -37,7 +40,7 @@ module Imports
     end
 
     def pdf_leaf
-      raise NoMethodError.new("#{self.class.name} records do not have a PDF leaf")
+      raise Imports::NoPdfLeafError, "#{self.class.name} records do not have a PDF leaf"
     end
   end
 end

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -22,6 +22,7 @@ module Imports
 
     def pdf_leaf
       import&.pdf_leaf
+    rescue NoPdfLeafError
     end
 
     def transfer_source_file_data!

--- a/spec/models/imports/docx_listing_spec.rb
+++ b/spec/models/imports/docx_listing_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Imports::DocxListing, type: :model do
 
       expect {
         docx_listing.pdf_leaf
-      }.to raise_error(NoMethodError, "Imports::DocxListing records do not have a PDF leaf")
+      }.to raise_error(Imports::NoPdfLeafError, "Imports::DocxListing records do not have a PDF leaf")
     end
   end
 end

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -111,6 +111,15 @@ RSpec.describe Imports::Uncategorized, type: :model do
       end
     end
 
+    context "when import is a docx_listing" do
+      it "returns nil" do
+        uncat = create(:imports_uncategorized)
+        create(:imports_docx_listing, parent: uncat)
+
+        expect(uncat.pdf_leaf).to be_nil
+      end
+    end
+
     context "when pdf leaf does not exist" do
       it "returns nil" do
         uncat = create(:imports_uncategorized)


### PR DESCRIPTION
When an `Imports::Uncategorized` child is of type `Imports::DocxListing`, it doesn't have a single pdf leaf. In these cases the `Imports::DocxListing` record will have multiple children of type `Imports::Uncategorized` which will have the pdf leaf. If an `Imports::Uncategorized` record is the parent of a `Imports::DocxListing` record, then just return `nil` for the `pdf_leaf`.