### PR TITLE
Update enums to use positional arguments

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -21,11 +21,11 @@ class Import < ApplicationRecord
     :needs_backend_support,
     :unfurled
   ]
-  enum courtesy_notification: [
+  enum :courtesy_notification, [
     :not_required,
     :pending,
     :completed
-  ], _prefix: true
+  ], :prefix => true
 
   scope :needs_unfurling, -> { unfurled.where("created_at < ?", 1.day.ago) }
 

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -25,7 +25,7 @@ class Import < ApplicationRecord
     :not_required,
     :pending,
     :completed
-  ], :prefix => true
+  ], prefix: true
 
   scope :needs_unfurling, -> { unfurled.where("created_at < ?", 1.day.ago) }
 

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -23,8 +23,8 @@ class OccupationStandard < ApplicationRecord
   delegate :name, to: :industry, prefix: true, allow_nil: true
   delegate :state, to: :registration_agency, allow_nil: true
 
-  enum :ojt_type, [:time, :competency, :hybrid], :suffix => :based
-  enum :national_standard_type, [:program_standard, :guideline_standard, :occupational_framework], :prefix => :national
+  enum :ojt_type, [:time, :competency, :hybrid], suffix: :based
+  enum :national_standard_type, [:program_standard, :guideline_standard, :occupational_framework], prefix: :national
   enum :status, [:importing, :in_review, :published]
 
   validates :title, :ojt_type, presence: true

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -23,9 +23,9 @@ class OccupationStandard < ApplicationRecord
   delegate :name, to: :industry, prefix: true, allow_nil: true
   delegate :state, to: :registration_agency, allow_nil: true
 
-  enum ojt_type: [:time, :competency, :hybrid], _suffix: :based
-  enum national_standard_type: [:program_standard, :guideline_standard, :occupational_framework], _prefix: :national
-  enum status: [:importing, :in_review, :published]
+  enum :ojt_type, [:time, :competency, :hybrid], :suffix => :based
+  enum :national_standard_type, [:program_standard, :guideline_standard, :occupational_framework], :prefix => :national
+  enum :status, [:importing, :in_review, :published]
 
   validates :title, :ojt_type, presence: true
   validates :registration_agency, presence: true

--- a/app/models/registration_agency.rb
+++ b/app/models/registration_agency.rb
@@ -5,7 +5,7 @@ class RegistrationAgency < ApplicationRecord
   belongs_to :state, optional: true
   has_many :occupation_standards
 
-  enum agency_type: [:oa, :saa]
+  enum :agency_type, [:oa, :saa]
 
   def to_s
     state_name = state&.name || "National"

--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -1,7 +1,7 @@
 class StandardsImport < ApplicationRecord
   has_many :imports, as: :parent, dependent: :destroy
 
-  enum courtesy_notification: [:not_required, :pending, :completed], _prefix: true
+  enum :courtesy_notification, [:not_required, :pending, :completed], :prefix => true
 
   validates :email, :name, presence: true, unless: -> { courtesy_notification_not_required? }
   normalizes :email, with: ->(email) { email.strip.downcase }

--- a/app/models/standards_import.rb
+++ b/app/models/standards_import.rb
@@ -1,7 +1,7 @@
 class StandardsImport < ApplicationRecord
   has_many :imports, as: :parent, dependent: :destroy
 
-  enum :courtesy_notification, [:not_required, :pending, :completed], :prefix => true
+  enum :courtesy_notification, [:not_required, :pending, :completed], prefix: true
 
   validates :email, :name, presence: true, unless: -> { courtesy_notification_not_required? }
   normalizes :email, with: ->(email) { email.strip.downcase }


### PR DESCRIPTION
Defining enums with keyword arguments is deprecated and will be removed in Rails 8.0.

[Asana ticket](https://app.asana.com/0/1203289004376659/1208946454714575)
