### PR TITLE
Fix the Needs Redaction filter

### DIFF
--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -110,7 +110,7 @@ class ImportDashboard < Administrate::BaseDashboard
         .joins("JOIN active_storage_blobs ON (active_storage_attachments.blob_id = active_storage_blobs.id)")
         .where("active_storage_blobs.filename ILIKE ?", "%#{arg}%")
     },
-    not_redacted: ->(resources) { resources.not_redacted },
+    needs_redaction: ->(resources) { resources.ready_for_redaction },
     redacted: ->(resources) { resources.already_redacted }
   }.freeze
 

--- a/app/views/admin/imports/_filters.html.erb
+++ b/app/views/admin/imports/_filters.html.erb
@@ -7,7 +7,7 @@
 <div id="dropdown" class="z-10 hidden bg-white divide-y divide-gray-100 rounded-lg shadow w-44 dark:bg-gray-700">
     <ul class="py-2 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton">
       <li>
-        <%= link_to "Needs Redaction", url_for(search: "not_redacted:", pdf_only: true),
+        <%= link_to "Needs Redaction", url_for(search: "needs_redaction:", pdf_only: true),
               class: "block px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white" %>
       </li>
       <li>

--- a/spec/requests/admin/imports_spec.rb
+++ b/spec/requests/admin/imports_spec.rb
@@ -123,11 +123,11 @@ RSpec.describe "Admin::Imports", type: :request do
 
           admin = create(:admin)
           redacted = create(:imports_pdf, :with_redacted_pdf)
-          not_redacted = create(:imports_pdf)
+          not_redacted = create(:imports_pdf, status: :completed, public_document: false)
 
           sign_in admin
 
-          get admin_imports_path(search: "not_redacted:", pdf_only: true)
+          get admin_imports_path(search: "needs_redaction:", pdf_only: true)
 
           expect(response).to be_successful
           expect(response.body).to include(not_redacted.id)
@@ -175,11 +175,11 @@ RSpec.describe "Admin::Imports", type: :request do
 
           admin = create(:admin, :converter)
           redacted = create(:imports_pdf, :with_redacted_pdf)
-          not_redacted = create(:imports_pdf)
+          not_redacted = create(:imports_pdf, status: :completed, public_document: false)
 
           sign_in admin
 
-          get admin_imports_path(search: "not_redacted:")
+          get admin_imports_path(search: "needs_redaction:")
 
           expect(response).to be_successful
           expect(response.body).to include(not_redacted.id)

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -75,38 +75,42 @@ RSpec.describe "admin/imports/index", :admin do
       admin = create(:admin)
       create(:imports_uncategorized)
       create(:imports_pdf, :with_redacted_pdf, status: :pending)
-      create(:imports_pdf, status: :needs_support)
+      create(:imports_pdf, status: :completed, public_document: false)
+      create(:imports_pdf, status: :needs_backend_support, public_document: true)
 
       login_as admin
       visit admin_imports_path
 
       expect(page).to have_content("Imports::Uncategorized")
-      expect(page).to have_content("Imports::Pdf").twice
+      expect(page).to have_content("Imports::Pdf").thrice
 
       expect(page).to have_button "Filter by:"
       click_on "Filter by"
       click_on "Needs Redaction"
 
-      expect(page).to have_text "needs_support"
+      expect(page).to have_text "completed"
       expect(page).to_not have_text "pending"
+      expect(page).to_not have_text "needs_backend_support"
       expect(page).to_not have_content("Imports::Uncategorized")
       expect(page).to have_content("Imports::Pdf").once
 
       click_on "Filter by"
       click_on "Redacted"
 
-      expect(page).to_not have_text "needs_support"
+      expect(page).to_not have_text "completed"
       expect(page).to have_text "pending"
+      expect(page).to_not have_text "needs_backend_support"
       expect(page).to_not have_content("Imports::Uncategorized")
       expect(page).to have_content("Imports::Pdf").once
 
       click_on "Filter by"
       click_on "Show All"
 
-      expect(page).to have_text "needs_support"
+      expect(page).to have_text "completed"
       expect(page).to have_text "pending"
+      expect(page).to have_text "needs_backend_support"
       expect(page).to have_content("Imports::Uncategorized")
-      expect(page).to have_content("Imports::Pdf").twice
+      expect(page).to have_content("Imports::Pdf").thrice
 
       stub_feature_flag(:show_imports_in_administrate, false)
     end
@@ -117,7 +121,7 @@ RSpec.describe "admin/imports/index", :admin do
       admin = create(:admin)
       source_file = create(:source_file)
       uncat = create(:imports_uncategorized, source_file: source_file, status: "unfurled")
-      create(:imports_pdf, parent: uncat, status: "pending", created_at: 1.day.ago) # inaccurately set the created_at date so we can easily Destroy the uncat record
+      create(:imports_pdf, parent: uncat, status: "pending", created_at: 1.day.ago) # inaccurately set the created_at date so we can easily Destroy the uncat record by matching on the first record
 
       login_as admin
       visit admin_imports_path
@@ -166,7 +170,8 @@ RSpec.describe "admin/imports/index", :admin do
 
       admin = create(:admin, :converter)
       create(:imports_pdf, :with_redacted_pdf, status: :pending)
-      create(:imports_pdf, status: :needs_support)
+      create(:imports_pdf, status: :completed)
+      create(:imports_pdf, status: :needs_backend_support, public_document: true)
 
       login_as admin
       visit admin_imports_path
@@ -175,20 +180,23 @@ RSpec.describe "admin/imports/index", :admin do
       click_on "Filter by"
       click_on "Needs Redaction"
 
-      expect(page).to have_text "needs_support"
+      expect(page).to have_text "completed"
       expect(page).to_not have_text "pending"
+      expect(page).to_not have_text "needs_backend_support"
 
       click_on "Filter by"
       click_on "Redacted"
 
-      expect(page).to_not have_text "needs_support"
+      expect(page).to_not have_text "completed"
       expect(page).to have_text "pending"
+      expect(page).to_not have_text "needs_backend_support"
 
       click_on "Filter by"
       click_on "Show All"
 
-      expect(page).to have_text "needs_support"
+      expect(page).to have_text "completed"
       expect(page).to have_text "pending"
+      expect(page).to have_text "needs_backend_support"
 
       stub_feature_flag(:show_imports_in_administrate, false)
     end


### PR DESCRIPTION
When the Import dashboard was modified
to use the Administrate Filter section, the 
Needs Redaction filter was incorrectly set up
to return all non-redacted files, rather than files
that fit the criteria to be redacted.

