### PR TITLE
Fix non text input styling

### DIFF
--- a/app/assets/stylesheets/administrate_customizations.scss
+++ b/app/assets/stylesheets/administrate_customizations.scss
@@ -1,7 +1,9 @@
 /* Flowbite styling is causing the Submit buttons to disappear
 so reinstate initial behavior */
+[type="text"],
+[type="number"],
 .main-content__body {
-  button, input:not([type="text"]), .button {
+  button, input:not([type]), .button {
     appearance: auto;
     background-color: #1976d2;
 


### PR DESCRIPTION
We customized administrate styling a while ago which led to fact that non text inputs had a blue background. Only text inputs had the white background. Forms looked a bit inconsistent. This PR adds inputs with type of numbers to also have a white background.

### Visualisation

**Before**
<img width="1240" alt="number_input_before" src="https://github.com/user-attachments/assets/57a48eda-70ec-4cfb-9b30-6158c35e45dd" />

**After**
<img width="1246" alt="number_input_after" src="https://github.com/user-attachments/assets/571ebc3c-f9c6-4c83-9b78-0a35797db41f" />


