### PR TITLE
Fix permitted param key when updating Imports

### DIFF
--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -32,7 +32,10 @@ module Admin
     private
 
     def resource_params
-      super.permit(policy(requested_resource).permitted_attributes)
+      params.require(requested_resource.class.model_name.param_key)
+        .permit(dashboard.permitted_attributes(action_name))
+        .transform_values { |v| read_param_value(v) }
+        .permit(policy(requested_resource).permitted_attributes)
     end
 
     def after_resource_updated_path(resource)

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -12,7 +12,7 @@
               "Needs support",
               admin_import_path(page.resource),
               params: {
-                import: {status: "needs_support"},
+                imports_pdf: {status: "needs_support"},
                 redirect_back_to: admin_import_path(page.resource)
               },
               method: :patch,

--- a/spec/requests/admin/imports_spec.rb
+++ b/spec/requests/admin/imports_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe "Admin::Imports", type: :request do
 
           sign_in admin
           patch admin_import_path(import), params: {
-            import: {
+            imports_uncategorized: {
               status: "archived"
             }
           }
@@ -381,7 +381,7 @@ RSpec.describe "Admin::Imports", type: :request do
 
           sign_in admin
           patch admin_import_path(import), params: {
-            import: {
+            imports_pdf: {
               status: "needs_support",
               assignee_id: assignee.id,
               metadata: {foo: "bob"}.to_json
@@ -406,7 +406,7 @@ RSpec.describe "Admin::Imports", type: :request do
 
           sign_in admin
           patch admin_import_path(import), params: {
-            import: {
+            imports_pdf: {
               status: "completed",
               assignee_id: assignee.id
             },

--- a/spec/system/admin/imports/edit_spec.rb
+++ b/spec/system/admin/imports/edit_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "admin/imports/edit", :admin do
+  context "when Imports::Pdf" do
+    context "when admin" do
+      it "can update the status" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin)
+        import = create(:imports_pdf, status: :pending)
+
+        login_as admin
+        visit edit_admin_import_path(import)
+
+        select "archived"
+        click_on "Update Pdf"
+
+        expect(page).to have_text "archived"
+        expect(import.reload).to be_archived
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
+
+  context "when Imports::Uncategorized" do
+    context "when admin" do
+      it "can update the status" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin)
+        import = create(:imports_uncategorized, status: :unfurled)
+
+        login_as admin
+        visit edit_admin_import_path(import)
+
+        select "archived"
+        click_on "Update Uncategorized"
+
+        expect(page).to have_text "archived"
+        expect(import.reload).to be_archived
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The resource_params method was returning
import: as the param_key instead of the
correct key for the STI model.

The Administrate method was:

```
    def resource_params
      params.require(resource_class.model_name.param_key)
        .permit(dashboard.permitted_attributes(action_name))
        .transform_values { |v| read_param_value(v) }
    end
```

but `resource_class.model_name.param_key` is changed to `requested_resource.class.model_name.param_key` in order to return `imports_pdf:` instead of `import:`.

[Asana ticket](https://app.asana.com/0/1203289004376659/1207439838600401/f)
