### PR TITLE
Disable prefetching for Convert with AI

### DIFF
--- a/app/views/admin/imports/show.html.erb
+++ b/app/views/admin/imports/show.html.erb
@@ -43,7 +43,8 @@
     <%= link_to(
           "Convert with AI",
           new_admin_occupation_standard_path(import_id: page.resource.id),
-          class: "button"
+          class: "button",
+          data: {turbo_prefetch: false}
         ) %>
 
     <%= if accessible_action?(:redact_file, :new) && page.resource.available_for_redaction?


### PR DESCRIPTION
Since administrate uses turbo since the latest upgrade, links get usually prefetched. For the 
link "Convert with AI", we don't want that to happen so we disable it for this link.
We usually wanted to add the change when working on OpenAI related tickets but I thought 
it might make sense to have it as its own PR, to make the change more obvious and easier 
to revert in case we want to.
