### PR TITLE
Do not clean up bulletins that have an attached data_import

### DIFF
--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -46,7 +46,7 @@ class StandardsImport < ApplicationRecord
 
   def clean_up_unprocessed_bulletin!
     if bulletin?
-      uncompleted_source_files = source_files.select { |sf| !sf.completed? }
+      uncompleted_source_files = source_files.select { |sf| !sf.completed? && sf.data_imports.empty? }
       if source_files.count == uncompleted_source_files.count
         files.order(:created_at).each_with_index do |file, index|
           next if index.zero?


### PR DESCRIPTION
When cleaning up source files on bulletin standards import, skip any standards imports where any of the source files have data imports. We want to ensure that we don't lose any of the manual work that has been done, even if those data imports have not been able to be imported for some reason.
