### PR TITLE
Add associated_occupation_standards to Imports dashboard

### DIFF
--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -21,6 +21,7 @@ class ImportDashboard < Administrate::BaseDashboard
     processed_at: Field::DateTime,
     processing_errors: Field::Text,
     public_document: Field::Boolean,
+    associated_occupation_standards: HasManyAssociatedOccupationStandardsField,
     redacted_pdf: Field::ActiveStorage.with_options(
       destroy_url: proc do |namespace, resource, attachment|
         [:redacted_import_admin_import, {attachment_id: attachment.id}]
@@ -66,6 +67,7 @@ class ImportDashboard < Administrate::BaseDashboard
     import
     imports
     data_imports
+    associated_occupation_standards
     created_at
     updated_at
   ].freeze

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -3,9 +3,10 @@ class Import < ApplicationRecord
   belongs_to :assignee, class_name: "User", optional: true
 
   # DataImport records can only be linked to type Imports::Pdf,
-  # but this association is needed for all types due to limitations
+  # but these associations are needed for all types due to limitations
   # of Administrate.
   has_many :data_imports, -> { none }, inverse_of: "import"
+  has_many :associated_occupation_standards, -> { none }, through: :data_imports, source: :occupation_standard
 
   # Only Imports::DocxListing have multiple imports, but this
   # association is needed for all types due to limitation of Administrate

--- a/spec/system/admin/imports/show_spec.rb
+++ b/spec/system/admin/imports/show_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "admin/imports/show", :admin do
     end
   end
 
-  context "when not Imports::Pdf type" do
+  context "when Imports::Uncategorized type" do
     context "when admin" do
       it "does not have buttons for needing support, data import or redact" do
         stub_feature_flag(:show_imports_in_administrate, true)
@@ -86,6 +86,75 @@ RSpec.describe "admin/imports/show", :admin do
         visit admin_import_path(import)
 
         expect(page).to have_text "Imports::Uncategorized"
+        expect(page).to_not have_button "Needs support"
+        expect(page).to_not have_link "New data import"
+        expect(page).to_not have_link "Redact document"
+        expect(page).to have_link "Edit", href: edit_admin_import_path(import)
+        expect(page).to have_link "Destroy"
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
+
+  context "when Imports::Doc type" do
+    context "when admin" do
+      it "does not have buttons for needing support, data import or redact" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin)
+        import = create(:imports_doc)
+
+        login_as admin
+        visit admin_import_path(import)
+
+        expect(page).to have_text "Imports::Doc"
+        expect(page).to_not have_button "Needs support"
+        expect(page).to_not have_link "New data import"
+        expect(page).to_not have_link "Redact document"
+        expect(page).to have_link "Edit", href: edit_admin_import_path(import)
+        expect(page).to have_link "Destroy"
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
+
+  context "when Imports::Docx type" do
+    context "when admin" do
+      it "does not have buttons for needing support, data import or redact" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin)
+        import = create(:imports_docx)
+
+        login_as admin
+        visit admin_import_path(import)
+
+        expect(page).to have_text "Imports::Doc"
+        expect(page).to_not have_button "Needs support"
+        expect(page).to_not have_link "New data import"
+        expect(page).to_not have_link "Redact document"
+        expect(page).to have_link "Edit", href: edit_admin_import_path(import)
+        expect(page).to have_link "Destroy"
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
+
+  context "when Imports::DocxListing type" do
+    context "when admin" do
+      it "does not have buttons for needing support, data import or redact" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin)
+        import = create(:imports_docx_listing)
+
+        login_as admin
+        visit admin_import_path(import)
+
+        expect(page).to have_text "Imports::Doc"
         expect(page).to_not have_button "Needs support"
         expect(page).to_not have_link "New data import"
         expect(page).to_not have_link "Redact document"


### PR DESCRIPTION
<img width="1335" alt="Screenshot 2024-05-23 at 2 56 38 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/56ff9ef9-7c08-45f5-93a2-f4af8f3cd39d">
