### PR TITLE
Modify thank you for uploading page for imports structure

### DIFF
--- a/app/controllers/standards_imports_controller.rb
+++ b/app/controllers/standards_imports_controller.rb
@@ -27,7 +27,13 @@ class StandardsImportsController < ApplicationController
   end
 
   def show
-    @standards_import = StandardsImport.includes(files_attachments: [:blob, source_file: :original_source_file]).find(params[:id])
+    # standard:disable Style/ConditionalAssignment
+    if Flipper.enabled?(:show_imports_in_administrate)
+      @standards_import = StandardsImport.includes(imports: {file_attachment: :blob}).find(params[:id])
+    else
+      @standards_import = StandardsImport.includes(files_attachments: [:blob, source_file: :original_source_file]).find(params[:id])
+    end
+    # standard:enable Style/ConditionalAssignment
   end
 
   private

--- a/app/views/standards_imports/show.html.erb
+++ b/app/views/standards_imports/show.html.erb
@@ -50,11 +50,19 @@
           </div>
           <div class="mb-4">
             <div class="show-label">Files</div>
-            <% @standards_import.files.each do |file| %>
-              <% next if file.has_linked_original_file? %>
-              <div class="w-full mb-1">
-                <%= link_to file.filename.to_s, url_for(file), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
-              </div>
+            <% if Flipper.enabled?(:show_imports_in_administrate) %>
+              <% @standards_import.imports.each do |uncat_import| %>
+                <div class="w-full mb-1">
+                  <%= link_to uncat_import.filename, url_for(uncat_import.file), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
+                </div>
+              <% end %>
+            <% else %>
+              <% @standards_import.files.each do |file| %>
+                <% next if file.has_linked_original_file? %>
+                <div class="w-full mb-1">
+                  <%= link_to file.filename.to_s, url_for(file), class: "text-blue-600 hover:text-blue-800 visited:text-purple-600" %>
+                </div>
+              <% end %>
             <% end %>
           </div>
         </div>

--- a/spec/views/standards_imports/show_spec.rb
+++ b/spec/views/standards_imports/show_spec.rb
@@ -1,22 +1,51 @@
 require "rails_helper"
 
 RSpec.describe "standards_imports/show", type: :view do
-  it "does not display files that are linked to an original file" do
-    allow_any_instance_of(ActionView::TestCase::TestController).to receive(:current_user).and_return(nil)
+  context "with imports feature flag off" do
+    it "does not display files that are linked to an original file" do
+      allow_any_instance_of(ActionView::TestCase::TestController).to receive(:current_user).and_return(nil)
 
-    # Simulate a guest user uploading a docx file that gets converted to a pdf
-    # by the time they are shown the standards_imports/show page. We do not want
-    # to display the converted pdf file to them.
-    perform_enqueued_jobs do
+      # Simulate a guest user uploading a docx file that gets converted to a pdf
+      # by the time they are shown the standards_imports/show page. We do not want
+      # to display the converted pdf file to them.
+      perform_enqueued_jobs do
+        docx_file = file_fixture("document.docx")
+        import = create(:standards_import, files: [docx_file])
+
+        assign :standards_import, import.reload
+
+        render template: "standards_imports/show", layout: "layouts/application"
+
+        expect(rendered).to have_content "document.docx"
+        expect(rendered).to_not have_content "document.pdf"
+      end
+    end
+  end
+
+  context "with imports feature flag on" do
+    it "displays all files uploaded" do
+      stub_feature_flag(:show_imports_in_administrate, true)
+
+      allow_any_instance_of(ActionView::TestCase::TestController).to receive(:current_user).and_return(nil)
+
       docx_file = file_fixture("document.docx")
-      import = create(:standards_import, files: [docx_file])
+      pdf_file1 = file_fixture("pixel1x1.pdf")
+      pdf_file2 = file_fixture("pixel1x1_redacted.pdf")
 
-      assign :standards_import, import.reload
+      standards_import = create(:standards_import)
+      uncat1 = create(:imports_uncategorized, parent: standards_import, file: docx_file)
+      _uncat2 = create(:imports_uncategorized, parent: standards_import, file: pdf_file1)
+      create(:imports_pdf, parent: uncat1, file: pdf_file2)
+
+      assign :standards_import, standards_import.reload
 
       render template: "standards_imports/show", layout: "layouts/application"
 
       expect(rendered).to have_content "document.docx"
-      expect(rendered).to_not have_content "document.pdf"
+      expect(rendered).to have_content "pixel1x1.pdf"
+      expect(rendered).to_not have_content "pixel1x1_redacted.pdf"
+
+      stub_feature_flag(:show_imports_in_administrate, false)
     end
   end
 end


### PR DESCRIPTION
The thank you page that greets a guest user after they upload standards was not updated to use the new import tree structure. This PR makes that change.

PR best viewed not showing whitespace.

<img width="795" alt="Screenshot 2024-06-26 at 3 23 17 PM" src="https://github.com/ApprenticeshipStandardsDotOrg/ApprenticeshipStandardsDotOrg/assets/1938665/e9b457fd-7ca5-4886-aa08-9c0cfca4f355">

