### PR TITLE
Wait until link is available before getting file href

### DIFF
--- a/app/jobs/scraper/washington_job.rb
+++ b/app/jobs/scraper/washington_job.rb
@@ -40,13 +40,13 @@ class Scraper::WashingtonJob < Scraper::WatirJob
       program_link = url_base + "#/program-details?programId=#{id}&from=%2Fprogram-search"
       browser.goto(program_link)
       browser.refresh
-      file = browser.a(text: "Review the Program Standards").href
-      file_path = file.gsub("https://", "")
+      link = browser.a(text: "Review the Program Standards").wait_until(&:present?)
+      file = link.href
       organization = browser.h3(class: "lni-u-heading--3").text
 
       begin
         CreateImportFromUri.call(
-          uri: "https://#{file_path}",
+          uri: file,
           title: organization,
           notes: "From Scraper::WashingtonJob",
           source: program_link


### PR DESCRIPTION
Some of the Washington Scraper links were
failing because they weren't waiting for
the href to be defined (these were getting
returned as:
https://secure.lni.wa.gov/arts-public/undefined),
but others are failing because the actual
href is bad. These are getting returned as:
https://secure.lni.wa.gov/arts-public/null

[Asana ticket](https://app.asana.com/0/1203289004376659/1207484648105648/f)
