### PR TITLE
Allow converters to archive imports

### DIFF
--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -7,19 +7,30 @@
 
   <div>
     <% if page.resource.is_a?(Imports::Pdf) %>
-      <%= if current_user.converter?
-            button_to(
-              "Needs support",
-              admin_import_path(page.resource),
-              params: {
-                imports_pdf: {status: "needs_support"},
-                redirect_back_to: admin_import_path(page.resource)
-              },
-              method: :patch,
-              class: "button",
-              form_class: "form-button"
-            )
-          end %>
+      <% if current_user.converter? %>
+            <%= button_to(
+                  "Needs support",
+                  admin_import_path(page.resource),
+                  params: {
+                    imports_pdf: {status: "needs_support"},
+                    redirect_back_to: admin_import_path(page.resource)
+                  },
+                  method: :patch,
+                  class: "button",
+                  form_class: "form-button"
+                ) %>
+            <%= button_to(
+                  "Archive",
+                  admin_import_path(page.resource),
+                  params: {
+                    imports_pdf: {status: "archived"},
+                    redirect_back_to: admin_import_path(page.resource)
+                  },
+                  method: :patch,
+                  class: "button",
+                  form_class: "form-button"
+                ) %>
+        <% end %>
 
       <%= link_to(
             "New data import",

--- a/spec/system/admin/imports/show_spec.rb
+++ b/spec/system/admin/imports/show_spec.rb
@@ -81,6 +81,25 @@ RSpec.describe "admin/imports/show", :admin do
         stub_feature_flag(:show_imports_in_administrate, false)
       end
 
+      it "has button for archiving" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin, :converter)
+        import = create(:imports_pdf, status: :pending)
+
+        login_as admin
+        visit admin_import_path(import)
+
+        expect(page).to have_button "Archive"
+
+        click_on "Archive"
+
+        expect(page).to have_text "archived"
+        expect(import.reload).to be_archived
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+
       it "can view the associated occupation standards" do
         stub_feature_flag(:show_imports_in_administrate, true)
         stub_feature_flag(:similar_programs_elasticsearch, false)


### PR DESCRIPTION
* Converters need to be able to archive imports.
* Add archive button to admin imports page
* https://app.asana.com/0/1203289004376659/1207489892416900/f

[Asana ticket](#)
