### PR TITLE
Remove Occupation Standards create button on admin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,6 +570,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-darwin-23

--- a/app/views/admin/occupation_standards/_index_header.html.erb
+++ b/app/views/admin/occupation_standards/_index_header.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:title) do %>
+<%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <%= content_for(:header_middle) %>
+
+  <% if show_search_bar %>
+  <%= render(
+        "search",
+        search_term: search_term,
+        resource_name: display_resource_name(page.resource_name)
+      ) %>
+  <% end %>
+
+  <%= content_for(:header_last) %>
+</header>


### PR DESCRIPTION
An Occupation Standard gets created when we import standards. A PDF file is needed. The admin panel showed a "New Occupation Standard" button though which fails when trying to open it as there's no way to upload a PDF. This PR basically just overwrites the index_header partial used by administrate to remove the new record creation button. I did not add a system spec on purpose as we usually don't test what we don't expect. There are tests for the Standard Import to work correctly.

### Visualisation
<img width="1243" alt="Occupation_Standards_Admin_Header" src="https://github.com/user-attachments/assets/04c0dc17-0469-48f9-a88e-dc2c2f434ba8" />

