### PR TITLE
Update occupation_standard attributes from RAPIDS

### DIFF
--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -38,7 +38,7 @@ class ImportDataFromRAPIDSJob < ApplicationJob
 
   def process_api_response(response)
     response["wps"].each do |occupation_standard_response|
-      occupation_standard = 
+      occupation_standard =
         RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
       if !occupation_standard.persisted?

--- a/app/jobs/import_data_from_rapids_job.rb
+++ b/app/jobs/import_data_from_rapids_job.rb
@@ -38,45 +38,30 @@ class ImportDataFromRAPIDSJob < ApplicationJob
 
   def process_api_response(response)
     response["wps"].each do |occupation_standard_response|
-      occupation_standard = process_occupation_standard(occupation_standard_response)
+      occupation_standard = 
+        RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
-      next if occupation_standard.persisted?
-
-      occupation_standard.work_processes = process_work_processes(
-        occupation_standard_response["dwas"],
-        occupation_standard
-      )
-
-      document = fetch_document_response(occupation_standard.external_id)
-      if document
-        attachment = convert_response_to_attachment(document)
-        pdf = CreateImportFromIo.call(
-          io: attachment,
-          filename: "#{occupation_standard.external_id}.docx",
-          title: "RAPIDSAPI",
-          source: "RAPIDSAPI"
+      if !occupation_standard.persisted?
+        occupation_standard.work_processes = process_work_processes(
+          occupation_standard_response["dwas"],
+          occupation_standard
         )
 
-        pdf&.data_imports&.create!(occupation_standard: occupation_standard)
+        document = fetch_document_response(occupation_standard.external_id)
+        if document
+          attachment = convert_response_to_attachment(document)
+          pdf = CreateImportFromIo.call(
+            io: attachment,
+            filename: "#{occupation_standard.external_id}.docx",
+            title: "RAPIDSAPI",
+            source: "RAPIDSAPI"
+          )
+
+          pdf&.data_imports&.create!(occupation_standard: occupation_standard)
+        end
       end
       occupation_standard.save
     end
-  end
-
-  def process_occupation_standard(occupation_standard_response)
-    find_occupation_standard(occupation_standard_response) ||
-      RAPIDS::OccupationStandard.initialize_from_response(
-        occupation_standard_response
-      )
-  end
-
-  def find_occupation_standard(occupation_standard_response)
-    ::OccupationStandard.includes(:organization).find_by(
-      title: fix_encoding(occupation_standard_response["occupationTitle"]),
-      organization: {
-        title: occupation_standard_response["sponsorName"]
-      }
-    )
   end
 
   def process_work_processes(work_processes_response, occupation_standard)

--- a/app/models/rapids/occupation_standard.rb
+++ b/app/models/rapids/occupation_standard.rb
@@ -9,11 +9,12 @@ module RAPIDS
     class << self
       include Sanitizable
 
-      def initialize_from_response(response)
+      def find_or_initialize_from_response(response)
         rapids_code = sanitize_rapids_code(response["rapidsCode"])
         onet_code = response["onetSocCode"]
         title = fix_encoding(response["occupationTitle"])
-        ::OccupationStandard.new(
+        occupation_standard = occupation_standard(response)
+        occupation_standard.assign_attributes(
           title: title,
           onet_code: onet_code,
           rapids_code: rapids_code,
@@ -26,9 +27,23 @@ module RAPIDS
           external_id: extract_wps_id(response["wpsDocument"]),
           registration_date: response["createdDt"]
         )
+        occupation_standard
       end
 
       private
+
+      def occupation_standard(response)
+        find_occupation_standard(response) || ::OccupationStandard.new
+      end
+
+      def find_occupation_standard(response)
+        ::OccupationStandard.includes(:organization).find_by(
+          title: fix_encoding(response["occupationTitle"]),
+          organization: {
+            title: response["sponsorName"]
+          }
+        )
+      end
 
       def ojt_type(occ_type)
         OCC_TYPE_MAPPING[occ_type]

--- a/spec/models/rapids/occupation_standard_spec.rb
+++ b/spec/models/rapids/occupation_standard_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
     it "returns occupation standard with correct data" do
       occupation_standard_response = create(:rapids_api_occupation_standard)
 
-      occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+      occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
       expect(occupation_standard.title).to eq occupation_standard_response["occupationTitle"]
       expect(occupation_standard.onet_code).to eq occupation_standard_response["onetSocCode"]
@@ -20,7 +20,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           occupationTitle: "\xA0ALARM OPERATOR (Gov Serv) (0870HYV1) Hybrid"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.title).to eq "ALARM OPERATOR (Gov Serv) (0870HYV1) Hybrid"
       end
@@ -33,7 +33,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           occType: "Hybrid"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.ojt_type).to eq "hybrid"
       end
@@ -44,7 +44,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           occType: "Time-Based"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.ojt_type).to eq "time"
       end
@@ -55,7 +55,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           occType: "Competency-Based"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.ojt_type).to eq "competency"
       end
@@ -71,7 +71,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
             sponsorNumber: ""
           )
 
-          occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+          occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
           expect(occupation_standard.registration_agency).to eq registration_agency_for_national_standard
         end
@@ -87,7 +87,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
             sponsorNumber: "2019-CA-73347"
           )
 
-          occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+          occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
           expect(occupation_standard.registration_agency).to eq oa_registration_agency_for_california
         end
@@ -102,7 +102,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
             sponsorNumber: "2019-ZA-73347"
           )
 
-          occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+          occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
           expect(occupation_standard.registration_agency).to eq registration_agency_for_national_standard
         end
@@ -117,7 +117,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
             sponsorNumber: "2019-73347"
           )
 
-          occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+          occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
           expect(occupation_standard.registration_agency).to eq registration_agency_for_national_standard
         end
@@ -131,7 +131,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           rapidsCode: "0870CB"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.rapids_code).to eq "0870"
       end
@@ -146,7 +146,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           rapidsCode: "0221"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.occupation).to eq occupation
       end
@@ -159,7 +159,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           rapidsCode: "0221CB"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.occupation).to eq occupation
       end
@@ -170,7 +170,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           rapidsCode: ""
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.occupation).to be_nil
       end
@@ -181,7 +181,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           rapidsCode: "0221CB"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.occupation).to be_nil
       end
@@ -196,7 +196,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
             onetSocCode: onet.code
           )
 
-          occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+          occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
           expect(occupation_standard.occupation).to eq occupation
         end
@@ -207,7 +207,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
             onetSocCode: "47-2121.00"
           )
 
-          occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+          occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
           expect(occupation_standard.occupation).to be_nil
         end
@@ -219,7 +219,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           wpsDocument: "https://entbpmpstg.dol.gov/suite/webapi/rapids/data-sharing/documents/wps/111111"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         expect(occupation_standard.external_id).to eq "111111"
       end
@@ -236,7 +236,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           sponsorNumber: "2019-73347"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         organization = occupation_standard.organization
         expect(organization.title).to eq "thoughtbot"
@@ -258,7 +258,7 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           sponsorNumber: "2019-73347"
         )
 
-        occupation_standard = RAPIDS::OccupationStandard.initialize_from_response(occupation_standard_response)
+        occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
 
         organization = occupation_standard.organization
         expect(organization.title).to eq "thoughtbot"
@@ -266,6 +266,36 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
         occupation_standard.save!
 
         expect(Organization.count).to eq 1
+      end
+    end
+
+    context "when occupation_standard is persisted" do
+      it "updates any occupation_standard attributes that have changed" do
+        registration_agency = create(:registration_agency, :for_national_program)
+        organization = create(:organization, title: "thoughtbot")
+        occupation_standard = create(
+          :occupation_standard,
+          title: "Developer",
+          registration_agency_id: registration_agency.id,
+          organization: organization,
+          registration_date: nil)
+
+        occupation_standard_response = create(
+          :rapids_api_occupation_standard,
+          :hybrid,
+          occupationTitle: "Developer",
+          sponsorName: "thoughtbot",
+          sponsorNumber: "2019-73347",
+          createdDt: "2024-06-13"
+        )
+
+        expect(occupation_standard.registration_date).to be(nil)
+
+        updated_occupation_standard = RAPIDS::OccupationStandard.find_or_initialize_from_response(occupation_standard_response)
+
+        updated_occupation_standard.save!
+
+        expect(occupation_standard.reload.registration_date).to eq(occupation_standard_response["createdDt"].to_date)
       end
     end
   end

--- a/spec/models/rapids/occupation_standard_spec.rb
+++ b/spec/models/rapids/occupation_standard_spec.rb
@@ -278,7 +278,8 @@ RSpec.describe RAPIDS::OccupationStandard, type: :model do
           title: "Developer",
           registration_agency_id: registration_agency.id,
           organization: organization,
-          registration_date: nil)
+          registration_date: nil
+        )
 
         occupation_standard_response = create(
           :rapids_api_occupation_standard,


### PR DESCRIPTION
* In a previous commit we added the createdDt from the RAPIDS API to the occupation_standard registration_date attribute. The job to import data from RAPIDS skips the occupation_standard if it's already persisted.
* Update the code so it finds or initializes the occupation_standard and calls save on it. In the event of nothing changing on a already persisted occupation_standard save will be a no-op since it checks if any of the attributes have changed before attempting to persist the changes.
* https://app.asana.com/0/1203289004376659/1207562844387223/f

[Asana ticket](#)
