### PR TITLE
Fix trade URL link for Oregons Scraper job

### DIFF
--- a/app/jobs/scraper/oregon_job.rb
+++ b/app/jobs/scraper/oregon_job.rb
@@ -11,9 +11,10 @@ class Scraper::OregonJob < Scraper::WatirJob
     body = Nokogiri::HTML(js_doc.inner_html)
 
     body.css("tr").each do |row|
-      title = row.css("td").first.content
+      details_td = row.css("td").last
+      file_path = details_td.css("a").last["href"]
 
-      browser.goto(apprenticeship_url + "trade-details.aspx?trade=" + title)
+      browser.goto(base + file_path)
       next if browser.element(css: "div.alert.alert-warning").present?
 
       programs = browser.element(css: "tbody").wait_until(&:present?)
@@ -24,7 +25,7 @@ class Scraper::OregonJob < Scraper::WatirJob
         program_path = row.css("td > a").first["href"]
 
         browser.goto(base + program_path)
-        next unless browser.element(css: "#primaryContent.col-md-12").present?
+        next unless browser.element(css: "#primaryContent").present?
 
         standards = browser.element(css: "tbody").wait_until(&:present?)
         standards_table = Nokogiri::HTML(standards.inner_html)


### PR DESCRIPTION
This makes sure to grab the actual URL for the standards page, rather than composing it from the title, as the title and URL do not always match.

[Asana ticket](https://app.asana.com/0/1203289004376659/1207349366734015/f)
