### PR TITLE
Import created date from the RAPIDS API

### DIFF
--- a/app/models/rapids/occupation_standard.rb
+++ b/app/models/rapids/occupation_standard.rb
@@ -23,7 +23,8 @@ module RAPIDS
           ),
           organization: find_or_create_organization_by_organization_name(response["sponsorName"]),
           occupation: find_occupation(rapids_code, onet_code),
-          external_id: extract_wps_id(response["wpsDocument"])
+          external_id: extract_wps_id(response["wpsDocument"]),
+          registration_date: response["createdDt"]
         )
       end
 

--- a/spec/factories/rapids_api/occupation_standards.rb
+++ b/spec/factories/rapids_api/occupation_standards.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     jobZone { "Job Zone Two: Some Preparation Needed." }
     isWPSUploaded { false }
     wpsDocument { "https://entbpmpstg.dol.gov/suite/webapi/rapids/data-sharing/documents/wps/1234" }
+    createdDt { "2024-06-13" }
     dwas { [] }
 
     transient do

--- a/spec/models/rapids/occupation_standard_spec.rb
+++ b/spec/models/rapids/occupation_standard_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
       expect(occupation_standard.title).to eq occupation_standard_response["occupationTitle"]
       expect(occupation_standard.onet_code).to eq occupation_standard_response["onetSocCode"]
       expect(occupation_standard.rapids_code).to eq occupation_standard_response["rapidsCode"]
+      expect(occupation_standard.registration_date).to eq occupation_standard_response["createdDt"].to_date
     end
 
     context "when occupation title has a different encoding" do


### PR DESCRIPTION
* createdDt was added to standards we are pulling from the RAPIDS API.
* Import the createdDt to the occupation_standards registration_date
  column.
* https://app.asana.com/0/1203289004376659/1207522761805698/f
