### PR TITLE
Update `Gemfile.lock` to add support for macOS 15 (x8_64-darwin) platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,6 +570,7 @@ PLATFORMS
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-darwin-23
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
These changes update the Gemfile.lock to include the x86_64-darwin-24 platform, adding compatibility for macOS 15.
