### PR TITLE
Add organization field to imports

### DIFF
--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -10,21 +10,22 @@ class ImportDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::String,
     assignee: AssigneeField,
-    type: Field::String,
+    associated_occupation_standards: HasManyAssociatedOccupationStandardsField,
     courtesy_notification: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
-    metadata: Field::JSONB,
+    cousins: Field::String.with_options(searchable: false),
+    created_at: Field::DateTime,
+    data_imports: HasManyDataImportsField,
     file: Field::ActiveStorage,
     filename: Field::String.with_options(searchable: false),
-    parent: Field::Polymorphic,
-    cousins: Field::String.with_options(searchable: false),
     import: Field::BelongsTo,
     imports: Field::HasMany,
+    metadata: Field::JSONB,
     notes: Field::String.with_options(searchable: false),
     organization: Field::String.with_options(searchable: false),
+    parent: Field::Polymorphic,
     processed_at: Field::DateTime,
     processing_errors: Field::Text,
     public_document: Field::Boolean,
-    associated_occupation_standards: HasManyAssociatedOccupationStandardsField,
     redacted_pdf: Field::ActiveStorage.with_options(
       destroy_url: proc do |namespace, resource, attachment|
         [:redacted_import_admin_import, {attachment_id: attachment.id}]
@@ -32,8 +33,7 @@ class ImportDashboard < Administrate::BaseDashboard
     ),
     redacted_pdf_url: Field::Url.with_options(searchable: false),
     status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
-    data_imports: HasManyDataImportsField,
-    created_at: Field::DateTime,
+    type: Field::String,
     updated_at: Field::DateTime
   }.freeze
 

--- a/app/dashboards/import_dashboard.rb
+++ b/app/dashboards/import_dashboard.rb
@@ -20,6 +20,7 @@ class ImportDashboard < Administrate::BaseDashboard
     import: Field::BelongsTo,
     imports: Field::HasMany,
     notes: Field::String.with_options(searchable: false),
+    organization: Field::String.with_options(searchable: false),
     processed_at: Field::DateTime,
     processing_errors: Field::Text,
     public_document: Field::Boolean,
@@ -44,6 +45,7 @@ class ImportDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     created_at
     type
+    organization
     filename
     assignee
     public_document
@@ -59,6 +61,7 @@ class ImportDashboard < Administrate::BaseDashboard
     associated_occupation_standards
     data_imports
     notes
+    organization
     status
     assignee
     metadata

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -45,6 +45,10 @@ class Import < ApplicationRecord
     end
   end
 
+  def organization
+    import_root.organization
+  end
+
   def import_root
     parent.import_root
   end

--- a/app/views/admin/imports/_collection.html.erb
+++ b/app/views/admin/imports/_collection.html.erb
@@ -67,6 +67,7 @@ to display a collection of resources in an HTML table.
   </thead>
 
   <tbody>
+    <% resources = resources.preload(parent: :parent) %>
     <% resources.each do |resource| %>
       <tr class="js-table-row"
           <% if accessible_action?(resource, :show) %>

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -282,4 +282,26 @@ RSpec.describe Imports::Pdf, type: :model do
       expect(pdf.needs_courtesy_notification?).to be true
     end
   end
+
+  describe "#organization" do
+    context "when standards_import has organization" do
+      it "returns standards_import organization" do
+        standards_import = create(:standards_import, organization: "Urban")
+        uncat = create(:imports_uncategorized, parent: standards_import)
+        pdf = create(:imports_pdf, parent: uncat)
+
+        expect(pdf.organization).to eq "Urban"
+      end
+    end
+
+    context "when standards_import does not have organization" do
+      it "is blank" do
+        standards_import = create(:standards_import, organization: nil)
+        uncat = create(:imports_uncategorized, parent: standards_import)
+        pdf = create(:imports_pdf, parent: uncat)
+
+        expect(uncat.organization).to be_blank
+      end
+    end
+  end
 end

--- a/spec/models/imports/pdf_spec.rb
+++ b/spec/models/imports/pdf_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Imports::Pdf, type: :model do
         uncat = create(:imports_uncategorized, parent: standards_import)
         pdf = create(:imports_pdf, parent: uncat)
 
-        expect(uncat.organization).to be_blank
+        expect(pdf.organization).to be_blank
       end
     end
   end


### PR DESCRIPTION
The organization from the StandardsImport model needs to be pulled over to the Import records. This also alphabetizes the attributes in the Administrate Import dashboard.

<img width="772" alt="Screenshot 2024-06-26 at 2 55 25 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/ba79d4a9-3b25-4156-842b-3e1b278313bb">
