### PR TITLE
Change a blank space to underscore in file url for Oregon Scraper job

### DIFF
--- a/app/jobs/scraper/oregon_job.rb
+++ b/app/jobs/scraper/oregon_job.rb
@@ -31,7 +31,7 @@ class Scraper::OregonJob < Scraper::WatirJob
         standards_table = Nokogiri::HTML(standards.inner_html)
         standards_table.css("tr").each do |row|
           file = row.css("td > a").first
-          file_path = file["href"]
+          file_path = file["href"].tr(" ", "_")
 
           CreateImportFromUri.call(
             uri: base + file_path,


### PR DESCRIPTION
Had file URL come in as:
`https://www.oregon.gov/boli/apprenticeship/Standards/7001 0159.0.pdf`
and adding the underscore fixed the
URL. Adding `+` or `%20` as a replacement
resulted in a 404.

[Rollbar](https://app.rollbar.com/a/apprenticeship-standards-dot-o/fix/item/apprenticeship-standards-dot-o/412/occurrence/409343929924)
