### PR TITLE
Fix admin styling

### DIFF
--- a/app/assets/stylesheets/administrate_customizations.scss
+++ b/app/assets/stylesheets/administrate_customizations.scss
@@ -45,14 +45,20 @@ div#dropdown {
   }
 }
 
-/* The input search is turning blue on hover.
-Seems like this is an Administrate issue,
-but will look into it more later. */
-input#search {
-  color: rgb(41, 63, 84);
+/* The table layout does not fit into its parent 
+container on smaller devices. This styling comes
+from administrate. */
+table {
+  table-layout: fixed;
+}
 
-  &:hover {
-    background-color: #fff;
-    color: rgb(41, 63, 84);
-  }
+td, th {
+  word-wrap: break-word;
+}
+
+/* The Filter by: button did not get displayed correctly. 
+The SVG got moved to the next line. */
+button#dropdownDefaultButton svg {
+  display: inline;
+  position: relative;
 }


### PR DESCRIPTION
Table content did not get displayed correctly on
smaller devices. The table cells also did not
wrap nicely and the Filter By button wrapped the
SVG to the next line. This commit fixes all
these little issues.

The input search field does not turn blue on hover
any longer, so I removed the customised styling.

### Visualisation

**Before**
<img width="1264" alt="Import_Before" src="https://github.com/user-attachments/assets/536b1878-f2ce-42d7-a574-81e398deb095" />

**After**
<img width="1252" alt="Import_after" src="https://github.com/user-attachments/assets/d7c02f0d-5983-4a99-b560-ae4a71340332" />

