### PR TITLE
Add rake task for running the RAPIDS data import

### DIFF
--- a/lib/tasks/rapids.rake
+++ b/lib/tasks/rapids.rake
@@ -1,0 +1,6 @@
+namespace :rapids do
+  task import_data: :environment do
+    puts "Running import data from RAPIDS job"
+    ImportDataFromRAPIDSJob.perform_later
+  end
+end


### PR DESCRIPTION
* We want to be able to schedule a task to run the RAPIDS import job weekly.
* Add rake task to run ImportDataFromRAPIDSJob
* https://app.asana.com/0/1203289004376659/1207562844387220/f

[Asana ticket](#)
