### PR TITLE
Show PDF cousins on admin show page

### DIFF
--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -16,6 +16,7 @@ class ImportDashboard < Administrate::BaseDashboard
     file: Field::ActiveStorage,
     filename: Field::String.with_options(searchable: false),
     parent: Field::Polymorphic,
+    cousins: Field::String.with_options(searchable: false),
     import: Field::BelongsTo,
     imports: Field::HasMany,
     processed_at: Field::DateTime,
@@ -66,6 +67,7 @@ class ImportDashboard < Administrate::BaseDashboard
     processing_errors
     courtesy_notification
     parent
+    cousins
     import
     imports
     created_at

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -42,4 +42,8 @@ class Import < ApplicationRecord
   def import_root
     parent.import_root
   end
+
+  def docx_listing_root
+    parent.docx_listing_root
+  end
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -46,4 +46,9 @@ class Import < ApplicationRecord
   def docx_listing_root
     parent.docx_listing_root
   end
+
+  # For Administrate
+  def cousins
+    []
+  end
 end

--- a/app/models/imports/docx_listing.rb
+++ b/app/models/imports/docx_listing.rb
@@ -47,6 +47,10 @@ module Imports
       raise Imports::NoPdfLeafError, "#{self.class.name} records do not have a PDF leaf"
     end
 
+    def pdf_leaves
+      imports.map(&:pdf_leaf)
+    end
+
     # For Administrate
     def import
     end

--- a/app/models/imports/docx_listing.rb
+++ b/app/models/imports/docx_listing.rb
@@ -48,7 +48,7 @@ module Imports
     end
 
     def pdf_leaves
-      imports.map(&:pdf_leaf)
+      imports.includes(:import).map(&:pdf_leaf)
     end
 
     # For Administrate

--- a/app/models/imports/docx_listing.rb
+++ b/app/models/imports/docx_listing.rb
@@ -39,6 +39,10 @@ module Imports
       raise
     end
 
+    def docx_listing_root
+      self
+    end
+
     def pdf_leaf
       raise Imports::NoPdfLeafError, "#{self.class.name} records do not have a PDF leaf"
     end

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -49,7 +49,7 @@ module Imports
 
     def cousins
       if docx_listing_root
-        docx_listing_root.pdf_leaves - [self]
+        (docx_listing_root.pdf_leaves - [self]).sort_by(&:filename)
       else
         []
       end

--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -47,6 +47,14 @@ module Imports
       self
     end
 
+    def cousins
+      if docx_listing_root
+        docx_listing_root.pdf_leaves - [self]
+      else
+        []
+      end
+    end
+
     # For Administrate
     def import
     end

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -22,6 +22,12 @@ module Imports
       raise
     end
 
+    def docx_listing_root
+      if parent.is_a?(DocxListing)
+        parent
+      end
+    end
+
     def pdf_leaf
       import&.pdf_leaf
     rescue NoPdfLeafError

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -76,7 +76,7 @@
         <% end %>
 
         <% attributes.each do |attribute| %>
-          <% next if attribute.name.match?("redacted") && !page.resource.is_a?(Imports::Pdf) %>
+          <% next if attribute.name.match?(/redacted|cousins/) && !page.resource.is_a?(Imports::Pdf) %>
           <% next if attribute.name == "import" && (page.resource.is_a?(Imports::Pdf) || page.resource.is_a?(Imports::DocxListing)) %>
           <% next if attribute.name == "imports" && !page.resource.is_a?(Imports::DocxListing) %>
           <% next if %w[courtesy_notification parent child type].include?(attribute.name) && current_user.converter? %>
@@ -93,6 +93,11 @@
                 <%= link_to "StandardsImport", admin_standards_import_path(attribute.data.id) %>
               <% else %>
                 <%= link_to attribute.data.type, admin_import_path(attribute.data.id) %>
+              <% end %>
+            <% elsif attribute.name == "cousins" %>
+              <% attribute.data.each do |cousin| %>
+                <%= link_to cousin.filename.to_s, admin_import_path(cousin) %>
+                <br>
               <% end %>
             <% elsif attribute.name == "import" %>
               <% if attribute.data %>

--- a/spec/models/imports/doc_spec.rb
+++ b/spec/models/imports/doc_spec.rb
@@ -64,6 +64,26 @@ RSpec.describe Imports::Doc, type: :model do
     end
   end
 
+  describe "#docx_listing_root" do
+    it "when bulletin, retrieves the docx_listing ancestor" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx_listing = create(:imports_docx_listing, parent: uncat)
+      uncat2 = create(:imports_uncategorized, parent: docx_listing)
+      doc = create(:imports_doc, parent: uncat2)
+
+      expect(doc.docx_listing_root).to eq docx_listing
+    end
+
+    it "when not bulletin, returns nil" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      doc = create(:imports_doc, parent: uncat)
+
+      expect(doc.docx_listing_root).to be_nil
+    end
+  end
+
   describe "#pdf_leaf" do
     context "when pdf exists" do
       it "returns the Imports::Pdf record" do

--- a/spec/models/imports/doc_spec.rb
+++ b/spec/models/imports/doc_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Imports::Doc, type: :model do
   end
 
   describe "#docx_listing_root" do
-    it "when bulletin, retrieves the docx_listing ancestor" do
+    it "when descended from bulletin, retrieves the docx_listing ancestor" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       docx_listing = create(:imports_docx_listing, parent: uncat)
@@ -75,7 +75,7 @@ RSpec.describe Imports::Doc, type: :model do
       expect(doc.docx_listing_root).to eq docx_listing
     end
 
-    it "when not bulletin, returns nil" do
+    it "when not descended from bulletin, returns nil" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       doc = create(:imports_doc, parent: uncat)

--- a/spec/models/imports/docx_listing_spec.rb
+++ b/spec/models/imports/docx_listing_spec.rb
@@ -99,4 +99,23 @@ RSpec.describe Imports::DocxListing, type: :model do
       }.to raise_error(Imports::NoPdfLeafError, "Imports::DocxListing records do not have a PDF leaf")
     end
   end
+
+  describe "#pdf_leaves" do
+    it "returns all the pdf descendants" do
+      docx_listing = create(:imports_docx_listing)
+      uncat1 = create(:imports_uncategorized, parent: docx_listing)
+      uncat2 = create(:imports_uncategorized, parent: docx_listing)
+      uncat3 = create(:imports_uncategorized, parent: docx_listing)
+
+      doc = create(:imports_doc, parent: uncat1)
+      pdf1 = create(:imports_pdf, parent: doc)
+
+      docx = create(:imports_docx, parent: uncat2)
+      pdf2 = create(:imports_pdf, parent: docx)
+
+      pdf3 = create(:imports_pdf, parent: uncat3)
+
+      expect(docx_listing.pdf_leaves).to contain_exactly(pdf1, pdf2, pdf3)
+    end
+  end
 end

--- a/spec/models/imports/docx_listing_spec.rb
+++ b/spec/models/imports/docx_listing_spec.rb
@@ -80,6 +80,16 @@ RSpec.describe Imports::DocxListing, type: :model do
     end
   end
 
+  describe "#docx_listing_root" do
+    it "returns self" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx_listing = create(:imports_docx_listing, parent: uncat)
+
+      expect(docx_listing.docx_listing_root).to eq docx_listing
+    end
+  end
+
   describe "#pdf_leaf" do
     it "raises a not implemented error" do
       docx_listing = create(:imports_docx_listing)

--- a/spec/models/imports/docx_spec.rb
+++ b/spec/models/imports/docx_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Imports::Docx, type: :model do
   end
 
   describe "#docx_listing_root" do
-    it "when bulletin, retrieves the docx_listing ancestor" do
+    it "when descended from bulletin, retrieves the docx_listing ancestor" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       docx_listing = create(:imports_docx_listing, parent: uncat)
@@ -74,7 +74,7 @@ RSpec.describe Imports::Docx, type: :model do
       expect(docx.docx_listing_root).to eq docx_listing
     end
 
-    it "when not bulletin, returns nil" do
+    it "when not descended from bulletin, returns nil" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       docx = create(:imports_docx, parent: uncat)

--- a/spec/models/imports/docx_spec.rb
+++ b/spec/models/imports/docx_spec.rb
@@ -63,6 +63,26 @@ RSpec.describe Imports::Docx, type: :model do
     end
   end
 
+  describe "#docx_listing_root" do
+    it "when bulletin, retrieves the docx_listing ancestor" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx_listing = create(:imports_docx_listing, parent: uncat)
+      uncat2 = create(:imports_uncategorized, parent: docx_listing)
+      docx = create(:imports_docx, parent: uncat2)
+
+      expect(docx.docx_listing_root).to eq docx_listing
+    end
+
+    it "when not bulletin, returns nil" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx = create(:imports_docx, parent: uncat)
+
+      expect(docx.docx_listing_root).to be_nil
+    end
+  end
+
   describe "#pdf_leaf" do
     context "when pdf exists" do
       it "returns the Imports::Pdf record" do

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -169,14 +169,14 @@ RSpec.describe Imports::Pdf, type: :model do
         uncat3 = create(:imports_uncategorized, parent: docx_listing)
 
         doc = create(:imports_doc, parent: uncat1)
-        pdf1 = create(:imports_pdf, parent: doc)
+        pdf1 = create(:imports_pdf, parent: doc, file: Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1_redacted.pdf"), "application/pdf"))
 
         docx = create(:imports_docx, parent: uncat2)
         pdf2 = create(:imports_pdf, parent: docx)
 
-        pdf3 = create(:imports_pdf, parent: uncat3)
+        pdf3 = create(:imports_pdf, parent: uncat3, file: Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "pixel1x1.pdf"), "application/pdf"))
 
-        expect(pdf2.cousins).to contain_exactly(pdf1, pdf3)
+        expect(pdf2.cousins).to eq [pdf3, pdf1]
       end
 
       it "when only 1 document in bulletin returns empty array" do

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Imports::Pdf, type: :model do
   end
 
   describe "#docx_listing_root" do
-    it "when bulletin, retrieves the docx_listing ancestor" do
+    it "when descended from bulletin, retrieves the docx_listing ancestor" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       docx_listing = create(:imports_docx_listing, parent: uncat)
@@ -142,7 +142,7 @@ RSpec.describe Imports::Pdf, type: :model do
       expect(pdf.docx_listing_root).to eq docx_listing
     end
 
-    it "when not bulletin, returns nil" do
+    it "when not descended from bulletin, returns nil" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       doc = create(:imports_doc, parent: uncat)

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -130,6 +130,28 @@ RSpec.describe Imports::Pdf, type: :model do
     end
   end
 
+  describe "#docx_listing_root" do
+    it "when bulletin, retrieves the docx_listing ancestor" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx_listing = create(:imports_docx_listing, parent: uncat)
+      uncat2 = create(:imports_uncategorized, parent: docx_listing)
+      doc = create(:imports_doc, parent: uncat2)
+      pdf = create(:imports_pdf, parent: doc)
+
+      expect(pdf.docx_listing_root).to eq docx_listing
+    end
+
+    it "when not bulletin, returns nil" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      doc = create(:imports_doc, parent: uncat)
+      pdf = create(:imports_pdf, parent: doc)
+
+      expect(pdf.docx_listing_root).to be_nil
+    end
+  end
+
   describe "#pdf_leaf" do
     it "returns self" do
       pdf = create(:imports_pdf)

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -159,4 +159,45 @@ RSpec.describe Imports::Pdf, type: :model do
       expect(pdf.pdf_leaf).to eq pdf
     end
   end
+
+  describe "#cousins" do
+    context "when descended from bulletin" do
+      it "returns all the pdf_leaves of the docx_listing ancestor, excluding self" do
+        docx_listing = create(:imports_docx_listing)
+        uncat1 = create(:imports_uncategorized, parent: docx_listing)
+        uncat2 = create(:imports_uncategorized, parent: docx_listing)
+        uncat3 = create(:imports_uncategorized, parent: docx_listing)
+
+        doc = create(:imports_doc, parent: uncat1)
+        pdf1 = create(:imports_pdf, parent: doc)
+
+        docx = create(:imports_docx, parent: uncat2)
+        pdf2 = create(:imports_pdf, parent: docx)
+
+        pdf3 = create(:imports_pdf, parent: uncat3)
+
+        expect(pdf2.cousins).to contain_exactly(pdf1, pdf3)
+      end
+
+      it "when only 1 document in bulletin returns empty array" do
+        docx_listing = create(:imports_docx_listing)
+        uncat = create(:imports_uncategorized, parent: docx_listing)
+        doc = create(:imports_doc, parent: uncat)
+        pdf = create(:imports_pdf, parent: doc)
+
+        expect(pdf.cousins).to be_empty
+      end
+    end
+
+    context "when not descended from bulletin" do
+      it "returns empty array" do
+        standards_import = create(:standards_import)
+        uncat = create(:imports_uncategorized, parent: standards_import)
+        doc = create(:imports_doc, parent: uncat)
+        pdf = create(:imports_pdf, parent: doc)
+
+        expect(pdf.cousins).to be_empty
+      end
+    end
+  end
 end

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -153,6 +153,24 @@ RSpec.describe Imports::Uncategorized, type: :model do
     end
   end
 
+  describe "#docx_listing_root" do
+    it "when bulletin, retrieves the docx_listing ancestor" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      docx_listing = create(:imports_docx_listing, parent: uncat)
+      uncat2 = create(:imports_uncategorized, parent: docx_listing)
+
+      expect(uncat2.docx_listing_root).to eq docx_listing
+    end
+
+    it "when not bulletin, returns nil" do
+      standards_import = create(:standards_import)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+
+      expect(uncat.docx_listing_root).to be_nil
+    end
+  end
+
   describe "#transfer_source_file_data!" do
     it "transfers the status to the pdf leaf" do
       source_file = create(:source_file, status: :completed)

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Imports::Uncategorized, type: :model do
   end
 
   describe "#docx_listing_root" do
-    it "when bulletin, retrieves the docx_listing ancestor" do
+    it "when descended from bulletin, retrieves the docx_listing ancestor" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
       docx_listing = create(:imports_docx_listing, parent: uncat)
@@ -163,7 +163,7 @@ RSpec.describe Imports::Uncategorized, type: :model do
       expect(uncat2.docx_listing_root).to eq docx_listing
     end
 
-    it "when not bulletin, returns nil" do
+    it "when not descended from bulletin, returns nil" do
       standards_import = create(:standards_import)
       uncat = create(:imports_uncategorized, parent: standards_import)
 


### PR DESCRIPTION
The majority of bulletins have either a single standard with some accompanying other files which can be discarded, or there are multiple standards within one bulletin. For some cases however, particularly with older bulletins, the work processes and the related instructions are in two separate attachments. With the new tree structure, this means that those two files will not be connected at all, and it won't be possible to create a single standard. To fix this, this change adds a "Cousins" field to the `Imports::Pdf` show view, which will show all the other extracted PDF documents from a bulletin. 

<img width="929" alt="Screenshot 2024-06-18 at 4 21 00 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/91ee5c40-bad1-40fb-88a3-94849ccdc5cf">


[Asana ticket](https://app.asana.com/0/1203289004376659/1207499740001692/f)
