### PR TITLE
Update registration agencies, refine conversion for OA vs SAA standards docs

### DIFF
--- a/app/controllers/admin/occupation_standards_controller.rb
+++ b/app/controllers/admin/occupation_standards_controller.rb
@@ -41,7 +41,17 @@ module Admin
     end
 
     def scoped_resource
-      OccupationStandard.includes(:open_ai_import, occupation: :onet, registration_agency: :state)
+      import_preloads = [
+        {file_attachment: :blob},
+        {parent: {parent: {parent: {parent: :parent}}}}
+      ]
+
+      OccupationStandard.includes(
+        {data_imports: {import: import_preloads}},
+        {occupation: :onet},
+        {open_ai_import: {import: import_preloads}},
+        {registration_agency: :state}
+      )
     end
 
     def filter_resources(resources, search_term:)

--- a/app/dashboards/occupation_standard_dashboard.rb
+++ b/app/dashboards/occupation_standard_dashboard.rb
@@ -23,6 +23,7 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
     rsi_hours_min: Field::Number,
     sample_set: Field::Boolean,
     source: EnumField,
+    source_documents: SourceDocumentsField.with_options(searchable: false),
     status: EnumField,
     term_months: Field::Number,
     title: Field::String,
@@ -55,6 +56,7 @@ class OccupationStandardDashboard < Administrate::BaseDashboard
     url
     status
     source
+    source_documents
     sample_set
     created_at
     updated_at

--- a/app/fields/source_documents_field.rb
+++ b/app/fields/source_documents_field.rb
@@ -1,0 +1,19 @@
+require "administrate/field/base"
+
+class SourceDocumentsField < Administrate::Field::Base
+  def data
+    resource.source_documents
+  end
+
+  def source_urls
+    resource.source_urls
+  end
+
+  def linkable_url?(url)
+    url.match?(/\Ahttps?:\/\//)
+  end
+
+  def to_s
+    data.map(&:filename).join(", ")
+  end
+end

--- a/app/models/occupation_standard.rb
+++ b/app/models/occupation_standard.rb
@@ -265,6 +265,35 @@ class OccupationStandard < ApplicationRecord
     data_import&.import
   end
 
+  def source_imports
+    [
+      open_ai_import&.import,
+      *data_imports.map(&:import)
+    ].compact.uniq
+  end
+
+  def source_documents
+    source_imports.select { |import| import.respond_to?(:file) && import.file.attached? }
+  end
+
+  def source_urls
+    source_imports.filter_map do |import|
+      root = import.import_root
+      root.source_url if root.respond_to?(:source_url)
+    end.compact_blank.uniq
+  end
+
+  def source_document_status
+    case source
+    when "rapids_api"
+      "No source PDF is linked; this standard was imported directly from the RAPIDS API."
+    when "onet_api"
+      "No source PDF is linked; this standard was imported directly from the O*NET API."
+    else
+      "No source PDF is linked to this occupation standard."
+    end
+  end
+
   def standards_import
     source_file&.import_root
   end

--- a/app/models/rapids/occupation_standard.rb
+++ b/app/models/rapids/occupation_standard.rb
@@ -63,7 +63,10 @@ module RAPIDS
           )
 
           if state
-            registration_agency = state.registration_agencies.find_by(agency_type: "oa")
+            registration_agency = RegistrationAgency.registration_agency_for_state(
+              state,
+              requested_agency_type: :oa
+            )
           end
         end
 

--- a/app/models/registration_agency.rb
+++ b/app/models/registration_agency.rb
@@ -7,6 +7,71 @@ class RegistrationAgency < ApplicationRecord
 
   enum :agency_type, [:oa, :saa]
 
+  OFFICE_OF_APPRENTICESHIP_STATE_ABBREVIATIONS = %w[
+    AK
+    AR
+    AS
+    CA
+    FM
+    GA
+    ID
+    IL
+    IN
+    MH
+    MI
+    MO
+    MP
+    MS
+    ND
+    NE
+    NH
+    NJ
+    OK
+    PW
+    SC
+    SD
+    TX
+    UT
+    WV
+    WY
+  ].freeze
+
+  STATE_APPRENTICESHIP_AGENCY_STATE_ABBREVIATIONS = %w[
+    AL
+    AZ
+    CA
+    CO
+    CT
+    DC
+    DE
+    FL
+    GU
+    HI
+    IA
+    KS
+    KY
+    LA
+    MA
+    MD
+    ME
+    MN
+    MT
+    NC
+    NM
+    NV
+    NY
+    OH
+    OR
+    PA
+    RI
+    TN
+    VA
+    VI
+    VT
+    WA
+    WI
+  ].freeze
+
   def to_s
     state_name = state&.name || "National"
     "#{state_name} (#{agency_type.upcase})"
@@ -14,5 +79,26 @@ class RegistrationAgency < ApplicationRecord
 
   def self.registration_agency_for_national_program
     find_by(state_id: nil)
+  end
+
+  def self.registration_agency_for_state(state, requested_agency_type: nil)
+    agency_type = authoritative_agency_type_for_state(state, requested_agency_type: requested_agency_type)
+    find_by(state: state, agency_type: agency_type) if agency_type
+  end
+
+  def self.authoritative_agency_type_for_state(state, requested_agency_type: nil)
+    return if state.blank?
+
+    if state.abbreviation == "CA"
+      return requested_agency_type.presence || :oa
+    end
+
+    if STATE_APPRENTICESHIP_AGENCY_STATE_ABBREVIATIONS.include?(state.abbreviation)
+      :saa
+    elsif OFFICE_OF_APPRENTICESHIP_STATE_ABBREVIATIONS.include?(state.abbreviation)
+      :oa
+    else
+      requested_agency_type
+    end
   end
 end

--- a/app/services/convert_pdf_import_with_ai.rb
+++ b/app/services/convert_pdf_import_with_ai.rb
@@ -161,15 +161,22 @@ class ConvertPdfImportWithAI
     state = registration_state(response)
     agency_type = registration_agency_type(response)
 
-    if national_standard?(response)
-      RegistrationAgency.find_by(state: nil, agency_type: agency_type.presence || :oa)
-    elsif state && agency_type
-      RegistrationAgency.find_by(state: state, agency_type: agency_type)
+    if state && agency_type
+      RegistrationAgency.registration_agency_for_state(state, requested_agency_type: agency_type) ||
+        single_registration_agency_for_state(state)
     elsif state
-      RegistrationAgency.find_by(state: state, agency_type: :oa)
+      RegistrationAgency.registration_agency_for_state(state, requested_agency_type: :oa) ||
+        single_registration_agency_for_state(state)
+    elsif national_standard?(response)
+      RegistrationAgency.find_by(state: nil, agency_type: agency_type.presence || :oa)
     else
       RegistrationAgency.registration_agency_for_national_program
     end
+  end
+
+  def single_registration_agency_for_state(state)
+    agencies = RegistrationAgency.where(state: state).to_a
+    agencies.one? ? agencies.first : nil
   end
 
   def registration_state(response)
@@ -192,11 +199,16 @@ class ConvertPdfImportWithAI
   end
 
   def national_standard?(response)
-    value(response, "national", "National").present? ||
-      value(response, "nationalStandardType", "national_standard_type").present?
+    registration_state(response).blank? &&
+      (
+        value(response, "national", "National").present? ||
+        value(response, "nationalStandardType", "national_standard_type").present?
+      )
   end
 
   def national_standard_type(response)
+    return unless national_standard?(response)
+
     type = value(response, "nationalStandardType", "national_standard_type", "National")
     return if type.blank?
 

--- a/app/services/import_occupation_standard_details.rb
+++ b/app/services/import_occupation_standard_details.rb
@@ -57,7 +57,11 @@ class ImportOccupationStandardDetails
   def registration_agency
     agency_type = row["National"] ? :oa : row["OA or SAA"].downcase.to_sym
     state = row["National"] ? nil : State.find_by(abbreviation: row["Registration State"])
-    RegistrationAgency.find_by(state: state, agency_type: agency_type)
+    if state
+      RegistrationAgency.registration_agency_for_state(state, requested_agency_type: agency_type)
+    else
+      RegistrationAgency.find_by(state: nil, agency_type: agency_type)
+    end
   end
 
   def organization

--- a/app/views/fields/source_documents_field/_show.html.erb
+++ b/app/views/fields/source_documents_field/_show.html.erb
@@ -1,0 +1,27 @@
+<% if field.data.any? %>
+  <ul>
+    <% field.data.each do |import| %>
+      <li>
+        <%= link_to import.filename,
+              rails_blob_path(import.file, disposition: "inline"),
+              target: "_blank",
+              rel: "noopener" %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <%= field.resource.source_document_status %>
+<% end %>
+
+<% if field.source_urls.any? %>
+  <div>
+    Source URL:
+    <% field.source_urls.each do |source_url| %>
+      <% if field.linkable_url?(source_url) %>
+        <%= link_to source_url, source_url, target: "_blank", rel: "noopener" %>
+      <% else %>
+        <%= source_url %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/db/migrate/20260807120000_update_registration_agency_classifications.rb
+++ b/db/migrate/20260807120000_update_registration_agency_classifications.rb
@@ -1,0 +1,147 @@
+class UpdateRegistrationAgencyClassifications < ActiveRecord::Migration[8.1]
+  OFFICE_OF_APPRENTICESHIP_STATE_ABBREVIATIONS = %w[
+    AK
+    AR
+    AS
+    CA
+    FM
+    GA
+    ID
+    IL
+    IN
+    MH
+    MI
+    MO
+    MP
+    MS
+    ND
+    NE
+    NH
+    NJ
+    OK
+    PW
+    SC
+    SD
+    TX
+    UT
+    WV
+    WY
+  ].freeze
+
+  STATE_APPRENTICESHIP_AGENCY_STATE_ABBREVIATIONS = %w[
+    AL
+    AZ
+    CA
+    CO
+    CT
+    DC
+    DE
+    FL
+    GU
+    HI
+    IA
+    KS
+    KY
+    LA
+    MA
+    MD
+    ME
+    MN
+    MT
+    NC
+    NM
+    NV
+    NY
+    OH
+    OR
+    PA
+    RI
+    TN
+    VA
+    VI
+    VT
+    WA
+    WI
+  ].freeze
+
+  AGENCY_TYPES = {
+    oa: 0,
+    saa: 1
+  }.freeze
+
+  class MigrationState < ApplicationRecord
+    self.table_name = "states"
+  end
+
+  class MigrationRegistrationAgency < ApplicationRecord
+    self.table_name = "registration_agencies"
+
+    belongs_to :state, class_name: "UpdateRegistrationAgencyClassifications::MigrationState", optional: true
+  end
+
+  class MigrationOccupationStandard < ApplicationRecord
+    self.table_name = "occupation_standards"
+  end
+
+  def up
+    expected_agencies.each do |abbreviation, agency_types|
+      state = MigrationState.find_by(abbreviation: abbreviation)
+      next unless state
+
+      agency_types.each do |agency_type|
+        MigrationRegistrationAgency.find_or_create_by!(
+          state_id: state.id,
+          agency_type: AGENCY_TYPES.fetch(agency_type)
+        )
+      end
+    end
+
+    reassign_stale_agencies
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def expected_agencies
+    (OFFICE_OF_APPRENTICESHIP_STATE_ABBREVIATIONS + STATE_APPRENTICESHIP_AGENCY_STATE_ABBREVIATIONS)
+      .uniq
+      .index_with { |abbreviation| expected_agency_types_for(abbreviation) }
+  end
+
+  def expected_agency_types_for(abbreviation)
+    return [:oa, :saa] if abbreviation == "CA"
+
+    if STATE_APPRENTICESHIP_AGENCY_STATE_ABBREVIATIONS.include?(abbreviation)
+      [:saa]
+    elsif OFFICE_OF_APPRENTICESHIP_STATE_ABBREVIATIONS.include?(abbreviation)
+      [:oa]
+    else
+      []
+    end
+  end
+
+  def reassign_stale_agencies
+    MigrationRegistrationAgency.includes(:state).find_each do |agency|
+      state = agency.state
+      next unless state
+
+      expected_agency_types = expected_agency_types_for(state.abbreviation)
+      next if expected_agency_types.empty?
+      next if expected_agency_types.map { |type| AGENCY_TYPES.fetch(type) }.include?(agency.agency_type)
+
+      replacement = MigrationRegistrationAgency.find_by!(
+        state_id: state.id,
+        agency_type: AGENCY_TYPES.fetch(expected_agency_types.first)
+      )
+
+      MigrationOccupationStandard
+        .where(registration_agency_id: agency.id)
+        .update_all(registration_agency_id: replacement.id)
+
+      agency.destroy!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_07_120000) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pgcrypto"
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pgcrypto"
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "blob_id", null: false

--- a/lib/tasks/files/registration_agencies.csv
+++ b/lib/tasks/files/registration_agencies.csv
@@ -5,7 +5,7 @@ Arkansas,OA
 Arizona,SAA
 California,OA
 California,SAA
-Colorado,OA
+Colorado,SAA
 Connecticut,SAA
 District of Columbia,SAA
 Delaware,SAA
@@ -13,7 +13,7 @@ Florida,SAA
 Georgia,OA
 Guam,SAA
 Hawaii,SAA
-Iowa,OA
+Iowa,SAA
 Idaho,OA
 Illinois,OA
 Indiana,OA

--- a/spec/models/registration_agency_spec.rb
+++ b/spec/models/registration_agency_spec.rb
@@ -28,6 +28,45 @@ RSpec.describe RegistrationAgency, type: :model do
     end
   end
 
+  describe ".registration_agency_for_state" do
+    it "uses the state's authoritative SAA agency when a document says OA" do
+      colorado = create(:state, abbreviation: "CO")
+      colorado_saa = create(:registration_agency, state: colorado, agency_type: :saa)
+
+      result = described_class.registration_agency_for_state(
+        colorado,
+        requested_agency_type: :oa
+      )
+
+      expect(result).to eq colorado_saa
+    end
+
+    it "uses the state's authoritative OA agency when a document says SAA" do
+      texas = create(:state, abbreviation: "TX")
+      texas_oa = create(:registration_agency, state: texas, agency_type: :oa)
+
+      result = described_class.registration_agency_for_state(
+        texas,
+        requested_agency_type: :saa
+      )
+
+      expect(result).to eq texas_oa
+    end
+
+    it "uses the requested California agency because California has both agency types" do
+      california = create(:state, abbreviation: "CA")
+      create(:registration_agency, state: california, agency_type: :oa)
+      california_saa = create(:registration_agency, state: california, agency_type: :saa)
+
+      result = described_class.registration_agency_for_state(
+        california,
+        requested_agency_type: :saa
+      )
+
+      expect(result).to eq california_saa
+    end
+  end
+
   describe "#to_s" do
     it "returns state name and agency type" do
       ca = build_stubbed(:state, name: "California")

--- a/spec/services/convert_pdf_import_with_ai_spec.rb
+++ b/spec/services/convert_pdf_import_with_ai_spec.rb
@@ -77,6 +77,70 @@ RSpec.describe ConvertPdfImportWithAI do
       expect(result.occupation_standard.state).to be_nil
     end
 
+    it "prefers a state registration agency when OpenAI also returns a national standard type" do
+      pdf = create(:imports_pdf)
+      prompt = create(:open_ai_prompt, prompt: "Extract")
+      alabama_agency = create(:registration_agency, for_state_abbreviation: "AL", agency_type: :saa)
+
+      stub_pdf_text("Alabama program standard")
+      stub_open_ai_response(prompt, "Alabama program standard", {
+        title: "Automobile Body Repairer",
+        ojtType: "competency",
+        registrationAgencyType: "saa",
+        registrationState: "AL",
+        nationalStandardType: "program_standard"
+      }.to_json)
+      expect_any_instance_of(OccupationStandard).not_to receive(:update_document)
+
+      result = described_class.new(import: pdf, open_ai_prompt: prompt).call
+
+      expect(result.created).to be true
+      expect(result.occupation_standard.registration_agency).to eq alabama_agency
+      expect(result.occupation_standard.national_standard_type).to be_nil
+    end
+
+    it "uses the state's authoritative registration agency when OpenAI returns the wrong agency type" do
+      pdf = create(:imports_pdf)
+      prompt = create(:open_ai_prompt, prompt: "Extract")
+      colorado_agency = create(:registration_agency, for_state_abbreviation: "CO", agency_type: :saa)
+
+      stub_pdf_text("Colorado teacher standard")
+      stub_open_ai_response(prompt, "Colorado teacher standard", {
+        title: "Special Education Teacher",
+        ojtType: "competency",
+        registrationAgencyType: "oa",
+        registrationState: "CO"
+      }.to_json)
+      expect_any_instance_of(OccupationStandard).not_to receive(:update_document)
+
+      result = described_class.new(import: pdf, open_ai_prompt: prompt).call
+
+      expect(result.created).to be true
+      expect(result.occupation_standard.registration_agency).to eq colorado_agency
+    end
+
+    it "allows either California agency because California has both OA and SAA agencies" do
+      pdf = create(:imports_pdf)
+      prompt = create(:open_ai_prompt, prompt: "Extract")
+      california = create(:state, abbreviation: "CA")
+      create(:registration_agency, state: california, agency_type: :oa)
+      california_saa = create(:registration_agency, state: california, agency_type: :saa)
+
+      stub_pdf_text("California teacher standard")
+      stub_open_ai_response(prompt, "California teacher standard", {
+        title: "Special Education Teacher",
+        ojtType: "competency",
+        registrationAgencyType: "saa",
+        registrationState: "CA"
+      }.to_json)
+      expect_any_instance_of(OccupationStandard).not_to receive(:update_document)
+
+      result = described_class.new(import: pdf, open_ai_prompt: prompt).call
+
+      expect(result.created).to be true
+      expect(result.occupation_standard.registration_agency).to eq california_saa
+    end
+
     it "stores extraction errors without creating an invalid occupation standard" do
       pdf = create(:imports_pdf)
       prompt = create(:open_ai_prompt, prompt: "Extract")

--- a/spec/system/admin/occupation_standards/show_spec.rb
+++ b/spec/system/admin/occupation_standards/show_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "admin/occupation_standards/show" do
     expect(page).to have_selector("dt", text: "Term months")
     expect(page).to have_selector("dt", text: "URL")
     expect(page).to have_selector("dt", text: "Status")
+    expect(page).to have_selector("dt", text: "Source documents")
     expect(page).to have_selector("dt", text: "Created at")
     expect(page).to have_selector("dt", text: "Updated at")
 
@@ -51,6 +52,7 @@ RSpec.describe "admin/occupation_standards/show" do
     expect(page).to have_selector("dd", text: occupation_standard.term_months)
     expect(page).to have_selector("dd", text: occupation_standard.url)
     expect(page).to have_selector("dd", text: occupation_standard.status.titleize)
+    expect(page).to have_link("pixel1x1.pdf", href: rails_blob_path(occupation_standard.source_documents.first.file, disposition: "inline"))
     expect(page).to have_selector("dd", text: "2022-01-15 01:02:03 EST")
     expect(page).to have_selector("dd", text: "2022-06-17 10:11:12 EDT")
 
@@ -120,5 +122,45 @@ RSpec.describe "admin/occupation_standards/show" do
 
     expect(page).to have_selector("h1", text: occupation_standard.title)
     expect(page).to have_selector("dt", text: "Occupation")
+  end
+
+  it "links to the source document from an AI conversion", :admin do
+    occupation_standard = create(:occupation_standard, source: :ai_conversion)
+    import = create(:imports_pdf)
+    create(:open_ai_import, import: import, occupation_standard: occupation_standard)
+    admin = create(:admin)
+
+    login_as admin
+    visit admin_occupation_standard_path(occupation_standard)
+
+    expect(page).to have_selector("dt", text: "Source documents")
+    expect(page).to have_link(import.filename, href: rails_blob_path(import.file, disposition: "inline"))
+  end
+
+  it "shows the source URL from the root import", :admin do
+    source_url = "https://example.com/source-programs"
+    standards_import = create(:standards_import, source_url: source_url)
+    import = create(:imports_pdf, parent: standards_import)
+    occupation_standard = create(:occupation_standard)
+    create(:data_import, import: import, occupation_standard: occupation_standard)
+    admin = create(:admin)
+
+    login_as admin
+    visit admin_occupation_standard_path(occupation_standard)
+
+    expect(page).to have_link(import.filename, href: rails_blob_path(import.file, disposition: "inline"))
+    expect(page).to have_text("Source URL:")
+    expect(page).to have_link(source_url, href: source_url)
+  end
+
+  it "shows when an API-imported standard does not have a source document", :admin do
+    occupation_standard = create(:occupation_standard, source: :rapids_api)
+    admin = create(:admin)
+
+    login_as admin
+    visit admin_occupation_standard_path(occupation_standard)
+
+    expect(page).to have_selector("dt", text: "Source documents")
+    expect(page).to have_text("No source PDF is linked; this standard was imported directly from the RAPIDS API.")
   end
 end


### PR DESCRIPTION
* Update registration entries based on definitive list: https://www.apprenticeship.gov/about-us/apprenticeship-system
* Refine conversion process for OA vs SAA documents

[Asana ticket](https://app.asana.com/1/33342061919290/project/1202142120438783/task/1217288964549813?focus=true)
