### PR TITLE
Fix broken DataImport edit page

### DIFF
--- a/app/controllers/admin/data_imports_controller.rb
+++ b/app/controllers/admin/data_imports_controller.rb
@@ -64,10 +64,16 @@ module Admin
     private
 
     def set_parent
-      @parent = if Flipper.enabled?(:show_imports_in_administrate)
-        Imports::Pdf.find(params[:import_id])
+      if Flipper.enabled?(:show_imports_in_administrate)
+        @parent = Imports::Pdf.find_by(id: params[:import_id])
+        if @parent.nil?
+          @parent = requested_resource.import
+        end
       else
-        SourceFile.find(params[:source_file_id])
+        @parent = SourceFile.find_by(id: params[:source_file_id])
+        if @parent.nil?
+          @parent = requested_resource.source_file
+        end
       end
     end
 

--- a/app/views/admin/data_imports/_collection_item_actions.html.erb
+++ b/app/views/admin/data_imports/_collection_item_actions.html.erb
@@ -1,9 +1,19 @@
 <% if existing_action?(collection_presenter.resource_name, :edit) %>
-  <td><%= if accessible_action?(resource, :edit)
-            link_to(
-              t("administrate.actions.edit"),
-              [:edit, namespace, resource.source_file, resource],
-              class: "action-edit"
-            )
-          end %></td>
+  <% if Flipper.enabled?(:show_imports_in_administrate) %>
+    <td><%= if accessible_action?(resource, :edit)
+              link_to(
+                t("administrate.actions.edit"),
+                edit_admin_import_data_import_path(resource.import, resource),
+                class: "action-edit"
+              )
+            end %></td>
+  <% else %>
+    <td><%= if accessible_action?(resource, :edit)
+              link_to(
+                t("administrate.actions.edit"),
+                [:edit, namespace, resource.source_file, resource],
+                class: "action-edit"
+              )
+            end %></td>
+  <% end %>
 <% end %>

--- a/spec/system/admin/data_imports/show_spec.rb
+++ b/spec/system/admin/data_imports/show_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "admin/data_imports/show" do
-  context "with import feature flag" do 
+  context "with import feature flag" do
     it "has Edit Data Import button with correct link", :admin, :js do
       stub_feature_flag(:show_imports_in_administrate, true)
 

--- a/spec/system/admin/data_imports/show_spec.rb
+++ b/spec/system/admin/data_imports/show_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "admin/data_imports/show" do
+  context "with import feature flag" do 
+    it "has Edit Data Import button with correct link", :admin, :js do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
+      admin = create(:admin)
+      import = create(:imports_pdf)
+      data_import = create(:data_import, import: import, source_file: nil)
+
+      login_as admin
+      visit admin_data_import_path(data_import)
+
+      expect(page).to have_link "Edit #{data_import.file.filename}", href: edit_admin_data_import_path(data_import)
+
+      click_on "Edit #{data_import.file.filename}"
+
+      expect(page).to have_text "The file imported on this screen should be based on"
+    end
+  end
+end

--- a/spec/system/admin/imports/show_spec.rb
+++ b/spec/system/admin/imports/show_spec.rb
@@ -26,6 +26,22 @@ RSpec.describe "admin/imports/show", :admin do
         stub_feature_flag(:show_imports_in_administrate, false)
       end
 
+      it "displays data imports with the correct link" do
+        stub_feature_flag(:show_imports_in_administrate, true)
+
+        admin = create(:admin)
+        import = create(:imports_pdf)
+        data_import = create(:data_import, import: import)
+
+        login_as admin
+        visit admin_import_path(import)
+
+        expect(page).to have_text "occupation-standards-template.xlsx"
+        expect(page).to have_link "Edit", href: edit_admin_import_data_import_path(import, data_import)
+
+        stub_feature_flag(:show_imports_in_administrate, false)
+      end
+
       context "when import is not public document and completed" do
         it "shows redact document link" do
           stub_feature_flag(:show_imports_in_administrate, true)


### PR DESCRIPTION
It seems like there is some
weirdness with the Administrate
has_many links sometimes being
nested and sometimes not. It will
be easier to investigate and clean
this up once the SourceFile has
been completely removed.

[Asana ticket](https://app.asana.com/0/1203289004376659/1207636165007789/f)
