### PR TITLE
Report processing errors

### DIFF
--- a/app/models/imports/doc.rb
+++ b/app/models/imports/doc.rb
@@ -27,7 +27,7 @@ module Imports
         processing_errors: e.message,
         status: :needs_backend_support
       )
-      raise
+      Rails.error.report(e, context: {import_id: id}, severity: :error)
     end
 
     def pdf_leaf

--- a/app/models/imports/docx.rb
+++ b/app/models/imports/docx.rb
@@ -27,7 +27,7 @@ module Imports
         processing_errors: e.message,
         status: :needs_backend_support
       )
-      raise
+      Rails.error.report(e, context: {import_id: id}, severity: :error)
     end
 
     def pdf_leaf

--- a/app/models/imports/docx_listing.rb
+++ b/app/models/imports/docx_listing.rb
@@ -36,7 +36,7 @@ module Imports
         processing_errors: e.message,
         status: :needs_backend_support
       )
-      raise
+      Rails.error.report(e, context: {import_id: id}, severity: :error)
     end
 
     def docx_listing_root

--- a/app/models/imports/uncategorized.rb
+++ b/app/models/imports/uncategorized.rb
@@ -18,7 +18,7 @@ module Imports
         processing_errors: e.message,
         status: :needs_backend_support
       )
-      raise
+      Rails.error.report(e, context: {import_id: id}, severity: :error)
     end
 
     def docx_listing_root

--- a/spec/models/imports/doc_spec.rb
+++ b/spec/models/imports/doc_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Imports::Doc, type: :model do
       allow(ConvertDocToPdf).to receive(:call).and_raise(ConvertDocToPdf::PdfConversionError)
       doc = create(:imports_doc)
 
-      expect { doc.process }.to raise_error(ConvertDocToPdf::PdfConversionError)
+      expect_any_instance_of(ErrorSubscriber).to receive(:report).with(kind_of(ConvertDocToPdf::PdfConversionError), hash_including(context: {import_id: doc.id}, severity: :error)).and_call_original
+      doc.process
       doc.reload
 
       expect(doc.pdf).to be_blank

--- a/spec/models/imports/docx_listing_spec.rb
+++ b/spec/models/imports/docx_listing_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Imports::DocxListing, type: :model do
         file: Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "files", "oleObject1.bin"))
       )
 
-      expect { docx_listing.process }.to raise_error(Zip::Error)
+      expect_any_instance_of(ErrorSubscriber).to receive(:report).with(kind_of(Zip::Error), hash_including(context: {import_id: docx_listing.id}, severity: :error)).and_call_original
+      docx_listing.process
       docx_listing.reload
 
       expect(docx_listing.processed_at).to be_blank

--- a/spec/models/imports/docx_spec.rb
+++ b/spec/models/imports/docx_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe Imports::Docx, type: :model do
       allow(ConvertDocToPdf).to receive(:call).and_raise(ConvertDocToPdf::PdfConversionError)
       docx = create(:imports_docx)
 
-      expect { docx.process }.to raise_error(ConvertDocToPdf::PdfConversionError)
+      expect_any_instance_of(ErrorSubscriber).to receive(:report).with(kind_of(ConvertDocToPdf::PdfConversionError), hash_including(context: {import_id: docx.id}, severity: :error)).and_call_original
+      docx.process
       docx.reload
 
       expect(docx.pdf).to be_blank

--- a/spec/models/imports/uncategorized_spec.rb
+++ b/spec/models/imports/uncategorized_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe Imports::Uncategorized, type: :model do
         )
       )
 
-      expect { import.process(listing: false) }.to raise_error(Imports::UnknownFileTypeError)
+      expect_any_instance_of(ErrorSubscriber).to receive(:report).with(kind_of(Imports::UnknownFileTypeError), hash_including(context: {import_id: import.id}, severity: :error)).and_call_original
+      import.process(listing: false)
       import.reload
 
       expect(import.import).to be_blank
@@ -117,7 +118,8 @@ RSpec.describe Imports::Uncategorized, type: :model do
       import = create(:imports_uncategorized, :pdf)
       allow(import).to receive(:import).and_raise(ActiveRecord::RecordNotUnique)
 
-      expect { import.process(listing: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect_any_instance_of(ErrorSubscriber).to receive(:report).with(kind_of(ActiveRecord::RecordNotUnique), hash_including(context: {import_id: import.id}, severity: :error)).and_call_original
+      import.process(listing: false)
       import.reload
 
       expect(import.processed_at).to be_blank


### PR DESCRIPTION
Currently import processing errors
are getting raised, causing scraper
jobs to stop processing remaining
items. This change sends the error
to the Rails error subscriber so
it can be handled appropriately.

[Asana ticket](https://app.asana.com/0/1203289004376659/1207682190309860/f)
