### PR TITLE
Detect words in TextRepresentation#content from WordReplacement list

### DIFF
--- a/app/controllers/admin/word_replacements_controller.rb
+++ b/app/controllers/admin/word_replacements_controller.rb
@@ -1,0 +1,4 @@
+module Admin
+  class WordReplacementsController < Admin::ApplicationController
+  end
+end

--- a/app/dashboards/word_replacement_dashboard.rb
+++ b/app/dashboards/word_replacement_dashboard.rb
@@ -1,0 +1,61 @@
+require "administrate/base_dashboard"
+
+class WordReplacementDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::String,
+    replacement: Field::String,
+    word: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    word
+    replacement
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    word
+    replacement
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    word
+    replacement
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how word replacements are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(word_replacement)
+  #   "WordReplacement ##{word_replacement.id}"
+  # end
+end

--- a/app/models/word_replacement.rb
+++ b/app/models/word_replacement.rb
@@ -1,0 +1,2 @@
+class WordReplacement < ApplicationRecord
+end

--- a/app/policies/word_replacement_policy.rb
+++ b/app/policies/word_replacement_policy.rb
@@ -1,0 +1,2 @@
+class WordReplacementPolicy < AdminPolicy
+end

--- a/app/queries/detect_disallowed_words_in_text_representation_query.rb
+++ b/app/queries/detect_disallowed_words_in_text_representation_query.rb
@@ -1,0 +1,27 @@
+class DetectDisallowedWordsInTextRepresentationQuery
+  def self.run(text_representation_id)
+    result = TextRepresentation.connection.exec_query(
+      TextRepresentation.sanitize_sql([
+        "
+          SELECT array_agg(rm[1]) AS WORDS
+            FROM (
+              SELECT ts_headline(
+                content,
+                to_tsquery(array_to_string(array_agg(word_replacements.word), ' | '))
+              )
+              FROM text_representations
+              CROSS JOIN word_replacements
+              WHERE text_representations.id = :text_representation_id
+              GROUP BY content
+            ) AS t(s)
+            CROSS JOIN LATERAL regexp_matches(s, '<b>(.*?)</b>', 'g') AS rm(matches);
+        ",
+        {
+          text_representation_id: text_representation_id
+        }
+      ])
+    )
+
+    result.rows.flatten.first
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,6 +24,7 @@ default: &default
   username: <%= ENV.fetch("POSTGRES_USER", "postgres") %>
   password: <%= ENV.fetch("POSTGRES_PASSWORD", "") %>
   port: <%= ENV.fetch("POSTGRES_PORT", "5432") %>
+  prepared_statements: true
 
 development:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
       resources :wage_steps, only: [:show, :edit, :update]
       resources :onets, only: [:index, :show]
       resources :synonyms
+      resources :word_replacements
       resources :contact_requests, only: [:index, :show]
       resources :surveys, only: [:index]
       resources :users do

--- a/db/migrate/20241022164023_create_word_replacements.rb
+++ b/db/migrate/20241022164023_create_word_replacements.rb
@@ -1,0 +1,10 @@
+class CreateWordReplacements < ActiveRecord::Migration[7.2]
+  def change
+    create_table :word_replacements, id: :uuid do |t|
+      t.string :word, null: false
+      t.string :replacement, default: "****"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_24_154858) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_22_164023) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -340,6 +340,13 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_24_154858) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["occupation_standard_id"], name: "index_wage_steps_on_occupation_standard_id"
+  end
+
+  create_table "word_replacements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "word", null: false
+    t.string "replacement", default: "****"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "work_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/word_replacements.rb
+++ b/spec/factories/word_replacements.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :word_replacement do
+    word { "Slur" }
+    replacement { "****" }
+  end
+end

--- a/spec/policies/word_replacement_policy.rb
+++ b/spec/policies/word_replacement_policy.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe WordReplacementPolicy do
+  permissions :index?, :show?, :new?, :create?, :edit?, :update?, :destroy? do
+    it "grants access if user is an admin" do
+      admin = build(:admin)
+      word_replacement = build(:word_replacement)
+
+      expect(described_class).to permit(admin, word_replacement)
+    end
+
+    it "denies access if user is a converter" do
+      admin = build(:user, :converter)
+      word_replacement = build(:word_replacement)
+
+      expect(described_class).to_not permit(admin, word_replacement)
+    end
+  end
+end

--- a/spec/queries/detect_disallowed_words_in_text_representation_query_spec.rb
+++ b/spec/queries/detect_disallowed_words_in_text_representation_query_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe DetectDisallowedWordsInTextRepresentationQuery do
+  it "returns no result if no WordReplacement found" do
+    text_representation = create(:text_representation, content: "Sample content")
+
+    result = described_class.run(text_representation.id)
+
+    expect(result).to be_nil
+  end
+
+  it "returns no result if no match found" do
+    create(:word_replacement, word: "bad")
+    text_representation = create(:text_representation, content: "Sample content with a slur we want to detect and remove")
+
+    result = described_class.run(text_representation.id)
+
+    expect(result).to be_nil
+  end
+
+  it "returns single match if WordReplacement has a match" do
+    create(:word_replacement, word: "slur")
+    text_representation = create(:text_representation, content: "Sample content with a slur we want to detect and remove")
+
+    result = described_class.run(text_representation.id)
+
+    expect(result).to eq "{slur}"
+  end
+
+  it "returns multiple matches if WordReplacement has more that one entry" do
+    create(:word_replacement, word: "SLUR")
+    create(:word_replacement, word: "bad")
+    text_representation = create(:text_representation, content: "Sample content with a slur and a bad slur we want to detect and remove")
+
+    result = described_class.run(text_representation.id)
+
+    expect(result).to eq "{slur,bad,slur}"
+  end
+end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1208347992671019/f)

Each OccupationStandard has a related document (Import) with all the details about itself. Some of those documents contain words that we want to replace since they are either inappropriate or outdated.

First part of this feature is detect if an OccupationStandard has a document with those words. Each OccupationStandard has a TextRepresentation model, where we store the contents of its corresponding Import.

We have a new model called WordReplacement, where we store the list of words we want to replace. For now, we don't have an official list, but admins can add terms manually.

This PR introduces a query that checks if, given a text_representation_id, its contents have one of the words we want to replace.

UI for this is TBD

Additional notes:

This complete feature is a PoC to proof that this can be achieved. If we decide to implement this as a long-term supported feature, we may want to create a index to optimize the search process and use the index instead of asking postgreSQL to parse the content each time.  

```
CREATE INDEX text_representation_content_idx ON text_representation USING GIN (to_tsvector('english', content));
```


