### PR TITLE
Update daily uploads report mailer to handle new Import model

### DIFF
--- a/app/views/admin_mailer/daily_uploads_report.html.erb
+++ b/app/views/admin_mailer/daily_uploads_report.html.erb
@@ -6,7 +6,12 @@
       <%= link_to "Public", occupation_standard_url(data_import.occupation_standard, host: ENV.fetch("PUBLIC_DOMAIN", Rails.application.config.action_mailer.default_url_options[:host])) %> |
       <%= link_to "Admin", admin_occupation_standard_url(data_import.occupation_standard) %> |
       <%= link_to "Data Import", admin_data_import_url(data_import) %> |
-      <%= link_to "Source File", admin_source_file_url(data_import.source_file) %> <br> <br>
+      <% if Flipper.enabled?(:show_imports_in_administrate) %>
+        <%= link_to "Source File", admin_import_url(data_import.import) %>
+      <% else %>
+        <%= link_to "Source File", admin_source_file_url(data_import.source_file) %>
+      <% end %>
+      <br> <br>
 
       <%= render "daily_uploads_report_field", label: "Competencies count", value: data_import.occupation_standard.competencies_count %>
       <%= render "daily_uploads_report_field", label: "OJT hours min", value: data_import.occupation_standard.ojt_hours_min %>

--- a/app/views/admin_mailer/daily_uploads_report.text.erb
+++ b/app/views/admin_mailer/daily_uploads_report.text.erb
@@ -30,5 +30,9 @@
   <% end %>
 
   Data Import: <%= admin_data_import_url(data_import) %>
-  Source File: <%= admin_source_file_url(data_import.source_file) %>
+  <% if Flipper.enabled?(:show_imports_in_administrate) %>
+    Source File: <%= admin_import_url(data_import.import) %>
+  <% else %>
+    Source File: <%= admin_source_file_url(data_import.source_file) %>
+  <% end %>
 <% end %>

--- a/app/views/admin_mailer/daily_uploads_report.text.erb
+++ b/app/views/admin_mailer/daily_uploads_report.text.erb
@@ -4,21 +4,17 @@
   Public: <%= occupation_standard_url(data_import.occupation_standard, host: ENV.fetch("PUBLIC_DOMAIN", Rails.application.config.action_mailer.default_url_options[:host])) %>
   Admin: <%= admin_occupation_standard_url(data_import.occupation_standard) %>
   Competencies count: <%= data_import.occupation_standard.competencies_count %>
-
   <% if data_import.occupation_standard.ojt_hours_min.to_i.positive? %>
-    OJT hours min: <%= data_import.occupation_standard.ojt_hours_min %>
+  OJT hours min: <%= data_import.occupation_standard.ojt_hours_min %>
   <% end %>
-
   <% if data_import.occupation_standard.ojt_hours_max.to_i.positive? %>
-    OJT hours max: <%= data_import.occupation_standard.ojt_hours_max %>
+  OJT hours max: <%= data_import.occupation_standard.ojt_hours_max %>
   <% end %>
-
   <% if data_import.occupation_standard.rsi_hours_min.to_i.positive? %>
-    RSI hours min: <%= data_import.occupation_standard.rsi_hours_min %>
+  RSI hours min: <%= data_import.occupation_standard.rsi_hours_min %>
   <% end %>
-
   <% if data_import.occupation_standard.rsi_hours_max.to_i.positive? %>
-    RSI hours max: <%= data_import.occupation_standard.rsi_hours_max %>
+  RSI hours max: <%= data_import.occupation_standard.rsi_hours_max %>
   <% end %>
 
   Totals:
@@ -31,8 +27,10 @@
 
   Data Import: <%= admin_data_import_url(data_import) %>
   <% if Flipper.enabled?(:show_imports_in_administrate) %>
-    Source File: <%= admin_import_url(data_import.import) %>
+  Source File: <%= admin_import_url(data_import.import) %>
   <% else %>
-    Source File: <%= admin_source_file_url(data_import.source_file) %>
+  Source File: <%= admin_source_file_url(data_import.source_file) %>
   <% end %>
+
+
 <% end %>

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -42,43 +42,94 @@ RSpec.describe AdminMailer, type: :mailer do
   end
 
   describe "#daily_uploads_report" do
-    it "renders the header and body correctly" do
-      travel_to(Time.zone.local(2023, 6, 15)) do
-        data_import = create(:data_import, created_at: Time.zone.local(2023, 6, 14))
-        source_file = data_import.source_file
-        occupation_standard = data_import.occupation_standard
-        occupation_standard.update!(ojt_hours_min: 100, ojt_hours_max: 200, rsi_hours_min: 500, rsi_hours_max: 600, title: "Mechanic")
-        allow_any_instance_of(OccupationStandard).to receive(:competencies_count).and_return(123)
+    context "with imports feature flag off" do
+      it "renders the header and body correctly" do
+        travel_to(Time.zone.local(2023, 6, 15)) do
+          data_import = create(:data_import, created_at: Time.zone.local(2023, 6, 14))
+          source_file = data_import.source_file
+          occupation_standard = data_import.occupation_standard
+          occupation_standard.update!(ojt_hours_min: 100, ojt_hours_max: 200, rsi_hours_min: 500, rsi_hours_max: 600, title: "Mechanic")
+          allow_any_instance_of(OccupationStandard).to receive(:competencies_count).and_return(123)
 
-        mail = described_class.daily_uploads_report
+          mail = described_class.daily_uploads_report
 
-        expect(mail.subject).to eq("Daily imported standards report 2023-06-14")
-        expect(mail.to).to eq(["info@workhands.us"])
-        expect(mail.from).to eq(["no-reply@apprenticeshipstandards.org"])
+          expect(mail.subject).to eq("Daily imported standards report 2023-06-14")
+          expect(mail.to).to eq(["info@workhands.us"])
+          expect(mail.from).to eq(["no-reply@apprenticeshipstandards.org"])
 
-        mail.body.parts.each do |part|
-          expect(part.body.encoded).to match "Mechanic"
-          expect(part.body.encoded).to match "Public"
-          expect(part.body.encoded).to match "Admin"
-          expect(part.body.encoded).to match "Data Import"
-          expect(part.body.encoded).to match "Source File"
-          expect(part.body.encoded).to match occupation_standard_url(occupation_standard)
-          expect(part.body.encoded).to match admin_occupation_standard_url(occupation_standard)
-          expect(part.body.encoded).to match admin_data_import_url(data_import)
-          expect(part.body.encoded).to match admin_source_file_url(source_file)
-          expect(part.body.encoded).to match "Competencies count: 123"
-          expect(part.body.encoded).to match "OJT hours min: 100"
-          expect(part.body.encoded).to match "OJT hours max: 200"
-          expect(part.body.encoded).to match "RSI hours min: 500"
-          expect(part.body.encoded).to match "RSI hours max: 600"
+          mail.body.parts.each do |part|
+            expect(part.body.encoded).to match "Mechanic"
+            expect(part.body.encoded).to match "Public"
+            expect(part.body.encoded).to match "Admin"
+            expect(part.body.encoded).to match "Data Import"
+            expect(part.body.encoded).to match "Source File"
+            expect(part.body.encoded).to match occupation_standard_url(occupation_standard)
+            expect(part.body.encoded).to match admin_occupation_standard_url(occupation_standard)
+            expect(part.body.encoded).to match admin_data_import_url(data_import)
+            expect(part.body.encoded).to match admin_source_file_url(source_file)
+            expect(part.body.encoded).to match "Competencies count: 123"
+            expect(part.body.encoded).to match "OJT hours min: 100"
+            expect(part.body.encoded).to match "OJT hours max: 200"
+            expect(part.body.encoded).to match "RSI hours min: 500"
+            expect(part.body.encoded).to match "RSI hours max: 600"
+          end
         end
+      end
+
+      it "does not send mail if no imports" do
+        expect {
+          described_class.daily_uploads_report.deliver_now
+        }.not_to change(ActionMailer::Base.deliveries, :count)
       end
     end
 
-    it "does not send mail if no imports" do
-      expect {
-        described_class.daily_uploads_report.deliver_now
-      }.not_to change(ActionMailer::Base.deliveries, :count)
+    context "with imports feature flag on" do
+      it "renders the header and body correctly" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        travel_to(Time.zone.local(2023, 6, 15)) do
+          pdf = create(:imports_pdf)
+          data_import = create(:data_import, created_at: Time.zone.local(2023, 6, 14), import: pdf, source_file: nil)
+          occupation_standard = data_import.occupation_standard
+          occupation_standard.update!(ojt_hours_min: 100, ojt_hours_max: 200, rsi_hours_min: 500, rsi_hours_max: 600, title: "Mechanic")
+          allow_any_instance_of(OccupationStandard).to receive(:competencies_count).and_return(123)
+
+          mail = described_class.daily_uploads_report
+
+          expect(mail.subject).to eq("Daily imported standards report 2023-06-14")
+          expect(mail.to).to eq(["info@workhands.us"])
+          expect(mail.from).to eq(["no-reply@apprenticeshipstandards.org"])
+
+          mail.body.parts.each do |part|
+            expect(part.body.encoded).to match "Mechanic"
+            expect(part.body.encoded).to match "Public"
+            expect(part.body.encoded).to match "Admin"
+            expect(part.body.encoded).to match "Data Import"
+            expect(part.body.encoded).to match "Source File"
+            expect(part.body.encoded).to match occupation_standard_url(occupation_standard)
+            expect(part.body.encoded).to match admin_occupation_standard_url(occupation_standard)
+            expect(part.body.encoded).to match admin_data_import_url(data_import)
+            expect(part.body.encoded).to match admin_import_url(pdf)
+            expect(part.body.encoded).to match "Competencies count: 123"
+            expect(part.body.encoded).to match "OJT hours min: 100"
+            expect(part.body.encoded).to match "OJT hours max: 200"
+            expect(part.body.encoded).to match "RSI hours min: 500"
+            expect(part.body.encoded).to match "RSI hours max: 600"
+          end
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
+      end
+
+      it "does not send mail if no imports" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        expect {
+          described_class.daily_uploads_report.deliver_now
+        }.not_to change(ActionMailer::Base.deliveries, :count)
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes [Rollbar issue](https://app.rollbar.com/a/apprenticeship-standards-dot-o/fix/item/apprenticeship-standards-dot-o/395)

This updates the DailyUploadsReport mailer to correctly handle the email display with the Import model flag turned on.

This also fixes the copy layout of the text version of the email.

**Old layout:**
<img width="870" alt="Screenshot 2024-05-29 at 8 31 14 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/17a8a16f-cb33-434e-a0b3-c3cc8a9019b2">

**New layout:**
<img width="873" alt="Screenshot 2024-05-29 at 8 31 20 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/5acdb8dd-ac69-4b06-9b37-349271ab25f6">

