### PR TITLE
Not all imports have a file attached

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -30,7 +30,7 @@ class Import < ApplicationRecord
   scope :needs_unfurling, -> { unfurled.where("created_at < ?", 1.day.ago) }
 
   def filename
-    file.blob.filename.to_s
+    file&.blob&.filename.to_s
   end
 
   def redacted_pdf

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -200,4 +200,18 @@ RSpec.describe Imports::Uncategorized, type: :model do
       expect(uncat.transfer_source_file_data!).to be_nil
     end
   end
+
+  describe "#filename" do
+    it "returns filename if file attached" do
+      import = create(:imports_uncategorized)
+
+      expect(import.filename).to eq "pixel1x1.pdf"
+    end
+
+    it "returns empty string if no file attached" do
+      import = create(:imports_uncategorized, file: nil)
+
+      expect(import.filename).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
We are getting an error when trying to view the Imports page in Administrate since it is expecting all imports to have an attached file.

[Rollbar](https://app.rollbar.com/a/apprenticeship-standards-dot-o/fix/item/apprenticeship-standards-dot-o/405)
