### PR TITLE
Stop creating duplicate Imports::Uncategorized records

### DIFF
--- a/app/controllers/standards_imports_controller.rb
+++ b/app/controllers/standards_imports_controller.rb
@@ -60,7 +60,7 @@ class StandardsImportsController < ApplicationController
       @standards_import.files.each do |file|
         @standards_import.imports.build(
           type: "Imports::Uncategorized",
-          status: :pending,
+          status: :unfurled,
           public_document: @standards_import.public_document,
           file: file.blob
         )

--- a/app/controllers/standards_imports_controller.rb
+++ b/app/controllers/standards_imports_controller.rb
@@ -8,6 +8,8 @@ class StandardsImportsController < ApplicationController
   def create
     @standards_import = StandardsImport.new(standards_import_params)
 
+    build_uncategorized_imports
+
     unless user_signed_in?
       @standards_import.courtesy_notification = :pending
     end
@@ -51,5 +53,18 @@ class StandardsImportsController < ApplicationController
       :public_document,
       files: []
     )
+  end
+
+  def build_uncategorized_imports
+    if Flipper.enabled?(:show_imports_in_administrate)
+      @standards_import.files.each do |file|
+        @standards_import.imports.build(
+          type: "Imports::Uncategorized",
+          status: :pending,
+          public_document: @standards_import.public_document,
+          file: file.blob
+        )
+      end
+    end
   end
 end

--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -48,20 +48,6 @@ class StandardsImport < ApplicationRecord
     source_files.count == source_files.count { |source_file| source_file.courtesy_notification_completed? }
   end
 
-  def files=(files)
-    if Flipper.enabled?(:show_imports_in_administrate)
-      files.each do |file|
-        imports.build(
-          type: "Imports::Uncategorized",
-          status: :pending,
-          public_document: public_document,
-          file: file
-        )
-      end
-    end
-    super(files) # still attach to standards_import for now
-  end
-
   def file_count
     files.count
   end

--- a/lib/tasks/deployment/20240604201344_remove_pending_uncategorized_imports.rake
+++ b/lib/tasks/deployment/20240604201344_remove_pending_uncategorized_imports.rake
@@ -1,0 +1,16 @@
+namespace :after_party do
+  desc "Deployment task: remove_pending_uncategorized_imports"
+  task remove_pending_uncategorized_imports: :environment do
+    puts "Running deploy task 'remove_pending_uncategorized_imports'"
+
+    # Imports::Uncategorized should never have status pending. Fortunately
+    # when we accidentally created duplicate records, we set the dups
+    # as status pending. Deleting them all here.
+    Imports::Uncategorized.pending.destroy_all
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20240604201344_remove_pending_uncategorized_imports.rake
+++ b/lib/tasks/deployment/20240604201344_remove_pending_uncategorized_imports.rake
@@ -5,8 +5,16 @@ namespace :after_party do
 
     # Imports::Uncategorized should never have status pending. Fortunately
     # when we accidentally created duplicate records, we set the dups
-    # as status pending. Deleting them all here.
-    Imports::Uncategorized.pending.destroy_all
+    # as status pending. Deleting any where the courtesy_notification is not
+    # pending (meaning they came in through a scraper). Currently the
+    # courtesy_notifcation: pending count on prod is 0, but just in case any
+    # files are uploaded in the meantime, those imports should be set to status
+    # unfurled.
+    Imports::Uncategorized.pending.where.not(courtesy_notification: :pending).destroy_all
+
+    Imports::Uncategorized.pending.where(courtesy_notification: :pending).each do |import|
+      import.unfurled!
+    end
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).

--- a/spec/requests/standards_imports_spec.rb
+++ b/spec/requests/standards_imports_spec.rb
@@ -86,12 +86,14 @@ RSpec.describe "StandardsImports", type: :request do
           import1 = Imports::Uncategorized.first
           expect(import1).to be_courtesy_notification_pending
           expect(import1.file.blob.filename.to_s).to eq "pixel1x1.pdf"
+          expect(import1).to be_unfurled
           expect(import1).to_not be_public_document
           expect(import1.parent).to eq si
 
           import2 = Imports::Uncategorized.last
           expect(import2).to be_courtesy_notification_pending
           expect(import2.file.blob.filename.to_s).to eq "pixel1x1_redacted.pdf"
+          expect(import1).to be_unfurled
           expect(import2).to_not be_public_document
           expect(import2.parent).to eq si
 
@@ -176,6 +178,7 @@ RSpec.describe "StandardsImports", type: :request do
           import = Imports::Uncategorized.last
           expect(import).to be_courtesy_notification_not_required
           expect(import.file.blob.filename.to_s).to eq "pixel1x1.pdf"
+          expect(import).to be_unfurled
           expect(import).to be_public_document
 
           expect(response).to redirect_to admin_source_files_path

--- a/spec/requests/standards_imports_spec.rb
+++ b/spec/requests/standards_imports_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "StandardsImports", type: :request do
             }
           }.to change(StandardsImport, :count).by(1)
             .and change(ActiveStorage::Attachment, :count).by(4)
-            .and change(ActiveStorage::Blob, :count).by(4)
+            .and change(ActiveStorage::Blob, :count).by(2)
             .and change(Imports::Uncategorized, :count).by(2)
 
           si = StandardsImport.last
@@ -161,7 +161,7 @@ RSpec.describe "StandardsImports", type: :request do
             }
           }.to change(StandardsImport, :count).by(1)
             .and change(ActiveStorage::Attachment, :count).by(2)
-            .and change(ActiveStorage::Blob, :count).by(2)
+            .and change(ActiveStorage::Blob, :count).by(1)
             .and change(Imports::Uncategorized, :count).by(1)
 
           si = StandardsImport.last
@@ -239,6 +239,7 @@ RSpec.describe "StandardsImports", type: :request do
     context "with invalid parameters" do
       it "does not create new standards import record and renders new" do
         stub_feature_flag(:recaptcha, true)
+        stub_feature_flag(:show_imports_in_administrate, true)
         stub_recaptcha_high_score
 
         expect {
@@ -253,6 +254,9 @@ RSpec.describe "StandardsImports", type: :request do
         }.to_not change(StandardsImport, :count)
 
         expect(response).to have_http_status(:unprocessable_entity)
+
+        stub_feature_flag(:recaptcha, false)
+        stub_feature_flag(:show_imports_in_administrate, false)
       end
     end
   end


### PR DESCRIPTION
Do not create Uncategorized imports in the 
StandardsImport `files=` method:

It turns out the ActiveStorage `attach` method calls
`files=` [under the hood](https://github.com/rails/rails/blob/e215bf3360e6dfe1497c1503a495e384ed6b0995/activestorage/lib/active_storage/attached/one.rb#L59). This means that we are
creating duplicate `Imports::Uncategorized` records
[all over the place](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/blob/main/app/services/create_import_from_uri.rb#L38). However, we fortunately put
the incorrect status of `pending` on the duplicate
Uncategorized records, so they never got processed
and will be easy to clean up.

This changes the overriding of the `files=` method
for StandardsImport and just builds the Uncategorized
records in the controller itself. Since we ultimately
will NOT be attaching any files to the StandardsImport
records, it does not make sense to continue
to customize the `files=` method.

A one-time rake task was added to delete the duplicate
`Imports::Uncategorized` records

