### PR TITLE
Add rake tasks to enable or disable recaptcha

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -38,6 +38,9 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
+  puts "\n== Disable recaptcha locally =="
+  system! "bin/rails captcha:disable"
+
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 

--- a/lib/tasks/captcha.rake
+++ b/lib/tasks/captcha.rake
@@ -1,0 +1,9 @@
+namespace :captcha do
+  task enable: :environment do
+    Flipper.enable(:recaptcha)
+  end
+
+  task disable: :environment do
+    Flipper.disable(:recaptcha)
+  end
+end

--- a/spec/lib/tasks/captcha_spec.rb
+++ b/spec/lib/tasks/captcha_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+Rails.application.load_tasks
+
+describe "#enable" do
+  it "sets to true the recaptcha flag" do
+    Flipper.disable(:recaptcha)
+    Rake::Task["captcha:enable"].invoke
+
+    expect(Flipper.enabled?(:recaptcha)).to be true
+  end
+end
+
+describe "#disable" do
+  it "sets to false the recaptcha flag" do
+    Flipper.enable(:recaptcha)
+    Rake::Task["captcha:disable"].invoke
+
+    expect(Flipper.enabled?(:recaptcha)).to be false
+  end
+end


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1203289004376659/1209041701095003/f)

Our current recaptcha setup does not support localhost as origin. This PR creates two rake tasks to enable or disable recaptcha and runs the disable one when setting up the project