### PR TITLE
Do not show Redact button unless it matches criteria

### DIFF
--- a/app/models/imports/pdf.rb
+++ b/app/models/imports/pdf.rb
@@ -55,6 +55,10 @@ module Imports
       end
     end
 
+    def available_for_redaction?
+      !public_document? && completed?
+    end
+
     # For Administrate
     def import
     end

--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -38,9 +38,9 @@
             class: "button"
           ) %>
 
-      <%= if accessible_action?(:redact_file, :new)
+      <%= if accessible_action?(:redact_file, :new) && page.resource.available_for_redaction?
             link_to(
-              "Redact document",
+              "Redact document xxx",
               new_admin_import_redact_file_path(page.resource),
               class: "button"
             )

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -200,4 +200,24 @@ RSpec.describe Imports::Pdf, type: :model do
       end
     end
   end
+
+  describe "#available_for_redaction?" do
+    it "returns true when import is not public document and completed" do
+      pdf = create(:imports_pdf, public_document: false, status: :completed)
+
+      expect(pdf.available_for_redaction?).to be true
+    end
+
+    it "returns false when import is not public document but pending" do
+      pdf = create(:imports_pdf, public_document: false, status: :pending)
+
+      expect(pdf.available_for_redaction?).to be false
+    end
+
+    it "returns false when import is public document and completed" do
+      pdf = create(:imports_pdf, public_document: true, status: :completed)
+
+      expect(pdf.available_for_redaction?).to be false
+    end
+  end
 end

--- a/spec/system/admin/imports/show_spec.rb
+++ b/spec/system/admin/imports/show_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "admin/imports/show", :admin do
         expect(page).to have_text "Imports::Pdf"
         expect(page).to_not have_button "Needs support"
         expect(page).to have_link "New data import", href: new_admin_import_data_import_path(import)
-        expect(page).to have_link "Redact document", href: new_admin_import_redact_file_path(import)
+        expect(page).to_not have_link "Redact document", href: new_admin_import_redact_file_path(import)
         expect(page).to have_link "Edit", href: edit_admin_import_path(import)
         expect(page).to have_link "Destroy"
         expect(page).to have_text "Data import"
@@ -24,6 +24,22 @@ RSpec.describe "admin/imports/show", :admin do
         expect(page).to have_text "Associated occupation standards"
 
         stub_feature_flag(:show_imports_in_administrate, false)
+      end
+
+      context "when import is not public document and completed" do
+        it "shows redact document link" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin)
+          import = create(:imports_pdf, public_document: false, status: :completed)
+
+          login_as admin
+          visit admin_import_path(import)
+
+          expect(page).to have_link "Redact document", href: new_admin_import_redact_file_path(import)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
       end
 
       it "allows admin to remove a redacted file" do
@@ -63,7 +79,7 @@ RSpec.describe "admin/imports/show", :admin do
 
         expect(page).to have_button "Needs support"
         expect(page).to have_link "New data import", href: new_admin_import_data_import_path(import)
-        expect(page).to have_link "Redact document", href: new_admin_import_redact_file_path(import)
+        expect(page).to_not have_link "Redact document", href: new_admin_import_redact_file_path(import)
         expect(page).to have_text "Data imports"
         expect(page).to_not have_link "Edit", href: edit_admin_import_path(import)
         expect(page).to_not have_link "Destroy"
@@ -79,6 +95,22 @@ RSpec.describe "admin/imports/show", :admin do
         expect(import.reload).to be_needs_support
 
         stub_feature_flag(:show_imports_in_administrate, false)
+      end
+
+      context "when import is not public document and completed" do
+        it "shows redact document link" do
+          stub_feature_flag(:show_imports_in_administrate, true)
+
+          admin = create(:admin, :converter)
+          import = create(:imports_pdf, public_document: false, status: :completed)
+
+          login_as admin
+          visit admin_import_path(import)
+
+          expect(page).to have_link "Redact document", href: new_admin_import_redact_file_path(import)
+
+          stub_feature_flag(:show_imports_in_administrate, false)
+        end
       end
 
       it "has button for archiving" do


### PR DESCRIPTION
Only show redact button for PDFs when document is not public and already completed



[Asana ticket](https://app.asana.com/0/1203289004376659/1207439839440175/f)
