### PR TITLE
Update link to public_document to use Imports::Pdf file

### DIFF
--- a/app/views/occupation_standards/_public_document_old.html.erb
+++ b/app/views/occupation_standards/_public_document_old.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "public_document", data: {controller: "refresh", refresh_src_value: request.path} do %>
-  <%= link_to occupation_standard.data_import.import.file.url do %>
+  <%= link_to occupation_standard.original_file_url do %>
     <div class="flex w-full items-center space-x-4 rounded bg-slate-700 p-2 text-left text-white hover:bg-slate-600">
       <span>
         <svg aria-label="pdf icon" xmlns="http://www.w3.org/2000/svg" width="49" height="48" fill="none">

--- a/app/views/occupation_standards/show.html.erb
+++ b/app/views/occupation_standards/show.html.erb
@@ -100,7 +100,11 @@
                         <% if @occupation_standard.redacted_document.attached? %>
                           <%= render partial: "redacted_document", locals: {occupation_standard: @occupation_standard} %>
                         <% elsif @occupation_standard.public_document? %>
-                          <%= render partial: "public_document", locals: {occupation_standard: @occupation_standard} %>
+                          <% if Flipper.enabled?(:show_imports_in_administrate) %>
+                            <%= render partial: "public_document", locals: {occupation_standard: @occupation_standard} %>
+                          <% else %>
+                            <%= render partial: "public_document_old", locals: {occupation_standard: @occupation_standard} %>
+                          <% end %>
                         <% else %>
                           <%= render partial: "redacted_document_coming_soon" %>
                         <% end %>

--- a/spec/views/occupation_standards/index_spec.rb
+++ b/spec/views/occupation_standards/index_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "occupations/index", type: :view do
+RSpec.describe "occupation_standards/index", type: :view do
   it "displays the correct page title when page_title is present" do
     allow_any_instance_of(ActionView::TestCase::TestController).to receive(:controller_name).and_return("occupation_standards")
     allow_any_instance_of(ActionView::TestCase::TestController).to receive(:current_user).and_return(nil)

--- a/spec/views/occupation_standards/show_spec.rb
+++ b/spec/views/occupation_standards/show_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "occupation_standards/show", type: :view do
+  context "without imports feature flag" do
+    it "when public document, it has link to original document" do
+      allow_any_instance_of(ActionView::TestCase::TestController).to receive(:controller_name).and_return("occupation_standards")
+      allow_any_instance_of(ActionView::TestCase::TestController).to receive(:current_user).and_return(nil)
+      allow(ActiveStorage::Current).to receive(:url_options).and_return(host: "https://www.example.com")
+
+      perform_enqueued_jobs do
+        standards_import = create(:standards_import, :with_files, public_document: true)
+        attachment = standards_import.files.first
+        source_file = attachment.source_file
+        occupation_standard = create(:occupation_standard)
+        create(:data_import, source_file: source_file, occupation_standard: occupation_standard)
+
+        assign :occupation_standard, occupation_standard
+
+        render
+
+        expect(rendered).to have_text "View Original Document"
+      end
+    end
+  end
+
+  context "with imports feature flag" do
+    before do
+      stub_feature_flag(:show_imports_in_administrate, true)
+      stub_feature_flag(:similar_programs_elasticsearch, false)
+    end
+    after { stub_feature_flag(:show_imports_in_administrate, false) }
+
+    it "when public document, it has link to original document" do
+      allow_any_instance_of(ActionView::TestCase::TestController).to receive(:controller_name).and_return("occupation_standards")
+      allow_any_instance_of(ActionView::TestCase::TestController).to receive(:current_user).and_return(nil)
+      allow(ActiveStorage::Current).to receive(:url_options).and_return(host: "https://www.example.com")
+
+      standards_import = create(:standards_import, public_document: true)
+      uncat = create(:imports_uncategorized, parent: standards_import)
+      pdf = create(:imports_pdf, parent: uncat)
+      occupation_standard = create(:occupation_standard)
+      create(:data_import, import: pdf, occupation_standard: occupation_standard)
+
+      assign :occupation_standard, occupation_standard
+
+      render
+
+      expect(rendered).to have_text "View Original Document"
+    end
+  end
+end


### PR DESCRIPTION
The "View Original Document" link is currently using the file attached to the StandardsImport, but those files are soon going to be removed. Use the file attached to the `Imports::Pdf` record instead for the new imports tree structure.
