### PR TITLE
Add copy to remind converters to only use tabs they want to override

### DIFF
--- a/app/views/admin/data_imports/new.html.erb
+++ b/app/views/admin/data_imports/new.html.erb
@@ -13,6 +13,11 @@
 </header>
 
 <section aria-labelledby="title_id" class="main-content__body">
+  <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4" role="alert">
+    <p class="font-bold">Read Carefully</p>
+    <p>If you want to override only some of the data, make sure the rows in the tabs you want to keep are empty</p>
+    <p>i.e. just you want to add Related Instructions to a RAPIDS Occupation Standard that already has Work Processes, make the Work Processes tab in Excel empty and only provide the data for Related Instructions tab</p>
+  </div>
   <% if Flipper.enabled?(:show_imports_in_administrate) %>
     <%= render "form_new", page: page %>
   <% else %>

--- a/spec/system/admin/data_imports/new_spec.rb
+++ b/spec/system/admin/data_imports/new_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe "admin/data_imports/new" do
     within("h1") do
       expect(page).to have_content("Import data for pixel1x1.pdf")
     end
+    # binding.irb
+    expect(page).to have_alert, text: "Read Carefully"
+
     expect(page).to have_link("import template", href: "https://www.notion.so/888b37991598495cb22d0dabc08ae3b2?v=f29055b156fa471ea9c30e9467238e66")
     expect(page).to have_link("ApprenticeshipStandards Notion", href: "https://www.notion.so/Instructions-060de1705e7d471fa8bee7a7c535a2d6")
 


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1207499740001694/f)

![image](https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1335038/7b477aef-bac7-434e-b1e0-4246efe1a6c2)
