### PR TITLE
DataImport warning to mention Details tab should be empty

### DIFF
--- a/app/views/admin/data_imports/new.html.erb
+++ b/app/views/admin/data_imports/new.html.erb
@@ -15,8 +15,8 @@
 <section aria-labelledby="title_id" class="main-content__body">
   <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4" role="alert">
     <p class="font-bold">Read Carefully</p>
-    <p>If you want to override only some of the data, make sure the rows in the tabs you want to keep are empty</p>
-    <p>i.e. just you want to add Related Instructions to a RAPIDS Occupation Standard that already has Work Processes, make the Work Processes tab in Excel empty and only provide the data for Related Instructions tab</p>
+    <p>If you want to override only some of the data, make sure the rows in the tabs you want to keep are empty.</p>
+    <p>For example, if you just want to add Related Instructions to a RAPIDS Occupation Standard that already has Work Processes, make sure the Details tab and the Work Processes tab in Excel only contain the header row, and only provide data for the Related Instructions tab.</p>
   </div>
   <% if Flipper.enabled?(:show_imports_in_administrate) %>
     <%= render "form_new", page: page %>


### PR DESCRIPTION
This adds a bit of clarity that the Details
tab that defines the occupation standard
itself should also be blank when adding
related instructions to an existing
standard.

**Old**
<img width="1352" alt="Screenshot 2024-06-20 at 9 38 15 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/89d45d66-c669-4f7d-8171-2d09ee57de43">

**New**
<img width="1342" alt="Screenshot 2024-06-20 at 9 38 40 AM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/2d2ba7f6-7448-423e-ac10-141370be0a96">


[Asana ticket](https://app.asana.com/0/1203289004376659/1207167427906520/f)
