### PR TITLE
[maint] resolve failing spec on admin mailer for daily uploads report

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -4,6 +4,8 @@ class AdminMailer < ApplicationMailer
   #
   #   en.admin_mailer.new_standards_import.subject
   #
+  helper_method :public_domain
+
   def new_standards_import(standards_import)
     @standards_import = standards_import
 
@@ -36,5 +38,16 @@ class AdminMailer < ApplicationMailer
       mail to: "info@workhands.us",
         subject: "Daily redacted files report #{date}"
     end
+  end
+
+  private
+
+  def public_domain
+    value = ENV["PUBLIC_DOMAIN"]
+    if value =~ /localhost\:3000\z/
+      value = nil
+    end
+
+    value || Rails.application.config.action_mailer.default_url_options[:host]
   end
 end

--- a/app/views/admin_mailer/daily_uploads_report.html.erb
+++ b/app/views/admin_mailer/daily_uploads_report.html.erb
@@ -3,8 +3,8 @@
     <div>
       <span style="font-size: 1.5em; font-weight: 700"> <%= data_import.occupation_standard.title %> </span> <br>
       <span> <%= data_import.occupation_standard.ojt_type&.titleize %> based </span> <br> <br>
-      <%= link_to "Public", occupation_standard_url(data_import.occupation_standard, host: ENV.fetch("PUBLIC_DOMAIN", Rails.application.config.action_mailer.default_url_options[:host])) %> |
-      <%= link_to "Admin", admin_occupation_standard_url(data_import.occupation_standard) %> |
+      <%= link_to "Public", occupation_standard_url(data_import.occupation_standard, host: public_domain) %> |
+      <%= link_to "Admin", admin_occupation_standard_url(data_import.occupation_standard, host: public_domain) %> |
       <%= link_to "Data Import", admin_data_import_url(data_import) %> |
       <%= link_to "Source File", admin_import_url(data_import.import) %>
       <br> <br>

--- a/app/views/admin_mailer/daily_uploads_report.text.erb
+++ b/app/views/admin_mailer/daily_uploads_report.text.erb
@@ -1,8 +1,8 @@
 <% @data_imports.each do |data_import| %>
   <%= data_import.occupation_standard.title %>
   <%= data_import.occupation_standard.ojt_type&.titleize %> based
-  Public: <%= occupation_standard_url(data_import.occupation_standard, host: ENV.fetch("PUBLIC_DOMAIN", Rails.application.config.action_mailer.default_url_options[:host])) %>
-  Admin: <%= admin_occupation_standard_url(data_import.occupation_standard) %>
+  Public: <%= occupation_standard_url(data_import.occupation_standard, host: public_domain) %>
+  Admin: <%= admin_occupation_standard_url(data_import.occupation_standard, host: public_domain) %>
   Competencies count: <%= data_import.occupation_standard.competencies_count %>
   <% if data_import.occupation_standard.ojt_hours_min.to_i.positive? %>
   OJT hours min: <%= data_import.occupation_standard.ojt_hours_min %>


### PR DESCRIPTION
`spec/mailers/admin_spec.rb` failed for daily uploads report when testing locally.

The issue was inconsistent treatment of the host for urls embedded in the daily uploads report admin mailer. 

Resolved by establishing a helper method and using consistently in both HTML and text views for both the admin and public URLs.