### PR TITLE
Remove extracted attachments from bulletins with no processing

### DIFF
--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -44,6 +44,21 @@ class StandardsImport < ApplicationRecord
     end
   end
 
+  def clean_up_unprocessed_bulletin!
+    if bulletin?
+      uncompleted_source_files = source_files.select { |sf| !sf.completed? }
+      if source_files.count == uncompleted_source_files.count
+        files.order(:created_at).each_with_index do |file, index|
+          next if index.zero?
+
+          file.destroy!
+        end
+
+        update!(bulletin: false)
+      end
+    end
+  end
+
   def has_notified_uploader_of_all_conversions?
     source_files.count == source_files.count { |source_file| source_file.courtesy_notification_completed? }
   end

--- a/lib/tasks/standards_import.rake
+++ b/lib/tasks/standards_import.rake
@@ -8,4 +8,10 @@ namespace :standards_import do
       puts "Use FORCE=true to force this task"
     end
   end
+
+  task clean_up_bulletins: :environment do
+    StandardsImport.where(bulletin: true).find_each do |standards_import|
+      standards_import.clean_up_unprocessed_bulletin!
+    end
+  end
 end

--- a/spec/models/standards_import_spec.rb
+++ b/spec/models/standards_import_spec.rb
@@ -360,4 +360,95 @@ RSpec.describe StandardsImport, type: :model do
       si.notify_admin
     end
   end
+
+  describe "#clean_up_unprocessed_bulletin!" do
+    context "when bulletin" do
+      context "when number of source files matches non-completed source_files" do
+        it "deletes all source files except the initial one" do
+          allow(DocToPdfConverter).to receive(:convert)
+          perform_enqueued_jobs do
+            si = create(:standards_import, :with_docx_file_with_attachments, bulletin: true)
+            si.files.attach(file_fixture("pixel1x1.pdf"))
+            si.files.attach(file_fixture("document.doc"))
+
+            expect {
+              si.clean_up_unprocessed_bulletin!
+            }.to change(ActiveStorage::Attachment, :count).by(-2)
+              .and change(SourceFile, :count).by(-2)
+
+            si.reload
+
+            expect(si.files.count).to eq 1
+            expect(si.source_files.count).to eq 1
+            expect(si.bulletin?).to be_falsey
+          end
+        end
+      end
+
+      context "when initial bulletin had no files to extract" do
+        it "does not delete any source files but marks bulletin as false" do
+          perform_enqueued_jobs do
+            si = create(:standards_import, :with_pdf_file, bulletin: true)
+
+            expect {
+              si.clean_up_unprocessed_bulletin!
+            }.to change(ActiveStorage::Attachment, :count).by(0)
+              .and change(SourceFile, :count).by(0)
+
+            si.reload
+
+            expect(si.files.count).to eq 1
+            expect(si.source_files.count).to eq 1
+            expect(si.bulletin?).to be_falsey
+          end
+        end
+      end
+
+      context "when number of source files does not match non-completed source_files" do
+        it "does not delete any source files" do
+          allow(DocToPdfConverter).to receive(:convert)
+          perform_enqueued_jobs do
+            si = create(:standards_import, :with_docx_file_with_attachments, bulletin: true)
+            si.files.attach(file_fixture("pixel1x1.pdf"))
+            si.files.attach(file_fixture("document.doc"))
+
+            si.source_files.last.completed!
+
+            expect {
+              si.clean_up_unprocessed_bulletin!
+            }.to change(ActiveStorage::Attachment, :count).by(0)
+              .and change(SourceFile, :count).by(0)
+
+            si.reload
+
+            expect(si.files.count).to eq 3
+            expect(si.source_files.count).to eq 3
+            expect(si.bulletin?).to be_truthy
+          end
+        end
+      end
+    end
+
+    context "when not bulletin" do
+      it "does not delete any source files" do
+        allow(DocToPdfConverter).to receive(:convert)
+        perform_enqueued_jobs do
+          si = create(:standards_import, :with_docx_file_with_attachments, bulletin: false)
+          si.files.attach(file_fixture("pixel1x1.pdf"))
+          si.files.attach(file_fixture("document.doc"))
+
+          expect {
+            si.clean_up_unprocessed_bulletin!
+          }.to change(ActiveStorage::Attachment, :count).by(0)
+            .and change(SourceFile, :count).by(0)
+
+          si.reload
+
+          expect(si.files.count).to eq 3
+          expect(si.source_files.count).to eq 3
+          expect(si.bulletin?).to be_falsey
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
There are some bulletins in which the extracted
attachments have been added to the standards_import,
but none of these source files have been processed.
In these cases, remove all of the extracted attachments
from the standards_import. This will leave only the original
file that was downloaded from the Bulletins scraper job.
The standards_import record is then marked as `bulletin: false`
so we can pick it up to run it through the rake task that will create
imports for its source file record.
