### PR TITLE
Fix the file input styling on Administrate

### DIFF
--- a/app/assets/stylesheets/administrate_customizations.scss
+++ b/app/assets/stylesheets/administrate_customizations.scss
@@ -15,6 +15,17 @@ so reinstate initial behavior */
     background-color: #fff;
     color: #000;
   }
+
+  input[type="file"] {
+    background-color: #fff;
+    color: #000;
+    border: 1px solid black;
+
+    &:hover {
+      background-color: #eee;
+      color: #000;
+    }
+  }
 }
 
 .field-unit--last_file_notice {


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1207636168287174/f)

**Before**

<img width="1078" alt="Screenshot 2024-06-25 at 1 35 26 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/ff6bc091-6aad-43bc-b571-86839e8bef94">

**After**
<img width="1099" alt="Screenshot 2024-06-25 at 1 35 54 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/479af0d0-ce3f-49f0-8dd7-2c7edd605197">

**After (Hover)**
<img width="1118" alt="Screenshot 2024-06-25 at 1 36 00 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/9be22708-8211-4806-a31b-b524dde2abbb">

