### PR TITLE
Update erb linting command

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ We are using [erb_lint][erb_lint] for ERB linting. To check the style of all
 `.erb` files, run:
 
 ```
-bundle exec erblint --lint-all --autocorrect
+bundle exec erb_lint --lint-all --autocorrect
 ```
 
 [standard]: https://github.com/testdouble/standard


### PR DESCRIPTION
Running bundle exec erblint is deprecated. It's now bundle exec erb_lint.
More information on [erb_lint](https://github.com/Shopify/erb_lint?tab=readme-ov-file#usage).

