### PR TITLE
Fix Claim button

### DIFF
--- a/app/views/admin/imports/_collection.html.erb
+++ b/app/views/admin/imports/_collection.html.erb
@@ -71,7 +71,7 @@ to display a collection of resources in an HTML table.
       <% collection_presenter.attributes_for(resource).each do |attribute| %>
       <td class="cell-data cell-data--<%= attribute.html_class %>">
         <% if authorized_action?(resource, :show) -%>
-        <a href="<%= admin_import_path(resource) -%>" tabindex="-1" class="action-show">
+        <a href="<%= admin_import_path(resource) -%>" tabindex="-1" class="action-show" data-turbo="false">
           <%= render_field attribute %>
         </a>
         <% else %>

--- a/spec/system/admin/imports/index_spec.rb
+++ b/spec/system/admin/imports/index_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "admin/imports/index", :admin do
       expect(page).to have_text "The file imported on this screen"
     end
 
-    it "can claim an import" do
+    it "can claim an import", js: true do
       converter = create(:user, :converter, name: "Mickey Mouse")
       create(:imports_pdf)
       create(:imports_pdf, assignee: converter)


### PR DESCRIPTION
With the last upgrade of administrate, turbo got
introduced. The form for the claim button on imports is nested in an anchor tag. With turbo enabled on links by default, the link itself takes precedence over the form. This led to the fact that we always got redirected to the show page of an import but we were not able to add an assignee. This commit fixes it.

[Asana ticket](https://app.asana.com/0/1203289004376659/1209041701094994/f)
