### PR TITLE
Fix bulletin cleanup when converted doc -> pdf source file exists

### DIFF
--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -51,7 +51,13 @@ class StandardsImport < ApplicationRecord
         files.order(:created_at).each_with_index do |file, index|
           next if index.zero?
 
-          file.destroy!
+          begin
+            file.destroy!
+          rescue ActiveRecord::InvalidForeignKey
+            source_file = file.source_file
+            source_file.converted_source_file.destroy!
+            file.destroy!
+          end
         end
 
         update!(bulletin: false)

--- a/spec/models/standards_import_spec.rb
+++ b/spec/models/standards_import_spec.rb
@@ -368,8 +368,12 @@ RSpec.describe StandardsImport, type: :model do
           allow(DocToPdfConverter).to receive(:convert)
           perform_enqueued_jobs do
             si = create(:standards_import, :with_docx_file_with_attachments, bulletin: true)
-            si.files.attach(file_fixture("pixel1x1.pdf"))
             si.files.attach(file_fixture("document.doc"))
+            si.files.attach(file_fixture("pixel1x1.pdf"))
+
+            doc_source_file = si.files[-2].source_file
+            pdf_source_file = si.files.last.source_file
+            doc_source_file.update!(converted_source_file: pdf_source_file)
 
             expect {
               si.clean_up_unprocessed_bulletin!


### PR DESCRIPTION
When a standards import bulletin extracts `.doc` or `.docx` files, the system would create pdf records that would get linked to those doc files. When trying to remove these attachments from a standards import record for the cleanup bulletins task, make sure to remove the converted pdf file first to bypass invalid foreign key errors.