### PR TITLE
Add invitation sent timestamp to user admin dashboard to prevent duplicate invitations

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -14,6 +14,7 @@ class UserDashboard < Administrate::BaseDashboard
     current_sign_in_ip: Field::String,
     email: Field::String,
     encrypted_password: Field::String,
+    invitation_sent_at: Field::DateTime,
     last_sign_in_at: Field::DateTime,
     last_sign_in_ip: Field::String,
     name: Field::String,
@@ -51,6 +52,7 @@ class UserDashboard < Administrate::BaseDashboard
     current_sign_in_ip
     last_sign_in_at
     last_sign_in_ip
+    invitation_sent_at
     reset_password_sent_at
     sign_in_count
     created_at


### PR DESCRIPTION
This change introduces a new field, `invitation_sent_at`, to the `administrator` user's dashboard, displaying the timestamp of when the invitation email was sent. By including this information on the user's show page in the admin panel, administrators will have a clearer view of whether an invitation has already been sent, reducing the risk of accidentally sending duplicate invitations.

<img width="1401" alt="Screenshot 2024-11-14 at 2 58 37 PM" src="https://github.com/user-attachments/assets/0742a160-a74a-4bc8-841d-51f280042d96">


[Asana ticket](https://app.asana.com/0/1203289004376659/1206201273701899/f)
