### PR TITLE
Add link to the public view of an occupation standard on admin page

### DIFF
--- a/app/views/admin/occupation_standards/show.html.erb
+++ b/app/views/admin/occupation_standards/show.html.erb
@@ -6,6 +6,13 @@
   </h1>
 
   <div>
+    <%= link_to(
+          "Public view",
+          occupation_standard_url(page.resource, host: ENV.fetch("PUBLIC_DOMAIN", ENV.fetch("HOST"))),
+          class: "button",
+          target: "_blank"
+        ) %>
+
     <%= if accessible_action?(page.resource, :edit)
           link_to(
             t("administrate.actions.edit_resource", name: page.page_title),

--- a/spec/system/admin/occupation_standards/show_spec.rb
+++ b/spec/system/admin/occupation_standards/show_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "admin/occupation_standards/show" do
     login_as admin
     visit admin_occupation_standard_path(occupation_standard)
 
+    expect(page).to have_link("Public view", href: occupation_standard_url(occupation_standard, host: ENV.fetch("PUBLIC_DOMAIN", ENV.fetch("HOST"))))
+
     expect(page).to have_selector("h1", text: "Mechanic")
 
     expect(page).to have_selector("dt", text: "Title")


### PR DESCRIPTION
This adds a link to the public view of an Occupation Standard from the admin page.

<img width="1589" alt="Screenshot 2024-06-05 at 8 40 44 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/71478400-2ca7-4f53-8061-2dad19bca4b2">
