### PR TITLE
Add needs_unfurling scope and use in rake task

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -27,6 +27,8 @@ class Import < ApplicationRecord
     :completed
   ], _prefix: true
 
+  scope :needs_unfurling, -> { unfurled.where("created_at < ?", 1.day.ago) }
+
   def filename
     file.blob.filename.to_s
   end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -7,7 +7,7 @@ namespace :import do
       Imports::Uncategorized
     ].each do |model|
       puts "Processing unfurled #{model} records"
-      model.unfurled.find_each.with_index do |import, index|
+      model.needs_unfurling.find_each.with_index do |import, index|
         import.process
         rest(index)
       rescue

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -3,6 +3,21 @@ require "rails_helper"
 RSpec.describe Imports::Uncategorized, type: :model do
   it_behaves_like "an imported file"
 
+  describe ".needs_unfurling" do
+    it "returns unfurled records that were created more than a day ago" do
+      match_records = [
+        create(:imports_uncategorized, status: :unfurled, created_at: 2.days.ago),
+        create(:imports_docx, status: :unfurled, created_at: 26.hours.ago),
+        create(:imports_doc, status: :unfurled, created_at: 1.week.ago)
+      ]
+      create(:imports_uncategorized, status: :unfurled, created_at: 23.hours.ago)
+      create(:imports_docx, status: :unfurled)
+      create(:imports_doc, status: :archived, created_at: 1.week.ago)
+
+      expect(Import.needs_unfurling).to match_array match_records
+    end
+  end
+
   describe "#process" do
     it "detects Docx listings" do
       allow_any_instance_of(Imports::DocxListing).to receive(:process).with(hash_including(listing: false))


### PR DESCRIPTION
In order to make sure that the rake task
to process unfurled import records doesn't
try to process records currently in the state
of being processed, only grab records that were
created more than a day ago.

[Asana ticket](https://app.asana.com/0/1203289004376659/1207407417241749/f)
