### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Rails 7, and PostgreSQL 14.
    127.0.0.1 admin.example.localhost
    # End ApprenticeshipStandards.org additions
    ```
-5. Start the rails app with `bin/dev`:
+5. Install `lipvips` with Homebrew: `brew install vips`
+6. Start the rails app with `bin/dev`:
     * The public facing application will be available at http://localhost:3000
     * The admin pages will be available at http://admin.example.localhost:3000
     * Email previews will be available at http://localhost:1080
@@ -213,7 +214,7 @@ post-deployment tasks.
 We are using [RSpec](http://rspec.info/) for tests. Before beginning a new
 feature, please run the specs and make sure the entire test suite is passing.
 All tests should be passing when submitting a PR. Please write specs as
-appropriate.
+appropriate. Ensure that Elasticsearch is running.
 
 To run all specs:
 


### PR DESCRIPTION
(1) For being able to display preview images for PDFs (imports), we rely on lipvips. It can get installed with homebrew but it wasn't mentioned in the README.

(2) When we run the tests, we have to have Elasticsearch running. This was not mentioned in the README before.

[Asana ticket](https://app.asana.com/0/1203289004376659/1209041701095000/f)
