### PR TITLE
Clarify invitation email in user creation flash message and add tests for invite action

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -17,7 +17,7 @@ module Admin
         resource.invite!
         redirect_to(
           after_resource_created_path(resource),
-          notice: translate_with_resource("create.success")
+          notice: "#{resource_class.name} was successfully created, and an invitation email has been sent to #{resource.email}."
         )
       else
         render :new, locals: {

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -81,4 +81,51 @@ RSpec.describe "Admin::User", type: :request do
       expect(email.from).to eq ["no-reply@apprenticeshipstandards.org"]
     end
   end
+
+  describe "POST /invite", :admin do
+    it "sends invitation email" do
+      admin = create(:admin)
+      user = create(:user)
+
+      sign_in admin
+      post invite_admin_user_path(id: user.id)
+
+      email = ActionMailer::Base.deliveries.last
+      expect(email.subject).to eq "Invitation instructions"
+      expect(email.to).to eq [user.email]
+      expect(email.from).to eq ["no-reply@apprenticeshipstandards.org"]
+    end
+
+    it "redirects to user path" do
+      admin = create(:admin)
+      user = create(:user)
+
+      sign_in admin
+      post invite_admin_user_path(id: user.id)
+
+      expect(response).to redirect_to admin_user_path(user)
+    end
+
+    it "renders flash notice on success" do
+      admin = create(:admin)
+      user = create(:user)
+
+      sign_in admin
+      post invite_admin_user_path(id: user.id)
+
+      expect(flash[:notice]).to eq I18n.t("devise.invitations.send_instructions", email: user.email)
+    end
+
+    it "renders flash error on failure" do
+      admin = create(:admin)
+      user = create(:user)
+
+      allow_any_instance_of(User).to receive(:invite!).and_return(double(errors: ["error"]))
+
+      sign_in admin
+      post invite_admin_user_path(id: user.id)
+
+      expect(flash[:error]).to eq "There was an error trying to send an invite to this user"
+    end
+  end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -62,6 +62,22 @@ RSpec.describe "Admin::User", type: :request do
       }.to change(User, :count).by(1)
     end
 
+    it "renders flash notice on success" do
+      admin = create(:admin)
+      params = {
+        user: {
+          name: "Test #1",
+          email: "test@test.com",
+          role: :admin
+        }
+      }
+
+      sign_in admin
+      post admin_users_path, params: params
+
+      expect(flash[:notice]).to eq "User was successfully created, and an invitation email has been sent to test@test.com."
+    end
+
     it "sends invitation email" do
       admin = create(:admin)
       params = {


### PR DESCRIPTION
This change aims to reduce potential confusion regarding the invitation email sent after user creation through the admin panel. The flash message now explicitly mentions that an invitation email has been sent.

Additionally, introduce tests for the `Admin::UsersController#invite` action, which previously lacked test coverage. This is the first in a series of changes related to this area, as outlined in the attached Asana ticket.

[Asana ticket](https://app.asana.com/0/1203289004376659/1206201273701899/f)
