### PR TITLE
Update related_occupation_standard method for new import structure

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -28,12 +28,21 @@ class DataImport < ApplicationRecord
   end
 
   def related_occupation_standard(title)
-    OccupationStandard
-      .joins(data_imports: :source_file)
-      .where(occupation_standards: {title: title})
-      .where.not(data_imports: {id: id})
-      .where(source_files: {id: source_file_id})
-      .first
+    if Flipper.enabled?(:show_imports_in_administrate)
+      OccupationStandard
+        .joins(data_imports: :import)
+        .where(occupation_standards: {title: title})
+        .where.not(data_imports: {id: id})
+        .where(imports: {id: import_id})
+        .first
+    else
+      OccupationStandard
+        .joins(data_imports: :source_file)
+        .where(occupation_standards: {title: title})
+        .where.not(data_imports: {id: id})
+        .where(source_files: {id: source_file_id})
+        .first
+    end
   end
 
   def set_import_field!

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -50,20 +50,44 @@ RSpec.describe DataImport, type: :model do
   end
 
   describe "#related_occupation_standard" do
-    it "returns occupation standard linked to same source file with same name" do
-      initial_os = create(:occupation_standard, title: "NOT HUMAN RESOURCE SPECIALIST")
-      data_import = create(:data_import, occupation_standard: initial_os)
-      source_file = data_import.source_file
+    context "with imports feature flag off" do
+      it "returns occupation standard linked to same source file with same name" do
+        initial_os = create(:occupation_standard, title: "NOT HUMAN RESOURCE SPECIALIST")
+        data_import = create(:data_import, occupation_standard: initial_os)
+        source_file = data_import.source_file
 
-      different_os_for_same_source_file = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
-      _data_import_with_some_errors = create(:data_import, occupation_standard: different_os_for_same_source_file, source_file: source_file)
+        different_os_for_same_source_file = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
+        _data_import_with_some_errors = create(:data_import, occupation_standard: different_os_for_same_source_file, source_file: source_file)
 
-      os_from_a_different_source_file = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
-      create(:data_import, occupation_standard: os_from_a_different_source_file)
+        os_from_a_different_source_file = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
+        create(:data_import, occupation_standard: os_from_a_different_source_file)
 
-      data_import_corrected = create(:data_import, occupation_standard: nil, source_file: source_file)
+        data_import_corrected = create(:data_import, occupation_standard: nil, source_file: source_file)
 
-      expect(data_import_corrected.related_occupation_standard("HUMAN RESOURCE SPECIALIST")).to eq different_os_for_same_source_file
+        expect(data_import_corrected.related_occupation_standard("HUMAN RESOURCE SPECIALIST")).to eq different_os_for_same_source_file
+      end
+    end
+
+    context "with imports feature flag on" do
+      before { stub_feature_flag(:show_imports_in_administrate, true) }
+      after { stub_feature_flag(:show_imports_in_administrate, false) }
+
+      it "returns occupation standard linked to same import with same name" do
+        initial_os = create(:occupation_standard, title: "NOT HUMAN RESOURCE SPECIALIST")
+        pdf = create(:imports_pdf)
+        _initial_data_import = create(:data_import, occupation_standard: initial_os, import: pdf)
+
+        different_os_for_same_pdf = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
+        _data_import_with_some_errors = create(:data_import, occupation_standard: different_os_for_same_pdf, import: pdf)
+
+        os_from_a_different_pdf = create(:occupation_standard, title: "HUMAN RESOURCE SPECIALIST")
+        different_pdf = create(:imports_pdf)
+        create(:data_import, occupation_standard: os_from_a_different_pdf, import: different_pdf)
+
+        data_import_corrected = create(:data_import, occupation_standard: nil, import: pdf)
+
+        expect(data_import_corrected.related_occupation_standard("HUMAN RESOURCE SPECIALIST")).to eq different_os_for_same_pdf
+      end
     end
   end
 


### PR DESCRIPTION
The `related_occupation_standard` method is used when uploading a new DataImport file. In order to not end up with duplicates of an occupation standard, this method is used to find an existing OccupationStandard attached to the same pdf with the same title. This PR updates the method to use the new imports tree structure.

PR best viewed hiding whitespace.
