### PR TITLE
Add child import and imports to Administrate Import show page

### DIFF
--- a/app/controllers/admin/standards_imports_controller.rb
+++ b/app/controllers/admin/standards_imports_controller.rb
@@ -40,6 +40,9 @@ module Admin
     #     resource_class.with_less_stuff
     #   end
     # end
+    def scoped_resource
+      resource_class.includes(imports: :file_attachment)
+    end
 
     # Override `resource_params` if you want to transform the submitted
     # data before it's persisted. For example, the following would turn all

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -17,6 +17,7 @@ class ImportDashboard < Administrate::BaseDashboard
     filename: Field::String.with_options(searchable: false),
     parent: Field::Polymorphic,
     import: Field::BelongsTo,
+    imports: Field::HasMany,
     processed_at: Field::DateTime,
     processing_errors: Field::Text,
     public_document: Field::Boolean,
@@ -63,6 +64,7 @@ class ImportDashboard < Administrate::BaseDashboard
     courtesy_notification
     parent
     import
+    imports
     data_imports
     created_at
     updated_at

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -16,6 +16,7 @@ class ImportDashboard < Administrate::BaseDashboard
     file: Field::ActiveStorage,
     filename: Field::String.with_options(searchable: false),
     parent: Field::Polymorphic,
+    import: Field::BelongsTo,
     processed_at: Field::DateTime,
     processing_errors: Field::Text,
     public_document: Field::Boolean,
@@ -61,6 +62,7 @@ class ImportDashboard < Administrate::BaseDashboard
     processing_errors
     courtesy_notification
     parent
+    import
     data_imports
     created_at
     updated_at

--- a/app/dashboards/standards_import_dashboard.rb
+++ b/app/dashboards/standards_import_dashboard.rb
@@ -9,6 +9,7 @@ class StandardsImportDashboard < Administrate::BaseDashboard
     notes: Field::Text,
     organization: Field::String,
     files: Field::ActiveStorage,
+    imports: Field::HasMany,
     source_files: HasManySourceFilesField,
     courtesy_notification: EnumField.with_options(searchable: false),
     created_at: Field::DateTime,
@@ -31,6 +32,7 @@ class StandardsImportDashboard < Administrate::BaseDashboard
     organization
     bulletin
     courtesy_notification
+    imports
     created_at
     updated_at
   ].freeze

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -7,6 +7,9 @@ class Import < ApplicationRecord
   # of Administrate.
   has_many :data_imports, -> { none }, inverse_of: "import"
 
+  # Only Imports::DocxListing have multiple imports
+  has_many :imports, -> { none }
+
   enum :status, [
     :pending,
     :completed,

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -7,7 +7,8 @@ class Import < ApplicationRecord
   # of Administrate.
   has_many :data_imports, -> { none }, inverse_of: "import"
 
-  # Only Imports::DocxListing have multiple imports
+  # Only Imports::DocxListing have multiple imports, but this
+  # association is needed for all types due to limitation of Administrate
   has_many :imports, -> { none }
 
   enum :status, [

--- a/app/models/imports/doc.rb
+++ b/app/models/imports/doc.rb
@@ -33,5 +33,10 @@ module Imports
     def pdf_leaf
       pdf
     end
+
+    # For Administrate
+    def import
+      pdf
+    end
   end
 end

--- a/app/models/imports/docx.rb
+++ b/app/models/imports/docx.rb
@@ -33,5 +33,10 @@ module Imports
     def pdf_leaf
       pdf
     end
+
+    # For Administrate
+    def import
+      pdf
+    end
   end
 end

--- a/app/models/imports/docx_listing.rb
+++ b/app/models/imports/docx_listing.rb
@@ -42,5 +42,9 @@ module Imports
     def pdf_leaf
       raise Imports::NoPdfLeafError, "#{self.class.name} records do not have a PDF leaf"
     end
+
+    # For Administrate
+    def import
+    end
   end
 end

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -47,6 +47,7 @@ module Imports
       self
     end
 
+    # For Administrate
     def import
     end
   end

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -46,5 +46,8 @@ module Imports
     def pdf_leaf
       self
     end
+
+    def import
+    end
   end
 end

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -66,7 +66,8 @@
 
         <% attributes.each do |attribute| %>
           <% next if attribute.name.match?("redacted") && !page.resource.is_a?(Imports::Pdf) %>
-          <% next if attribute.name == "import" && page.resource.is_a?(Imports::Pdf) %>
+          <% next if attribute.name == "import" && (page.resource.is_a?(Imports::Pdf) || page.resource.is_a?(Imports::DocxListing)) %>
+          <% next if attribute.name == "imports" && !page.resource.is_a?(Imports::DocxListing) %>
           <dt class="attribute-label" id="<%= attribute.name %>">
             <%= t(
                   "helpers.label.#{resource_name}.#{attribute.name}",

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -84,11 +84,7 @@
               <% end %>
             <% elsif attribute.name == "import" %>
               <% if attribute.data %>
-                <% if page.resource.is_a?(Imports::Uncategorized) %>
-                  <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
-                <% elsif page.resource.is_a?(Imports::Doc) || page.resource.is_a?(Imports::Docx) %>
-                  <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
-                <% end %>
+                <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
               <% end %>
             <% else %>
               <%= render_field attribute, page: page %></dd>

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -66,6 +66,7 @@
 
         <% attributes.each do |attribute| %>
           <% next if attribute.name.match?("redacted") && !page.resource.is_a?(Imports::Pdf) %>
+          <% next if attribute.name == "import" && page.resource.is_a?(Imports::Pdf) %>
           <dt class="attribute-label" id="<%= attribute.name %>">
             <%= t(
                   "helpers.label.#{resource_name}.#{attribute.name}",
@@ -78,6 +79,12 @@
               <% if attribute.data.is_a?(StandardsImport) %>
                 <%= link_to "StandardsImport", admin_standards_import_path(attribute.data.id) %>
               <% else %>
+                <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
+              <% end %>
+            <% elsif attribute.name == "import" %>
+              <% if page.resource.is_a?(Imports::Uncategorized) %>
+                <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
+              <% elsif page.resource.is_a?(Imports::Doc) || page.resource.is_a?(Imports::Docx) %>
                 <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
               <% end %>
             <% else %>

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -83,10 +83,12 @@
                 <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
               <% end %>
             <% elsif attribute.name == "import" %>
-              <% if page.resource.is_a?(Imports::Uncategorized) %>
-                <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
-              <% elsif page.resource.is_a?(Imports::Doc) || page.resource.is_a?(Imports::Docx) %>
-                <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
+              <% if attribute.data %>
+                <% if page.resource.is_a?(Imports::Uncategorized) %>
+                  <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
+                <% elsif page.resource.is_a?(Imports::Doc) || page.resource.is_a?(Imports::Docx) %>
+                  <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
+                <% end %>
               <% end %>
             <% else %>
               <%= render_field attribute, page: page %></dd>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -27,14 +27,14 @@ from the associated resource class's dashboard.
     <% partial_name = "collection" %>
   <% end %>
   <%= render(
-    partial_name,
-    collection_presenter: field.associated_collection(order),
-    collection_field_name: field.name,
-    page: page,
-    resources: field.resources(page_number, order),
-    table_title: field.name,
-    resource_class: field.associated_class,
-  ) %>
+        partial_name,
+        collection_presenter: field.associated_collection(order),
+        collection_field_name: field.name,
+        page: page,
+        resources: field.resources(page_number, order),
+        table_title: field.name,
+        resource_class: field.associated_class
+      ) %>
   <% if field.more_than_limit? %>
     <%= render("pagination", resources: field.resources(page_number), param_name: "#{field.name}[page]") %>
   <% end %>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -1,0 +1,44 @@
+<%#
+# HasMany Show Partial
+
+This partial renders a has_many relationship,
+to be displayed on a resource's show page.
+
+By default, the relationship is rendered
+as a table of the first few associated resources.
+The columns of the table are taken
+from the associated resource class's dashboard.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::HasMany][1].
+  Contains methods to help display a table of associated resources.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
+%>
+
+<% if field.resources.any? %>
+  <% order = field.order_from_params(params.fetch(field.name, {})) %>
+  <% page_number = params.fetch(field.name, {}).fetch(:page, nil) %>
+  <% if field.name == "imports" %>
+    <% partial_name = "admin/imports/collection" %>
+  <% else %>
+    <% partial_name = "collection" %>
+  <% end %>
+  <%= render(
+    partial_name,
+    collection_presenter: field.associated_collection(order),
+    collection_field_name: field.name,
+    page: page,
+    resources: field.resources(page_number, order),
+    table_title: field.name,
+    resource_class: field.associated_class,
+  ) %>
+  <% if field.more_than_limit? %>
+    <%= render("pagination", resources: field.resources(page_number), param_name: "#{field.name}[page]") %>
+  <% end %>
+
+<% else %>
+  <%= t("administrate.fields.has_many.none", default: "–") %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,3 +26,4 @@ en:
     label:
       import:
         import: Child
+        imports: Children

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,3 +22,7 @@ en:
   time:
     formats:
       default: "%Y-%m-%d %H:%M:%S %Z"
+  helpers:
+    label:
+      import:
+        import: Child


### PR DESCRIPTION
For `Imports::Uncategorized`, `Imports::Doc`, and `Imports::Docx`, this displays the child record on the show page:

<img width="669" alt="Screenshot 2024-05-22 at 4 52 06 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/a4c0558d-a0ac-4e72-a3e8-f16bc0da7f98">

For `Imports::DocxListing`, this displays the children:

<img width="1298" alt="Screenshot 2024-05-22 at 4 53 04 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/55ed9f2f-1ec6-4f6a-9960-35a21913d01b">

For `Imports::Pdf`, neither the child nor children field is displayed:

<img width="647" alt="Screenshot 2024-05-22 at 4 53 55 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/b9205f14-b2fd-4919-b1a6-13712cf1a1cf">

This change also fixes an N+1 query on the standards_imports admin index page.
