### PR TITLE
Display StandardsImport notes on Pdf listing for non-public documents

### DIFF
--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -19,7 +19,7 @@ class ImportDashboard < Administrate::BaseDashboard
     cousins: Field::String.with_options(searchable: false),
     import: Field::BelongsTo,
     imports: Field::HasMany,
-    notes: Field::String,
+    notes: Field::String.with_options(searchable: false),
     processed_at: Field::DateTime,
     processing_errors: Field::Text,
     public_document: Field::Boolean,

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -19,6 +19,7 @@ class ImportDashboard < Administrate::BaseDashboard
     cousins: Field::String.with_options(searchable: false),
     import: Field::BelongsTo,
     imports: Field::HasMany,
+    notes: Field::String,
     processed_at: Field::DateTime,
     processing_errors: Field::Text,
     public_document: Field::Boolean,
@@ -57,6 +58,7 @@ class ImportDashboard < Administrate::BaseDashboard
     file
     associated_occupation_standards
     data_imports
+    notes
     status
     assignee
     metadata

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -39,6 +39,12 @@ class Import < ApplicationRecord
   def redacted_pdf_url
   end
 
+  def notes
+    if !import_root.public_document
+      import_root&.notes
+    end
+  end
+
   def import_root
     parent.import_root
   end

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -220,4 +220,26 @@ RSpec.describe Imports::Pdf, type: :model do
       expect(pdf.available_for_redaction?).to be false
     end
   end
+
+  describe "#notes" do
+    context "when standards_import is public" do
+      it "is blank" do
+        standards_import = create(:standards_import, public_document: true, notes: "from some scraper job")
+        uncat = create(:imports_uncategorized, parent: standards_import)
+        pdf = create(:imports_pdf, parent: uncat)
+
+        expect(pdf.notes).to be_blank
+      end
+    end
+
+    context "when standards_import is not public" do
+      it "returns standards_import notes" do
+        standards_import = create(:standards_import, public_document: false, notes: "Please anonymize sponsor")
+        uncat = create(:imports_uncategorized, parent: standards_import)
+        pdf = create(:imports_pdf, parent: uncat)
+
+        expect(pdf.notes).to eq "Please anonymize sponsor"
+      end
+    end
+  end
 end


### PR DESCRIPTION
For non-public documents, there may be information in the notes about how to anonymize the data,
but we are not displaying that anywhere on the `Imports::Pdf` page.

