### PR TITLE
Display filename only on admin/imports index view

### DIFF
--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -14,6 +14,7 @@ class ImportDashboard < Administrate::BaseDashboard
     courtesy_notification: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     metadata: Field::JSONB,
     file: Field::ActiveStorage,
+    filename: Field::String.with_options(searchable: false),
     parent: Field::Polymorphic,
     processed_at: Field::DateTime,
     processing_errors: Field::Text,
@@ -38,7 +39,7 @@ class ImportDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     created_at
     type
-    file
+    filename
     assignee
     public_document
     status


### PR DESCRIPTION
**Old**

<img width="1134" alt="Screenshot 2024-05-22 at 2 04 02 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/4d5dafaa-0e52-4de4-97c8-a74c485db70a">

**New**

<img width="1419" alt="Screenshot 2024-05-22 at 3 04 18 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/eb7a8818-308a-4328-8c28-5a306dc5fc59">

