### PR TITLE
Add nested field for competencies on work processes

### DIFF
--- a/app/dashboards/competency_dashboard.rb
+++ b/app/dashboards/competency_dashboard.rb
@@ -47,10 +47,10 @@ class CompetencyDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    competency_options
-    description
-    sort_order
     title
+    description
+    competency_options
+    sort_order
     work_process
   ].freeze
 

--- a/app/dashboards/work_process_dashboard.rb
+++ b/app/dashboards/work_process_dashboard.rb
@@ -5,7 +5,7 @@ class WorkProcessDashboard < Administrate::BaseDashboard
 
   ATTRIBUTE_TYPES = {
     id: Field::String,
-    competencies: Field::HasMany,
+    competencies: Field::NestedHasMany.with_options(skip: :work_process),
     default_hours: Field::Number,
     description: Field::String,
     maximum_hours: Field::Number,
@@ -46,6 +46,7 @@ class WorkProcessDashboard < Administrate::BaseDashboard
     maximum_hours
     minimum_hours
     sort_order
+    competencies
   ].freeze
 
   COLLECTION_FILTERS = {}.freeze

--- a/app/models/work_process.rb
+++ b/app/models/work_process.rb
@@ -8,6 +8,8 @@ class WorkProcess < ApplicationRecord
 
   delegate :work_processes_hours, to: :occupation_standard, prefix: true, allow_nil: true
 
+  accepts_nested_attributes_for :competencies, allow_destroy: true
+
   def hours
     [maximum_hours, minimum_hours].compact.first
   end

--- a/spec/factories/competencies.rb
+++ b/spec/factories/competencies.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :competency do
     work_process
-    title { "Competency" }
+    title { "Competency Title" }
     description { "Competency Description" }
     sequence(:sort_order) { |n| n }
   end

--- a/spec/factories/occupation_standards.rb
+++ b/spec/factories/occupation_standards.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
       work_processes { build_list(:work_process, 1) }
     end
 
+    trait :with_work_processes_and_competencies do
+      work_processes { build_list(:work_process, 1, :with_competencies) }
+    end
+
     trait :state_standard do
       national_standard_type { nil }
     end

--- a/spec/factories/work_processes.rb
+++ b/spec/factories/work_processes.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     sequence(:title) { |n| "Work Process ##{n}" }
     description { "Work Process Description" }
     occupation_standard
+
+    trait :with_competencies do
+      competencies { build_list(:competency, 1) }
+    end
   end
 end

--- a/spec/system/admin/occupation_standards/edit_spec.rb
+++ b/spec/system/admin/occupation_standards/edit_spec.rb
@@ -40,45 +40,91 @@ RSpec.describe "admin/occupation_standards/edit" do
     expect(page).to have_selector("h1", text: "Edit Mechanic")
   end
 
-  it "allows an admin user to add a new work process to an occupation standard", :admin, js: true do
-    occupation_standard = create(:occupation_standard)
-    admin = create(:admin)
+  describe "work processes" do
+    it "allows an admin user to add a new work process to an occupation standard", :admin, js: true do
+      occupation_standard = create(:occupation_standard)
+      admin = create(:admin)
 
-    login_as admin
-    visit edit_admin_occupation_standard_path(occupation_standard)
+      login_as admin
+      visit edit_admin_occupation_standard_path(occupation_standard)
 
-    within_fieldset("Work processes") do
-      click_on "Add Work Process"
+      within_fieldset("Work processes") do
+        click_on "Add Work Process"
 
-      within(".nested-fields") do
-        fill_in "Title", with: "New Work Process"
+        within(".nested-fields") do
+          fill_in "Title", with: "New Work Process"
+        end
       end
+
+      click_on "Update Occupation standard"
+
+      refresh
+
+      expect(page).to have_content("New Work Process")
+      expect(occupation_standard.work_processes.count).to eq 1
     end
 
-    click_on "Update Occupation standard"
+    it "allows an admin user to remove a new work process from an occupation standard", :admin, js: true do
+      occupation_standard = create(:occupation_standard, :with_work_processes)
+      admin = create(:admin)
 
-    refresh
+      login_as admin
+      visit edit_admin_occupation_standard_path(occupation_standard)
 
-    expect(page).to have_content("New Work Process")
-    expect(occupation_standard.work_processes.count).to eq 1
+      within_fieldset("Work processes") do
+        click_on "Remove Work Process"
+      end
+
+      click_on "Update Occupation standard"
+
+      refresh
+
+      expect(page).not_to have_content("Work Process #")
+      expect(occupation_standard.work_processes.count).to eq 0
+    end
   end
 
-  it "allows an admin user to remove a new work process from an occupation standard", :admin, js: true do
-    occupation_standard = create(:occupation_standard, :with_work_processes)
-    admin = create(:admin)
+  describe "competencies" do
+    it "allows an admin user to add a new competency to a work process", :admin, js: true do
+      occupation_standard = create(:occupation_standard, :with_work_processes)
+      admin = create(:admin)
 
-    login_as admin
-    visit edit_admin_occupation_standard_path(occupation_standard)
+      login_as admin
+      visit edit_admin_occupation_standard_path(occupation_standard)
 
-    within_fieldset("Work processes") do
-      click_on "Remove Work Process"
+      within_fieldset("Competencies") do
+        click_on "Add Competency"
+
+        within(".nested-fields") do
+          fill_in "Title", with: "New Competency"
+        end
+      end
+
+      click_on "Update Occupation standard"
+
+      refresh
+
+      expect(page).to have_content("1 competencies")
+      expect(occupation_standard.work_processes.first.competencies.count).to eq 1
     end
 
-    click_on "Update Occupation standard"
+    it "allows an admin user to remove a competency from a work process", :admin, js: true do
+      occupation_standard = create(:occupation_standard, :with_work_processes_and_competencies)
+      admin = create(:admin)
 
-    refresh
+      login_as admin
+      visit edit_admin_occupation_standard_path(occupation_standard)
 
-    expect(page).not_to have_content("Work Process #")
-    expect(occupation_standard.work_processes.count).to eq 0
+      within_fieldset("Competencies") do
+        click_on "Remove Competency"
+      end
+
+      click_on "Update Occupation standard"
+
+      refresh
+
+      expect(page).not_to have_content("Competency Title")
+      expect(occupation_standard.work_processes.first.competencies.count).to eq 0
+    end
   end
 end


### PR DESCRIPTION
In order to add or remove a competency to/from a work process via the occupation standard admin page, we introduced a nested has_many field for this record.
We also updated the factories for work processes and competencies and added the system test for occupation standards.

### Visualisation
<img width="1627" alt="competencies_on_work_processes" src="https://github.com/user-attachments/assets/58d21f26-5b5c-45fc-96fd-3bfa416c3fd2" />

### Note
This PR gets merged into the nested work process PR as it uses the same gem.


[Asana ticket](https://app.asana.com/0/1203289004376659/1208999829806206/f)
