### PR TITLE
Reduce viewable Import fields on Converter view in Administrate

### DIFF
--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -54,8 +54,9 @@ class ImportDashboard < Administrate::BaseDashboard
     id
     type
     file
-    assignee
+    data_imports
     status
+    assignee
     metadata
     public_document
     redacted_pdf
@@ -66,7 +67,6 @@ class ImportDashboard < Administrate::BaseDashboard
     parent
     import
     imports
-    data_imports
     associated_occupation_standards
     created_at
     updated_at

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -68,6 +68,7 @@
           <% next if attribute.name.match?("redacted") && !page.resource.is_a?(Imports::Pdf) %>
           <% next if attribute.name == "import" && (page.resource.is_a?(Imports::Pdf) || page.resource.is_a?(Imports::DocxListing)) %>
           <% next if attribute.name == "imports" && !page.resource.is_a?(Imports::DocxListing) %>
+          <% next if %w[courtesy_notification parent child associated_occupation_standards type].include?(attribute.name) && current_user.converter? %>
           <dt class="attribute-label" id="<%= attribute.name %>">
             <%= t(
                   "helpers.label.#{resource_name}.#{attribute.name}",

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "admin/imports/index", :admin do
       admin = create(:admin, :converter)
       create(:imports_uncategorized)
       create(:imports_docx_listing)
-      pdf = create(:imports_pdf)
+      pdf = create(:imports_pdf, status: :completed)
 
       login_as admin
       visit admin_imports_path
@@ -156,7 +156,7 @@ RSpec.describe "admin/imports/index", :admin do
       expect(page).to_not have_text "Destroy"
 
       click_on "Imports::Pdf", match: :first
-      expect(page).to have_text "Imports::Uncategorized" # parent
+      expect(page).to have_text "completed"
 
       stub_feature_flag(:show_imports_in_administrate, false)
     end

--- a/spec/system/admin/imports/show_spec.rb
+++ b/spec/system/admin/imports/show_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "admin/imports/show", :admin do
         expect(page).to have_link "Redact document", href: new_admin_import_redact_file_path(import)
         expect(page).to have_link "Edit", href: edit_admin_import_path(import)
         expect(page).to have_link "Destroy"
+        expect(page).to have_text "Data import"
+        expect(page).to have_text "Courtesy notification"
+        expect(page).to have_text "Parent"
+        expect(page).to have_text "Associated occupation standards"
 
         stub_feature_flag(:show_imports_in_administrate, false)
       end
@@ -57,12 +61,18 @@ RSpec.describe "admin/imports/show", :admin do
         login_as admin
         visit admin_import_path(import)
 
-        expect(page).to have_text "Imports::Pdf"
         expect(page).to have_button "Needs support"
         expect(page).to have_link "New data import", href: new_admin_import_data_import_path(import)
         expect(page).to have_link "Redact document", href: new_admin_import_redact_file_path(import)
+        expect(page).to have_text "Data imports"
         expect(page).to_not have_link "Edit", href: edit_admin_import_path(import)
         expect(page).to_not have_link "Destroy"
+        expect(page).to_not have_text "Courtesy notification"
+        expect(page).to_not have_text "Parent"
+        expect(page).to_not have_text "Child"
+        expect(page).to_not have_text "Type"
+        expect(page).to_not have_text "Imports::Pdf"
+        expect(page).to_not have_text "Associated occupation standards"
 
         click_on "Needs support"
 
@@ -91,6 +101,12 @@ RSpec.describe "admin/imports/show", :admin do
         expect(page).to_not have_link "Redact document"
         expect(page).to have_link "Edit", href: edit_admin_import_path(import)
         expect(page).to have_link "Destroy"
+        expect(page).to have_text "Data import"
+        expect(page).to have_text "Courtesy notification"
+        expect(page).to have_text "Parent"
+        expect(page).to have_text "Child"
+        expect(page).to have_text "Type"
+        expect(page).to have_text "Associated occupation standards"
 
         stub_feature_flag(:show_imports_in_administrate, false)
       end


### PR DESCRIPTION
The Converter view has some links that are 404 since a converter is not allowed to view them. This reduces the number of fields viewable for a converter, and moves the DataImport association back up towards the top where it was with the SourceFile.
